### PR TITLE
Added backoff and retry logic to llmrater

### DIFF
--- a/evalbench/generators/models/gemini.py
+++ b/evalbench/generators/models/gemini.py
@@ -18,6 +18,7 @@ class GeminiGenerator(QueryGenerator):
         self.vertex_model = querygenerator_config["vertex_model"]
         self.base_prompt = querygenerator_config["base_prompt"]
         self.generation_config = None
+        self.name = "gemini"
 
         vertexai.init(project=self.project_id, location=self.location)
         self.model = GenerativeModel(self.vertex_model)

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,3 +17,4 @@ grpcio-tools
 aiologger
 jsonschema
 ratelimit
+backoff


### PR DESCRIPTION
Added backoff logic and retry logic to llmrater
1) @limit decorator function simply throws RateLimitExceptions when
   number of function calls to llm rater exceeds 30 in a period of 60 seconds.
2) @backoff catches RateLimitExeptions and any quota exceeded errors
   thrown by vertex ai.
3) From the function call pattern it was obsevered alot of workers hit
   this function simultanuously, for which vertex api throws 429 errors.
4) Keeping that in mind added jitter, which retries after a random
   time from interval (0, value), making sure the api calls are
   fragmented.
Previously this was not being handled, giving a score of 0 to
those cases. 

Don't see any llm rater comparison errors now.