### PR TITLE
Add support for google3 resources

### DIFF
--- a/evalbench/eval_service.py
+++ b/evalbench/eval_service.py
@@ -9,7 +9,7 @@ from typing import Awaitable, Callable, Optional
 import contextvars
 import yaml
 import grpc
-from util.config import load_yaml_config, config_to_df
+from util.config import load_yaml_config, config_to_df, update_google3_relative_paths
 from util import get_SessionManager
 from dataset.dataset import load_json, load_dataset_from_json
 from dataset import evalinput
@@ -91,9 +91,10 @@ class EvalServicer(eval_service_pb2_grpc.EvalServiceServicer):
     ) -> eval_response_pb2.EvalResponse:
         experiment_config = yaml.safe_load(request.yaml_config.decode("utf-8"))
         session = SESSIONMANAGER.get_session(rpc_id_var.get())
-        session["config"] = experiment_config
+        SESSIONMANAGER.write_resource_files(rpc_id_var.get(), request.resources)
+        update_google3_relative_paths(experiment_config, rpc_id_var.get())
 
-        # Create the DB
+        session["config"] = experiment_config
         session["db_config"] = load_yaml_config(experiment_config["database_config"])
         session["model_config"] = load_yaml_config(experiment_config["model_config"])
         return eval_response_pb2.EvalResponse(response=f"ack")

--- a/evalbench/evalproto/eval_config.proto
+++ b/evalbench/evalproto/eval_config.proto
@@ -4,6 +4,12 @@ package cloud_databases_nl2sql_eval_sqlgen_proto;
 
 option java_multiple_files = true;
 
+message Google3Resources {
+  string address = 1;
+  bytes content = 2;
+}
+
 message EvalConfigRequest {
   bytes yaml_config = 1;
+  repeated Google3Resources resources = 2;
 }

--- a/evalbench/util/config.py
+++ b/evalbench/util/config.py
@@ -1,8 +1,10 @@
 import logging
+import os
 
 from pyaml_env import parse_config
 import pandas as pd
 import json
+from .sessionmgr import SESSION_RESOURCES_PATH
 
 logging.getLogger().setLevel(logging.INFO)
 
@@ -37,5 +39,21 @@ def config_to_df(
             }
         )
     df = pd.DataFrame.from_dict(configs)
-    df[["job_id", "config", "value"]] = df[["job_id", "config", "value"]].astype("string")
+    df[["job_id", "config", "value"]] = df[["job_id", "config", "value"]].astype(
+        "string"
+    )
     return df
+
+
+def update_google3_relative_paths(experiment_config: dict, session_id: str):
+    if isinstance(experiment_config, dict):
+        for key, value in experiment_config.items():
+            if isinstance(value, dict):
+                update_google3_relative_paths(value, session_id)
+            elif isinstance(value, str) and value.startswith("google3/"):
+                updated_path = os.path.join(
+                    SESSION_RESOURCES_PATH,
+                    session_id,
+                    experiment_config[key],
+                )
+                experiment_config[key] = updated_path

--- a/evalbench/util/sessionmgr.py
+++ b/evalbench/util/sessionmgr.py
@@ -1,12 +1,17 @@
+import os
 from threading import Thread
 import logging
 import time
 from absl import app
 import uuid
 
+SESSION_RESOURCES_PATH = "../tmp_session_files/"
+
 
 class SessionManager:
-    def __init__(self, ):
+    def __init__(
+        self,
+    ):
         self.running = True
         self.sessions = {}
         self.ttl = 36000
@@ -23,12 +28,34 @@ class SessionManager:
     def get_session(self, session_id):
         return self.sessions[session_id]
 
+    def write_resource_files(self, session_id, resources):
+        for resource in resources:
+            full_path = os.path.join(
+                SESSION_RESOURCES_PATH, session_id, resource.address
+            )
+            os.makedirs(os.path.dirname(full_path), exist_ok=True)
+            with open(full_path, "wb") as f:
+                f.write(resource.content)
+
+    def prune_resource_files(self, session_id):
+        path = os.path.join(SESSION_RESOURCES_PATH, session_id)
+        if not os.path.exists(path):
+            return
+        for root, dirs, files in os.walk(path, topdown=False):
+            for file in files:
+                file_path = os.path.join(root, file)
+                os.remove(file_path)
+            for dir in dirs:
+                dir_path = os.path.join(root, dir)
+                os.rmdir(dir_path)
+        os.rmdir(path)
+
     def create_session(self, session_id):
         if session_id in self.sessions.keys():
             logging.info(f"Session {session_id} already exists.")
             return self.sessions[session_id]
         logging.info(f"Create session {session_id}.")
-        self.sessions[session_id] = {'create_ts': time.time(), 'session_id': session_id}
+        self.sessions[session_id] = {"create_ts": time.time(), "session_id": session_id}
         return self.sessions[session_id]
 
     def get_sessions(self):
@@ -45,10 +72,11 @@ class SessionManager:
         while self.running:
             logging.debug(f"Reaper cycle: {len(self.sessions)}")
             for session_id in self.sessions.keys():
-                if time.time() - self.sessions[session_id]['create_ts'] > self.ttl:
+                if time.time() - self.sessions[session_id]["create_ts"] > self.ttl:
                     old_sessions.append(session_id)
             for session_id in old_sessions:
                 logging.info(f"Delete session {session_id}.")
                 self.delete_session(session_id)
+                self.prune_resource_files(session_id)
                 old_sessions.remove(session_id)
             time.sleep(1)


### PR DESCRIPTION
Add support for google3 resources in evalbench
client until Git-on-borg solution is verified.

Currently, the request from NL2SQL will send the files / configs it needs at runtime in the request and stores it with the session. These are then deleted when the session is destroyed in the sessionmanager.