### PR TITLE
Fix: Backticks being removed causing mysql queries to fail

### DIFF
--- a/evalbench/work/sqlexecwork.py
+++ b/evalbench/work/sqlexecwork.py
@@ -63,18 +63,18 @@ class SQLExecWork(Work):
             self.eval_result["sql_generator_error"] is None
             and self.eval_result["generated_sql"]
         ):
-            self.eval_result["sanitized_sql"] = (
-                self.eval_result["generated_sql"]
-                .replace('sql: "', "")
-                .replace("\\n", " ")
-                .replace("\\n", " ")
-                .replace("\\", "")
-                .replace("  ", "")
-            )
-
-            if not self.db.db_config["db"] == "mysql":
-                self.eval_result["sanitized_sql"] = self.eval_result["sanitized_sql"].replace("`", "")
-
+            if self.experiment_config["prompt_generator"] == "NOOPGenerator":
+                self.eval_result["sanitized_sql"] = self.eval_result["generated_sql"]
+            else:
+                self.eval_result["sanitized_sql"] = (
+                    self.eval_result["generated_sql"]
+                    .replace('sql: "', "")
+                    .replace("\\n", " ")
+                    .replace("\\n", " ")
+                    .replace("\\", "")
+                    .replace("  ", "")
+                    .replace("`", "")
+                )
             generated_result, generated_error = self._execute_sql_flow(self.eval_result["sanitized_sql"],
                                                                        is_golden=False)
 


### PR DESCRIPTION
We were removing ` from all sql queries before executing them causing some mysql queries to fail when table name consists of multiple words.
See examples here: https://dashboards.corp.google.com/embed/cloud_databases_nl2sql_dashboards_dash_specs_run_details?p=run_id:ee1e52bb-4a5e-4acf-bf2a-61c32c3b7f07

Skipping this step when prompt generator is NOOP 