### PR TITLE
Add documentation for ExactMatcher scorer

### DIFF
--- a/evalbench/scorers/exactmatcher.py
+++ b/evalbench/scorers/exactmatcher.py
@@ -7,7 +7,7 @@ Run Configuration Options:
     1. use_eval_sql: Optional
         - Allowed values: True, False
         - Default value: False
-        - When use_eval_sql is set to True, it compares the results of eval queries which are used to verify DDL queries
+        - When use_eval_sql is set to True, it compares the results of eval queries which are used to verify DDL and DML queries
 """
 
 from typing import Tuple


### PR DESCRIPTION
pydoc preview:
Help on module scorers.exactmatcher in scorers:

NAME
    scorers.exactmatcher - ExactMatcher

DESCRIPTION
    It is a simple comparison strategy which checks if expected and generated results are exactly the same.

    Run Configuration Options:
        1. use_eval_sql: Optional
            - Allowed values: True, False
            - Default value: False
            - When use_eval_sql is set to True, it compares the results of eval queries which are used to verify DDL queries

CLASSES
    scorers.comparator.Comparator(abc.ABC)
        ExactMatcher

    class ExactMatcher(scorers.comparator.Comparator)
     |  ExactMatcher(config: dict)
     |
     |  ExactMatcher class implements the Comparator base class with exact match logic.
     |
     |  Attributes:
     |    1. name: Name of the comparator. Set to "exact match"
     |    2. config: the scorer config defined in the run config yaml file
     |
     |  Method resolution order:
     |      ExactMatcher
     |      scorers.comparator.Comparator
     |      abc.ABC
     |      builtins.object
     |
     |  Methods defined here:
     |
     |  __init__(self, config: dict)
     |      Initializes the Comparator with a config.
     |
     |      Args:
     |        name: A descriptive name for the comparison strategy.
     |
     |  compare(self, nl_prompt: str, golden_query: str, query_type: str, golden_execution_result: list, golden_eval_result: str, golden_error: str, generated_query: str, generated_execution_result: list, generated_eval_result: str, generated_error: str) -> Tuple[float, str]
     |      compare function implements the comparison logic for ExactMatcher comparator.
     |
     |  ----------------------------------------------------------------------
     |  Data and other attributes defined here:
     |
     |  __abstractmethods__ = frozenset()
     |
     |  ----------------------------------------------------------------------
     |  Data descriptors inherited from scorers.comparator.Comparator:
     |
     |  __dict__
     |      dictionary for instance variables
     |
     |  __weakref__
     |      list of weak references to the object

DATA
    Tuple = typing.Tuple
        Deprecated alias to builtins.tuple.

        Tuple[X, Y] is the cross-product type of X and Y.

        Example: Tuple[T1, T2] is a tuple of two elements corresponding
        to type variables T1 and T2.  Tuple[int, float, str] is a tuple
        of an int, a float and a string.

        To specify a variable-length tuple of homogeneous type, use Tuple[T, ...].

FILE
    /usr/local/google/home/dvnshgupta/evalbench/evalbench/scorers/exactmatcher.py