### PR TITLE
Fix issues with truncation

### DIFF
--- a/evalbench/util/loghandler.py
+++ b/evalbench/util/loghandler.py
@@ -8,10 +8,11 @@ def truncateExecutionOutputs(eval_output, truncated_result_count):
         "golden_eval_results",
         "eval_results",
     ]:
-        if key in eval_output:
+        if key in eval_output and isinstance(eval_output[key], list):
             suffix = ""
             if len(eval_output[key]) > truncated_result_count:
                 suffix = f"...and {len(eval_output[key]) - truncated_result_count} more items truncated"
             eval_output[key] = (
-                json.dumps(eval_output[key][:truncated_result_count]) + suffix
+                json.dumps(eval_output[key][:truncated_result_count], default=str)
+                + suffix
             )


### PR DESCRIPTION
- Currently decimals and dates throw issues (default=str) similar to Evaluator.py solves this.

- We have some none list type responses, checking for that to only truncate lists.