### PR TITLE
Populate actual RagL context for NL2Code datasets

### DIFF
--- a/evalbench/configs/base_experiment_nl2code_hibernate.yaml
+++ b/evalbench/configs/base_experiment_nl2code_hibernate.yaml
@@ -1,4 +1,5 @@
 dataset_config: https://dar-internal.googlesource.com/nl2code-dataset/cymbalshop-spring/dataset.json
+ragl_context_config: https://dar-internal.googlesource.com/nl2code-dataset/cymbalshop/context/ragl_snippets.json
 database_config: configs/db/nl2code_postgres.yaml
 model_config: configs/model/base_nl2code_model.yaml
 prompt_generator: 'NOOPGenerator'

--- a/evalbench/configs/base_experiment_nl2code_hibernate.yaml
+++ b/evalbench/configs/base_experiment_nl2code_hibernate.yaml
@@ -1,5 +1,5 @@
 dataset_config: https://dar-internal.googlesource.com/nl2code-dataset/cymbalshop-spring/dataset.json
-ragl_context_config: https://dar-internal.googlesource.com/nl2code-dataset/cymbalshop/context/ragl_snippets.json
+ragl_context_config: https://dar-internal.googlesource.com/nl2code-dataset/cymbalshop-spring/context/ragl_snippets.json
 database_config: configs/db/nl2code_postgres.yaml
 model_config: configs/model/base_nl2code_model.yaml
 prompt_generator: 'NOOPGenerator'

--- a/evalbench/configs/base_experiment_nl2code_jdbc.yaml
+++ b/evalbench/configs/base_experiment_nl2code_jdbc.yaml
@@ -1,4 +1,5 @@
 dataset_config: https://dar-internal.googlesource.com/nl2code-dataset/cymbalshop/dataset.json
+ragl_context_config: https://dar-internal.googlesource.com/nl2code-dataset/cymbalshop/context/ragl_snippets.json
 database_config: configs/db/nl2code_postgres.yaml
 model_config: configs/model/base_nl2code_model.yaml
 prompt_generator: 'NOOPGenerator'

--- a/evalbench/dataset/dataset.py
+++ b/evalbench/dataset/dataset.py
@@ -155,6 +155,10 @@ def load_dataset_from_nl2code(dataset: Sequence[dict], dataset_ragl_context : Se
             cursor_start=item["user_action"]["cursor_start"],
             cursor_end=item["user_action"]["cursor_end"],
         )
+
+        application_context_data = json.dumps(item["application_context"])
+        if dataset_ragl_context is not None and dataset_ragl_context.hasKey(item["id"]):
+            application_context_data = dataset_ragl_context[item["id"]]
         
         eval_input = eval_nl2code_request_pb2.EvalInputRequest(
             id = item["id"],
@@ -162,7 +166,7 @@ def load_dataset_from_nl2code(dataset: Sequence[dict], dataset_ragl_context : Se
             user_action = user_action,
             verification_command = item["verification_command"],
             description = item["description"],
-            application_context = dataset_ragl_context[item["id"]]
+            application_context = application_context_data
         )
         input_items.append(eval_input)
     return input_items

--- a/evalbench/nl2code_eval_service.py
+++ b/evalbench/nl2code_eval_service.py
@@ -114,10 +114,11 @@ class EvalServicer(eval_nl2code_service_pb2_grpc.EvalCodeGenServiceServicer):
         job_id = repo.clone_dataset()
         
         dataset_config_json = os.path.join('/evalbench/datasets/nl2code', job_id, experiment_config["dataset_config"])
+        ragl_context_config_json = os.path.join('/evalbench/datasets/nl2code', job_id, experiment_config["ragl_context_config"])
 
         # Load the dataset
         dataset, database, application_url, build_command = load_dataset_from_nl2code_json(
-            dataset_config_json
+            dataset_config_json, ragl_context_config_json
         )
         session["db_config"]["database_name"] = database
         repo.cloneApplication(application_url, job_id)


### PR DESCRIPTION
This changes reads the ragl context file present at a specific location inside dataset repo and adds it to the eval_nl2code_request proto.