### PR TITLE
fix and document returned SQL comparator

### DIFF
--- a/evalbench/scorers/returnedsql.py
+++ b/evalbench/scorers/returnedsql.py
@@ -4,7 +4,7 @@ ReturnedSQL
 This comparison stragtegy checks if the generated sql query has any non-comment lines.
 It assigns a score of 100 if there are non-comment lines, otherwise a score of 0.
 
-It checks for both single line comments (start with --) and multiline comments (start with /*, end with */)
+It checks for single line comments (start with -- and #) and multiline comments (start with /*, end with */)
 
 Runtime Options: None
 """
@@ -44,9 +44,11 @@ class ReturnedSQL(comparator.Comparator):
         if generated_query == "":
             return 100, None
 
+        generated_query = re.sub(r'/\*.*?\*/', '', generated_query, flags=re.DOTALL)
+
         query_lines = [line.strip() for line in generated_query.splitlines()]
         has_non_comment_line = any(
-            line and (not line.startswith("--") and not line.startswith("/*")) for line in query_lines
+            line and (not line.startswith("--") and not line.startswith("#")) for line in query_lines
         )
 
         score = 100 if has_non_comment_line else 0


### PR DESCRIPTION
pydocs preview:
Help on module scorers.returnedsql in scorers:

NAME
    scorers.returnedsql - ReturnedSQL

DESCRIPTION
    This comparison stragtegy checks if the generated sql query has any non-comment lines.
    It assigns a score of 100 if there are non-comment lines, otherwise a score of 0.

    It checks for both single line comments (start with --) and multiline comments (start with /*, end with */)

    Runtime Options: None

CLASSES
    scorers.comparator.Comparator(abc.ABC)
        ReturnedSQL

    class ReturnedSQL(scorers.comparator.Comparator)
     |  ReturnedSQL(config: dict)
     |
     |  ReturnedSQL class implements the Comparator base class with SQL finding logic.
     |
     |  Attributes:
     |      1. name: Name of the comparator. Set to "returned_sql"
     |      2. config: Scorer config defined in the run config yaml file
     |
     |  Method resolution order:
     |      ReturnedSQL
     |      scorers.comparator.Comparator
     |      abc.ABC
     |      builtins.object
     |
     |  Methods defined here:
     |
     |  __init__(self, config: dict)
     |      Initializes the Comparator with a config.
     |
     |      Args:
     |        name: A descriptive name for the comparison strategy.
     |
     |  compare(self, nl_prompt: str, golden_query: str, query_type: str, golden_execution_result: str, golden_eval_result: str, golden_error: str, generated_query: str, generated_execution_result: str, generated_eval_result: str, generated_error: str) -> Tuple[float, str]
     |      compare function implements the SQL finding logic for ReturnedSQL comparator.
     |
     |  ----------------------------------------------------------------------
     |  Data and other attributes defined here:
     |
     |  __abstractmethods__ = frozenset()
     |
     |  ----------------------------------------------------------------------
     |  Data descriptors inherited from scorers.comparator.Comparator:
     |
     |  __dict__
     |      dictionary for instance variables
     |
     |  __weakref__
     |      list of weak references to the object

DATA
    Tuple = typing.Tuple
        Deprecated alias to builtins.tuple.

        Tuple[X, Y] is the cross-product type of X and Y.

        Example: Tuple[T1, T2] is a tuple of two elements corresponding
        to type variables T1 and T2.  Tuple[int, float, str] is a tuple
        of an int, a float and a string.

        To specify a variable-length tuple of homogeneous type, use Tuple[T, ...].

FILE
    /usr/local/google/home/dvnshgupta/evalbench/evalbench/scorers/returnedsql.py