### PR TITLE
Fix issues with parsing of proto for evalitem

### DIFF
--- a/evalbench/dataset/evalinput.py
+++ b/evalbench/dataset/evalinput.py
@@ -1,3 +1,7 @@
+from google.protobuf.json_format import MessageToDict
+import eval_request_pb2
+
+
 class EvalInputRequest:
 
     def __init__(
@@ -20,18 +24,7 @@ class EvalInputRequest:
     ):
         """Initializes an EvalInputRequest object with all required fields.
 
-        :param id: A unique string identifier or name for this EvalInputRequest. Unique
-        within a dataset file.
-        :param query_type: The type of SQL query ("DDL" for Data Definition
-        Language, "DML" for Data Manipulation Language,
-                           or "DQL" for Data Query Language).
-        :param database: The database for this dataset.
-        :param nl_prompt: The human language question for which the
-        model is to generate an SQL query.
-        :param dialects: The list of dialects for which the model is to
-        generate an SQL query.
-        :param golden_query: The correct/expected SQL query for the given human
-        language question.
+        See eval_request_pb2 for types
         """
         self.id = id
         self.database = database
@@ -48,3 +41,26 @@ class EvalInputRequest:
         self.sql_generator_time = sql_generator_time
         self.generated_sql = generated_sql
         self.job_id = job_id
+
+    @classmethod
+    def init_from_proto(self, proto: eval_request_pb2.EvalInputRequest):
+        """Initializes an EvalInputRequest from eval_request_pb2 proto."""
+
+        request = MessageToDict(proto)
+        return self(
+            id=request.get("id"),
+            query_type=request.get("queryType"),
+            database=request.get("database"),
+            nl_prompt=request.get("nlPrompt"),
+            dialects=request.get("dialects"),
+            golden_sql=request.get("goldenSql"),
+            eval_query=request.get("evalQuery"),
+            setup_sql=request.get("setupSql"),
+            cleanup_sql=request.get("cleanupSql"),
+            tags=request.get("tags"),
+            other=request.get("other"),
+            sql_generator_error=request.get("sqlGeneratorError"),
+            sql_generator_time=request.get("sqlGeneratorTime"),
+            generated_sql=request.get("generatedSql"),
+            job_id=request.get("jobId"),
+        )

--- a/evalbench/eval_service.py
+++ b/evalbench/eval_service.py
@@ -145,23 +145,7 @@ class EvalServicer(eval_service_pb2_grpc.EvalServiceServicer):
 
         dataset = []
         async for request in request_iterator:
-            input = evalinput.EvalInputRequest(
-                id=request.id,
-                query_type=request.query_type,
-                database=request.database,
-                nl_prompt=request.nl_prompt,
-                dialects=request.dialects,
-                golden_sql=request.golden_sql,
-                eval_query=request.eval_query,
-                setup_sql=request.setup_sql,
-                cleanup_sql=request.cleanup_sql,
-                tags=request.tags,
-                other=request.other,
-                sql_generator_error=request.sql_generator_error,
-                sql_generator_time=request.sql_generator_time,
-                generated_sql=request.generated_sql,
-                job_id=request.job_id,
-            )
+            input = evalinput.EvalInputRequest.init_from_proto(request)
             dataset.append(input)
 
         session = SESSIONMANAGER.get_session(rpc_id_var.get())


### PR DESCRIPTION
repeated fields and maps (such as golden_sql, other) get passed as a RepeatedScalarContainer instead of
list of strings, maps, etc. during parsing of the proto into the class. This fixes that.

job_id before: da98cbe6-be1e-458c-8c64-969b06f2c093
job_id after: a61bf974-dab4-4f57-8d2a-cade49d4c38e