### PR TITLE
Fix and add documentation for set matcher

### DIFF
--- a/evalbench/scorers/setmatcher.py
+++ b/evalbench/scorers/setmatcher.py
@@ -49,7 +49,6 @@ class SetMatcher(comparator.Comparator):
             generated_execution_result_tuple = [
                 tuple(d.values()) for d in generated_execution_result
             ]
-            
             score = (
                 100
                 if set(golden_execution_result_tuple)


### PR DESCRIPTION
pydocs preview:
Help on module scorers.setmatcher in scorers:

NAME
    scorers.setmatcher

DESCRIPTION
    This comparison strategy compares the set of generated and expected results and gives full score if the sets match exactly.
    This is the execution accuracy measured in BIRD

    Run configurations: None

CLASSES
    scorers.comparator.Comparator(abc.ABC)
        SetMatcher

    class SetMatcher(scorers.comparator.Comparator)
     |  SetMatcher(config: dict)
     |
     |  SetMatcher class implements the Comparator base class with set comparison logic.
     |
     |  Attributes:
     |      1. name: Name of the comparator. Set to "set_match"
     |      2. config: Scorer config defined in the run config yaml file
     |
     |  Method resolution order:
     |      SetMatcher
     |      scorers.comparator.Comparator
     |      abc.ABC
     |      builtins.object
     |
     |  Methods defined here:
     |
     |  __init__(self, config: dict)
     |      Initializes the Comparator with a config.
     |
     |      Args:
     |        name: A descriptive name for the comparison strategy.
     |
     |  compare(self, nl_prompt: str, golden_query: str, query_type: str, golden_execution_result: list, golden_eval_result: str, golden_error: str, generated_query: str, generated_execution_result: list, generated_eval_result: str, generated_error: str) -> Tuple[float, str]
     |      Implements the set comparison logic
     |
     |  ----------------------------------------------------------------------
     |  Data and other attributes defined here:
     |
     |  __abstractmethods__ = frozenset()
     |
     |  ----------------------------------------------------------------------
     |  Data descriptors inherited from scorers.comparator.Comparator:
     |
     |  __dict__
     |      dictionary for instance variables
     |
     |  __weakref__
     |      list of weak references to the object

DATA
    Tuple = typing.Tuple
        Deprecated alias to builtins.tuple.

        Tuple[X, Y] is the cross-product type of X and Y.

        Example: Tuple[T1, T2] is a tuple of two elements corresponding
        to type variables T1 and T2.  Tuple[int, float, str] is a tuple
        of an int, a float and a string.

        To specify a variable-length tuple of homogeneous type, use Tuple[T, ...].

FILE
    /usr/local/google/home/dvnshgupta/evalbench/evalbench/scorers/setmatcher.py