### PR TITLE
feat: Added a SetMatcher to be aligned with BIRD Exection Accuracy

### DIFF
--- a/evalbench/scorers/score.py
+++ b/evalbench/scorers/score.py
@@ -4,6 +4,7 @@ from scorers import comparator
 from scorers import exactmatcher
 from scorers import generatedqueryregexpmatcher
 from scorers import recallmatcher
+from scorers import setmatcher
 from scorers import vertextmatcher
 from scorers import llmrater
 from scorers import returnedsql
@@ -24,6 +25,8 @@ def compare(eval_output_item: EvalOutput, experiment_config: dict[str, str], sco
         comparators.append(exactmatcher.ExactMatcher(scorers["exact_match"]))
     if "recall_match" in scorers:
         comparators.append(recallmatcher.RecallMatcher(scorers["recall_match"]))
+    if "set_match" in scorers:
+        comparators.append(setmatcher.SetMatcher(scorers["set_match"]))
     if "vertexmatcher" in scorers:
         comparators.append(vertextmatcher.VertexMatcher(scorers["vertexmatcher"]))
     if "llmrater" in scorers:

--- a/evalbench/scorers/setmatcher.py
+++ b/evalbench/scorers/setmatcher.py
@@ -1,0 +1,39 @@
+"""Set match between the golden query execution result and the generated query execution result. This is the Execution Accuracy measured in BIRD"""
+
+from typing import Tuple
+
+from scorers import comparator
+
+
+class SetMatcher(comparator.Comparator):
+    """SetMatcher.
+
+    Attributes:
+      name:
+    """
+
+    def __init__(self, config: dict):
+        self.name = "set_match"
+        self.config = config
+
+    def compare(
+        self,
+        nl_prompt: str,
+        golden_query: str,
+        query_type: str,
+        golden_execution_result: list,
+        golden_eval_result: str,
+        golden_error: str,
+        generated_query: str,
+        generated_execution_result: list,
+        generated_eval_result: str,
+        generated_error: str,
+    ) -> Tuple[float, str]:
+        if golden_error or generated_error:
+            return 0, None
+        else:
+            # Current results are a list of Dict. Converting to Tuple for set comparison
+            golden_execution_result_tuple = [tuple(d.values()) for d in golden_execution_result]
+            generated_execution_result_tuple = [tuple(d.values()) for d in generated_execution_result]
+            score = 100 if set(golden_execution_result_tuple) == set(generated_execution_result_tuple) else 0
+            return score, None


### PR DESCRIPTION
Did a quick test in 100 questions in superhero and the set_match is ~5% better than restricted exact_match, similar to what we observed in SQLite.

```
I1206 23:28:04.168488 140623092039680 analyzer.py:36] exact_match: 	60/100 = 60.0%
I1206 23:28:04.169535 140623092039680 analyzer.py:36] llmrater: 	69/100 = 69.0%
I1206 23:28:04.170440 140623092039680 analyzer.py:36] recall_match: 	0/100 = 0.0%
I1206 23:28:04.171472 140623092039680 analyzer.py:36] returned_sql: 	99/100 = 99.0%
I1206 23:28:04.172331 140623092039680 analyzer.py:36] set_match: 	65/100 = 65.0%
I1206 23:28:04.173423 140623092039680 analyzer.py:36] executable: 	86/100 = 86.0%
```