### PR TITLE
Bug-Fix: Close idle close_connections

### DIFF
--- a/evalbench/databases/sqlserver.py
+++ b/evalbench/databases/sqlserver.py
@@ -30,10 +30,10 @@ class SQLServerDB(DB):
         logging.getLogger("pytds").setLevel(logging.ERROR)
 
         # Initialize the Cloud SQL Connector object
-        connector = Connector()
+        self.connector = Connector()
 
         def getconn():
-            conn = connector.connect(
+            conn = self.connector.connect(
                 instance_connection_name,
                 "pytds",
                 user=db_user,
@@ -54,6 +54,18 @@ class SQLServerDB(DB):
         )
 
         self.cache_client = get_cache_client(db_config)
+
+    def __del__(self):
+        self.close_connections()
+
+    def close_connections(self):
+        try:
+            self.engine.dispose()
+            self.connector.close()
+        except Exception:
+            logging.warning(
+                f"Failed to close connections. This may result in idle unused connections."
+            )
 
     def generate_schema(self):
         # To be implemented

--- a/evalbench/util/sessionmgr.py
+++ b/evalbench/util/sessionmgr.py
@@ -14,7 +14,7 @@ class SessionManager:
     ):
         self.running = True
         self.sessions = {}
-        self.ttl = 36000
+        self.ttl = 3600
         logging.debug("Starting reaper...")
         reaper = Thread(target=self.reaper, args=[])
         reaper.start()
@@ -62,6 +62,8 @@ class SessionManager:
         return self.sessions
 
     def delete_session(self, session_id):
+        if "db" in self.sessions[session_id]:
+            self.sessions[session_id]["db"].close_connections()
         del self.sessions[session_id]
 
     def shutdown(self):


### PR DESCRIPTION
1. Added logic to Sessionmgr to close all idle connections at deletion time. 
2. This change also reduces the defined TTL for sessions to 1 hour from the previously set 10hrs given that we have reduced the TTL on guitar significantly also (1hr).

Verified this change with setting TTL to 5 min manually
<img width="1107" alt="Screenshot 2025-02-05 at 3 21 39 PM" src="https://github.com/user-attachments/assets/4f4c584d-ca10-4f93-ad59-b5d8360a9f1f" />
 https://screenshot.googleplex.com/74BrvTWcSoP8ypE
and ensuring connections are reclaimed post cleanup.