### PR TITLE
Add a gRPC server that can handle eval requests from a client using SQLGen

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -1,0 +1,33 @@
+FROM docker.io/python:3.11-bookworm AS base-env
+RUN pip install --no-cache-dir --upgrade pip
+
+FROM base-env AS protoc-env
+RUN pip install --no-cache-dir grpcio-tools
+COPY ./evalbench/proto /proto
+RUN mkdir proto_out
+RUN python -m grpc_tools.protoc --proto_path=./proto --python_out=./proto_out --pyi_out=./proto_out --grpc_python_out=./proto_out --experimental_editions ./proto/*.proto
+
+FROM base-env AS build-env
+COPY ./requirements.txt .
+RUN pip install --no-cache-dir -r ./requirements.txt
+
+FROM gcr.io/distroless/python3-debian12
+COPY --from=build-env /usr/local/lib/python3.11/site-packages /usr/local/lib/python3.11/site-packages
+COPY --chown=nonroot:nonroot . /app
+COPY --from=protoc-env --chown=nonroot:nonroot /proto_out /app/evalbench/
+WORKDIR /app/evalbench
+ENV PYTHONPATH=/usr/local/lib/python3.11/site-packages
+CMD ["eval_server.py"]
+
+EXPOSE 50051
+
+# local run steps:
+# gcloud auth application-default login
+# export EVAL_DB_PASSWORD=xxxx
+# podman build . -t evalbench
+# podman run -e GOOGLE_CLOUD_PROJECT=cloud-db-nl2sql -e EVAL_DB_PASSWORD -v "$HOME/.config/gcloud/application_default_credentials.json:/tmp/application_default_credentials.json:ro" -e GOOGLE_APPLICATION_CREDENTIALS=/tmp/application_default_credentials.json -p 50051:50051 evalbench eval_server.py --localhost
+
+# push
+# gcloud auth configure-docker us-central1-docker.pkg.dev
+# podman build . -t evalbench
+# podman push evalbench us-central1-docker.pkg.dev/cloud-db-nl2sql/evalbench/eval_server

--- a/evalbench/configs/base_experiment_service.yaml
+++ b/evalbench/configs/base_experiment_service.yaml
@@ -1,0 +1,12 @@
+dataset_config: ../datasets/hackathon/air_travel.json
+database_config: configs/db/postgres.yaml
+model_config: configs/model/base_sqlgen_passthrough.yaml
+prompt_generator: 'NOOPGenerator'
+eval_ids: []
+scorers:
+  exact_match:
+  recall_match:
+  vertexmatcher:
+    gcp_project_location: "us-central1"
+    gcp_project_id: "cloud-db-nl2sql"
+    model: "gemini-1.0-pro-001"

--- a/evalbench/configs/model/base_sqlgen_passthrough.yaml
+++ b/evalbench/configs/model/base_sqlgen_passthrough.yaml
@@ -1,0 +1,2 @@
+generator: noop
+base_prompt: ""

--- a/evalbench/eval_server.py
+++ b/evalbench/eval_server.py
@@ -1,0 +1,63 @@
+"""Server on GCP side for the evaluation service."""
+
+import asyncio
+from collections.abc import Sequence
+
+from absl import app
+from absl import flags
+from absl import logging
+import grpc
+
+import eval_service
+import eval_service_pb2_grpc
+
+_LOCALHOST = flags.DEFINE_bool(
+    "localhost",
+    False,
+    "Whether to use localhost. ALTS is only available on GCP, so this is useful"
+    " for local testing.",
+)
+
+_cleanup_coroutines = []
+
+
+async def _serve():
+    """Starts the server."""
+    logging.info("Starting server")
+    server = grpc.aio.server()
+    servicer = eval_service.EvalServicer()
+    eval_service_pb2_grpc.add_EvalServiceServicer_to_server(servicer, server)
+    if _LOCALHOST.value:
+        # --localhost is for testing purpose. Use insecure_server_credentials()
+        # because local creds does not work between a client running on the host
+        # and a server running inside a container on the same host.
+        logging.info("Using localhost server insecure credentials per flag")
+        creds = grpc.insecure_server_credentials()
+    else:
+        logging.info("Using ALTS server credentials")
+        creds = grpc.alts_server_credentials()
+    server.add_secure_port("[::]:50051", creds)
+    await server.start()
+    logging.info("Server started")
+
+    async def server_graceful_shutdown():
+        logging.info("Starting graceful shutdown...")
+        await server.stop(5)
+
+    _cleanup_coroutines.append(server_graceful_shutdown())
+    await server.wait_for_termination()
+
+
+def main(argv: Sequence[str]) -> None:
+    if len(argv) > 1:
+        raise app.UsageError("Too many command-line arguments.")
+    loop = asyncio.get_event_loop()
+    try:
+        loop.run_until_complete(_serve())
+    finally:
+        loop.run_until_complete(asyncio.gather(*_cleanup_coroutines))
+        loop.close()
+
+
+if __name__ == "__main__":
+    app.run(main)

--- a/evalbench/eval_service.py
+++ b/evalbench/eval_service.py
@@ -1,0 +1,108 @@
+"""A gRPC servicer that handles EvalService requests."""
+
+from collections.abc import AsyncIterator
+
+from absl import flags
+from absl import logging
+import datetime
+import urllib.request
+
+import grpc
+
+from util.config import load_yaml_config, config_to_df
+from dataset.dataset import load_json, load_dataset_from_json
+from dataset import evalinput
+import generators.models as models
+import generators.prompts as prompts
+import evaluator.evaluator as evaluator
+import reporting.report as report
+import reporting.bqstore as bqstore
+import reporting.analyzer as analyzer
+import databases
+import json
+
+import eval_request_pb2
+import eval_response_pb2
+import eval_service_pb2_grpc
+
+_experiment_config = flags.DEFINE_string(
+    "self.experiment_config",
+    "configs/base_experiment_service.yaml",
+    "Path to the eval execution configuration file.",
+)
+
+
+class EvalServicer(eval_service_pb2_grpc.EvalServiceServicer):
+    """A gRPC servicer that handles EvalService requests."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        logging.info("EvalBench v1.0.0")
+
+        self.experiment_config = load_yaml_config(_experiment_config.value)
+        if self.experiment_config == "":
+            return
+
+        logging.info("Loaded %s", _experiment_config.value)
+
+        db_config_yaml = self.experiment_config["database_config"]
+        model_config_yaml = self.experiment_config["model_config"]
+        dataset_config_json = self.experiment_config["dataset_config"]
+
+        # Load the dataset
+        dataset, database = load_dataset_from_json(dataset_config_json)
+
+        # Load the model config
+        self.model_config = load_yaml_config(model_config_yaml)
+
+        # Load the DB config DB name comes from the dataset
+        self.db_config = load_yaml_config(db_config_yaml)
+        self.db_config["database_name"] = database
+        self.model_config["database_config"] = self.db_config
+
+        # Create the DB
+        self.db = databases.get_database(self.db_config)
+
+        # Load the Query Generator
+        self.model_generator = models.get_generator(self.model_config)
+
+        # Load the Prompt Generator
+        self.prompt_generator = prompts.get_generator(self.db, self.experiment_config)
+
+    async def Eval(
+        self,
+        request_iterator: AsyncIterator[eval_request_pb2.EvalRequest],
+        context: grpc.ServicerContext,
+    ) -> eval_response_pb2.EvalResponse:
+        eval = evaluator.Evaluator(
+            self.experiment_config, self.prompt_generator, self.model_generator, self.db
+        )
+        dataset = []
+        async for request in request_iterator:
+            input = evalinput.EvalInput(
+                id=request.id,
+                query_type=request.query_type,
+                database=request.database,
+                # TODO: This is a hack to allow client side SQLGen generated SQL
+                # to pass through PromptGen and SQLGen generators, revisit this.
+                nl_prompt=request.eval_query,
+                dialects=request.dialects,
+                golden_sql=request.golden_sql,
+                eval_query=request.eval_query,
+                setup_sql=request.setup_sql,
+                cleanup_sql=request.cleanup_sql,
+                tags=request.tags,
+            )
+            dataset.append(input)
+
+        job_id, run_time = eval.evaluate(dataset)
+        results = load_json("/tmp/eval_output.json")
+        results_df = report.quick_summary(results)
+
+        scores = load_json("/tmp/score_result.json")
+        scores_df, summary_scores_df = analyzer.analyze_result(
+            scores, self.experiment_config
+        )
+        summary_scores_df["job_id"] = job_id
+        summary_scores_df["run_time"] = run_time
+        return eval_response_pb2.EvalResponse(response=f"ack")

--- a/evalbench/evaluator/evaluator.py
+++ b/evalbench/evaluator/evaluator.py
@@ -85,9 +85,9 @@ class Evaluator:
             )
             eval_outputs.append(eval_output)
 
-        with open("eval_output.json", "w") as f:
+        with open("/tmp/eval_output.json", "w") as f:
             json.dump(eval_outputs, f, sort_keys=True, indent=4, default=str)
 
-        with open("score_result.json", "w") as f:
+        with open("/tmp/score_result.json", "w") as f:
             json.dump(scoring_results, f, sort_keys=True, indent=4, default=str)
         return job_id, run_time

--- a/evalbench/generators/models/__init__.py
+++ b/evalbench/generators/models/__init__.py
@@ -1,5 +1,6 @@
 from .gemini import GeminiGenerator
 from .magick import MagicSQLGenerator
+from .passthrough import NOOPGenerator
 
 
 def get_generator(model_config):
@@ -7,3 +8,5 @@ def get_generator(model_config):
         return GeminiGenerator(model_config)
     if model_config["generator"] == "magick":
         return MagicSQLGenerator(model_config)
+    if model_config["generator"] == "noop":
+        return NOOPGenerator(model_config)

--- a/evalbench/generators/models/passthrough.py
+++ b/evalbench/generators/models/passthrough.py
@@ -1,0 +1,10 @@
+from .generator import QueryGenerator
+
+
+class NOOPGenerator(QueryGenerator):
+
+    def __init__(self, querygenerator_config):
+        super().__init__(querygenerator_config)
+
+    def generate(self, human_language_question):
+        return human_language_question

--- a/evalbench/proto/eval_request.proto
+++ b/evalbench/proto/eval_request.proto
@@ -1,0 +1,18 @@
+edition = "2023";
+
+package cloud_databases_nl2sql_eval_sqlgen_proto;
+
+option java_multiple_files = true;
+
+message EvalRequest {
+  string id = 1;
+  string query_type = 2;
+  string database = 3;
+  string nl_prompt = 4;
+  repeated string dialects = 5;
+  string golden_sql = 6;
+  string eval_query = 7;
+  string setup_sql = 8;
+  string cleanup_sql = 9;
+  repeated string tags = 10;
+}

--- a/evalbench/proto/eval_response.proto
+++ b/evalbench/proto/eval_response.proto
@@ -1,0 +1,9 @@
+edition = "2023";
+
+package cloud_databases_nl2sql_eval_sqlgen_proto;
+
+option java_multiple_files = true;
+
+message EvalResponse {
+  string response = 1;
+}

--- a/evalbench/proto/eval_service.proto
+++ b/evalbench/proto/eval_service.proto
@@ -1,0 +1,15 @@
+edition = "2023";
+
+package cloud_databases_nl2sql_eval_sqlgen_proto;
+
+import "eval_request.proto";
+import "eval_response.proto";
+
+option java_multiple_files = true;
+
+service EvalService {
+  // Evaluate.
+  rpc Eval(stream EvalRequest) returns (EvalResponse) {
+    // option deadline = 1800;
+  }
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,6 @@ pymysql
 sqlalchemy
 pyaml_env
 pyarrow
+absl-py
+tabulate
+grpcio


### PR DESCRIPTION
`eval_server.py` is the alternative `main()` of EvalBench. CLI mode `evalbench.py` is untouched.

`eval_service.py` implement the gRPC service logic, currently it converts streaming RPC requests into a list of EvalInput and call `Evaluator.evaluate()`.


Known limitations/future work:
- Configs are currently loaded at eval_service init, so cannot handle different databases yet. This is the main reason why GetDataset RPC is not implemented yet.
- EvalResponse proto is under-defined, we likely need to report back scoring results eventually. 
- Because of the way how Evaluator.evaluate() + SQLPromptGenWork + SQLGenWork currently works (`nl_prompt` -> `generated_prompt` -> `generated_sql`), there is currently a hack in `eval_service.py` where client-side SQLGen-generated SQL converted as `EvalInput.nl_prompt` so that this becomes `generated_sql` after going through passthrough prompt and model  generators. `Evaluator.evaluate()` needs to be refactored to get rid of this hack (e.g. the ability to skip SQLPromptGenWork & SQLGenWork, not just passthrough), otherwise the `generated_sql` value is still overriden by SQLGenWork. This would be a relatively invasive change since Evaluator.evaluate() is shared by the service and the CLI mode of evalbench.
- There is high OOM potential.