### PR TITLE
Increase Chunk Size for BQ for QuotaError

### DIFF
--- a/evalbench/reporting/bqstore.py
+++ b/evalbench/reporting/bqstore.py
@@ -4,7 +4,7 @@ import logging
 from enum import Enum
 
 STORETYPE = Enum('StoreType', ['CONFIGS', 'EVALS', 'SCORES', "SUMMARY"])
-_CHUNK_SIZE = 20
+_CHUNK_SIZE = 250
 
 project_id = "cloud-db-nl2sql"
 dataset_id = "{}.evalbench".format(project_id)


### PR DESCRIPTION
Increase chunk size for BQ as we're seeing [QuotaErrors](https://fusion2.corp.google.com/ci/guitar/workflows/%2F%2Fcloud%2Fdatabases%2Fnl2sql%2Feval%2Fsqlgen%2Fclient:gcp_eval_ci_bird_workflow/activity/2a68b55a-29d6-36b1-bbef-fd727841183c:0/invocations/288a844f-d36e-48c7-9985-3a08961de571/targets/%2F%2Fcloud%2Fdatabases%2Fnl2sql%2Feval%2Fsqlgen%2Fclient:sqlgen_eval_test/tests) on write