### PR TITLE
Update DDL issue on Postgres leaking temp databases

### DIFF
--- a/evalbench/databases/postgres.py
+++ b/evalbench/databases/postgres.py
@@ -55,7 +55,6 @@ class PGDB(DB):
             creator=getconn,
             pool_size=50,
             pool_recycle=3600,
-            pool_pre_ping=True,
             connect_args={"command_timeout": 60},
         )
 

--- a/evalbench/evaluator/evaluator.py
+++ b/evalbench/evaluator/evaluator.py
@@ -166,6 +166,10 @@ class Evaluator:
                 eval_outputs.append(eval_output)
 
             if query_type == "ddl":
+                logging.info("Closing connections to all temp databases")
+                while not db_queue.empty():
+                    db = db_queue.get()
+                    db.close_connections()
                 logging.info("Dropping temp databases")
                 setup_teardown.drop_temp_databases(db_config, temp_databases)
                 logging.info("Dropped")

--- a/evalbench/setup_teardown/databaseHandler/postgres_handler.py
+++ b/evalbench/setup_teardown/databaseHandler/postgres_handler.py
@@ -2,6 +2,7 @@ import os
 import csv
 import random
 import string
+import logging
 from typing import Any, Tuple, List
 from .db_handler import DBHandler
 from databases import get_database
@@ -86,7 +87,11 @@ class PostgresHandler(DBHandler):
     def drop_temp_databases(self, temp_databases: List[str]):
         db_instance = get_database(self.db_config)
         for database in temp_databases:
-            db_instance.drop_database(database)
+            _, error = db_instance.drop_database(database)
+            if error:
+                logging.error(
+                    f"Could not drop temporary database {database}. Error:{error}."
+                )
 
     def execute(self, queries: List[str]):
         result = None


### PR DESCRIPTION
Close all connections to temp databases as this previously failed deletion of temp databases due to existing open connections. Log error if this happens again.
Remove Pre-Ping as this also breaks autocommit on Postgres