### PR TITLE
Temp databases creation is failing for postgres databases.

### DIFF
--- a/evalbench/databases/postgres.py
+++ b/evalbench/databases/postgres.py
@@ -57,6 +57,7 @@ class PGDB(DB):
             pool_recycle=3600,
             pool_pre_ping=True,
             connect_args={"command_timeout": 60},
+            isolation_level="AUTOCOMMIT",
         )
 
         self.cache_client = get_cache_client(db_config)

--- a/evalbench/setup_teardown/databaseHandler/postgres_handler.py
+++ b/evalbench/setup_teardown/databaseHandler/postgres_handler.py
@@ -80,7 +80,9 @@ class PostgresHandler(DBHandler):
 
         db_instance = get_database(self.db_config)
         for database in db_names:
-            db_instance.create_database(database)
+            _, error = db_instance.create_database(database)
+            if error:
+                print(f"Error while creating database. error: {error}")
         return db_names
 
     def drop_temp_databases(self, temp_databases: List[str]):


### PR DESCRIPTION
This is effecting the ddl query runs. (Run [LINK](https://fusion2.corp.google.com/ci/guitar/workflows/%2F%2Fcloud%2Fdatabases%2Fnl2sql%2Feval%2Fpipelines:gcp_eval_ci_evals_workflow/activity/263feebb-4997-32d0-9b28-3fca9b72bcfe:0/tests))

From initial finding it seems the error is occuring because autocommit is not being enabled properly for each connection. Thus to fix this change enables autocommit at the time of engine creation.

Verified this change fixes the issue.