### PR TITLE
Allow limiting the number of results written to BigQuery

### DIFF
--- a/evalbench/evaluator/evaluator.py
+++ b/evalbench/evaluator/evaluator.py
@@ -6,7 +6,7 @@ import logging
 import databases
 import setup_teardown
 from databases.util import is_bat_dataset
-from util import printProgressBar
+from util import printProgressBar, truncateExecutionOutputs
 from work import promptgenwork
 from work import sqlgenwork
 from work import sqlexecwork
@@ -151,8 +151,17 @@ class Evaluator:
             for future in concurrent.futures.as_completed(self.scoringrunner.futures):
                 eval_output = future.result()
                 score_i = score_i + 1
+                if "truncate_execution_outputs" in self.experiment_config:
+                    truncateExecutionOutputs(
+                        eval_output,
+                        self.experiment_config["truncate_execution_outputs"],
+                    )
                 printProgressBar(
-                    score_i, dataset_len, prefix="Scoring:", suffix="Complete", length=50
+                    score_i,
+                    dataset_len,
+                    prefix="Scoring:",
+                    suffix="Complete",
+                    length=50,
                 )
                 eval_outputs.append(eval_output)
 

--- a/evalbench/util/__init__.py
+++ b/evalbench/util/__init__.py
@@ -1,4 +1,5 @@
 from .progress import printProgressBar
+from .loghandler import truncateExecutionOutputs
 from .sessionmgr import SessionManager
 
 SESSIONMANAGER = SessionManager()

--- a/evalbench/util/loghandler.py
+++ b/evalbench/util/loghandler.py
@@ -1,0 +1,17 @@
+import json
+
+
+def truncateExecutionOutputs(eval_output, truncated_result_count):
+    for key in [
+        "generated_result",
+        "golden_result",
+        "golden_eval_results",
+        "eval_results",
+    ]:
+        if key in eval_output:
+            suffix = ""
+            if len(eval_output[key]) > truncated_result_count:
+                suffix = f"...and {len(eval_output[key]) - truncated_result_count} more items truncated"
+            eval_output[key] = (
+                json.dumps(eval_output[key][:truncated_result_count]) + suffix
+            )


### PR DESCRIPTION
Allow limiting the number of results written to BigQuery.

This speeds up the guitar runs currently. Some results are writing ~100MB per row to BQ.