### PR TITLE
Improve Pool Recycling and add Pre-Ping

### DIFF
--- a/evalbench/databases/alloydb.py
+++ b/evalbench/databases/alloydb.py
@@ -51,6 +51,8 @@ class AlloyDB(DB):
             "postgresql+pg8000://",
             creator=getconn,
             pool_size=50,
+            pool_recycle=3600,
+            pool_pre_ping=True,
             connect_args={"command_timeout": 60},
         )
 

--- a/evalbench/databases/mysql.py
+++ b/evalbench/databases/mysql.py
@@ -46,6 +46,8 @@ class MySQLDB(DB):
             "mysql+pymysql://",
             creator=getconn,
             pool_size=50,
+            pool_recycle=3600,
+            pool_pre_ping=True,
             connect_args={
                 "connect_timeout": 60,
             },

--- a/evalbench/databases/postgres.py
+++ b/evalbench/databases/postgres.py
@@ -54,6 +54,8 @@ class PGDB(DB):
             "postgresql+pg8000://",
             creator=getconn,
             pool_size=50,
+            pool_recycle=3600,
+            pool_pre_ping=True,
             connect_args={"command_timeout": 60},
         )
 

--- a/evalbench/databases/sqlserver.py
+++ b/evalbench/databases/sqlserver.py
@@ -46,6 +46,8 @@ class SQLServerDB(DB):
             "mssql+pytds://",
             creator=getconn,
             pool_size=50,
+            pool_recycle=3600,
+            pool_pre_ping=True,
             connect_args={
                 "connect_timeout": 60,
             },


### PR DESCRIPTION
Added pool_recycle=3600 to prevent stale connections and pool_pre_ping=True to proactively check connection health before re-use.

https://docs.sqlalchemy.org/en/20/core/pooling.html#setting-pool-recycle https://docs.sqlalchemy.org/en/20/core/pooling.html#dealing-with-disconnects