### PR TITLE
Fix eval package name for the service

### DIFF
--- a/evalbench/evalproto/eval_service.proto
+++ b/evalbench/evalproto/eval_service.proto
@@ -1,6 +1,6 @@
 edition = "2023";
 
-package cloud_databases_nl2sql_eval_sqlgen_proto;
+package cloud_databases_eval_proto;
 
 import "eval_config.proto";
 import "eval_connect.proto";


### PR DESCRIPTION
Consolidate eval package names. cl/723515690 for Google side

make proto / make build are broken at HEAD due to package naming.