### PR TITLE
Fix id type in BQ and dataframe format

### DIFF
--- a/evalbench/reporting/analyzer.py
+++ b/evalbench/reporting/analyzer.py
@@ -74,11 +74,10 @@ def analyze_result(scores, experiment_config: dict[str, str]):
     summary_scores.append(summary)
     summary_scores_df = pd.DataFrame.from_dict(summary_scores)
     df[
-        ["generated_error", "comparator", "comparison_error", "generated_sql", "job_id"]
+        ["generated_error", "comparator", "comparison_error", "generated_sql", "job_id", "id"]
     ] = df[
-        ["generated_error", "comparator", "comparison_error", "generated_sql", "job_id"]
+        ["generated_error", "comparator", "comparison_error", "generated_sql", "job_id", "id"]
     ].astype(
         "string"
     )
-    df[["id"]] = df[["id"]].astype("int64")
     return df, summary_scores_df


### PR DESCRIPTION
Removing mismatched join fields since id is string everywhere except in this dataframe to BQ which causes join errors unless explicitly casted (not possible in Looker Studio) for reporting.