### PR TITLE
Remove None entries from eval_query, setup_sql, cleanup_sql 

### DIFF
--- a/evalbench/eval_service.py
+++ b/evalbench/eval_service.py
@@ -136,9 +136,9 @@ class EvalServicer(eval_service_pb2_grpc.EvalServiceServicer):
                     nl_prompt=eval_input.nl_prompt,
                     dialects=eval_input.dialects,
                     golden_sql=eval_input.golden_sql,
-                    eval_query=eval_input.eval_query,
-                    setup_sql=eval_input.setup_sql,
-                    cleanup_sql=eval_input.cleanup_sql,
+                    eval_query=[q for q in eval_input.eval_query if q is not None],
+                    setup_sql=[q for q in eval_input.setup_sql if q is not None],
+                    cleanup_sql=[q for q in eval_input.cleanup_sql if q is not None],
                     tags=eval_input.tags,
                 )
                 eval_input_request.other.update(eval_input.other)


### PR DESCRIPTION
Bat dataset json contains None entry in few data point causing failure when run as string is expected.