### PR TITLE
Execute setup command in batch size of 10 at once

### DIFF
--- a/evalbench/setup_teardown/databaseHandler/postgres_handler.py
+++ b/evalbench/setup_teardown/databaseHandler/postgres_handler.py
@@ -94,7 +94,7 @@ class PostgresHandler(DBHandler):
         db_instance = get_database(self.db_config)
         batch_size = 10
         for i in range(0, len(queries), batch_size):
-            batch_queries = queries[i : i + batch_size]
+            batch_queries = queries[i:i + batch_size]
             combined_queries = ";".join(batch_queries)
             result, error = db_instance.execute(combined_queries)
             if error:


### PR DESCRIPTION
Currently all setup command are being sent for execution in a single query string. This can cause rate limit to be exceeded as we will be executing multiple queries but they will be counted as one (as executed function will be called once).

Modified to run in batch size of 10.
Not executing queries one by one as that will slow down eval a lot. 