### PR TITLE
fix: make PYTHONPATH robust across different working directories

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -197,10 +197,10 @@ pod-shell-test:
 
 proto:
 	@python -m grpc_tools.protoc \
-		--proto_path=evalbench/evalproto \
-		--python_out=evalbench/evalproto \
-		--pyi_out=evalbench/evalproto \
-		--grpc_python_out=evalbench/evalproto \
+		--proto_path=evalbench \
+		--python_out=evalbench \
+		--pyi_out=evalbench \
+		--grpc_python_out=evalbench \
 		--experimental_editions evalbench/evalproto/*.proto
 
 clean:

--- a/evalbench/evalproto/eval_service.proto
+++ b/evalbench/evalproto/eval_service.proto
@@ -2,10 +2,10 @@ edition = "2023";
 
 package cloud_databases_eval_proto;
 
-import "eval_config.proto";
-import "eval_connect.proto";
-import "eval_request.proto";
-import "eval_response.proto";
+import "evalproto/eval_config.proto";
+import "evalproto/eval_connect.proto";
+import "evalproto/eval_request.proto";
+import "evalproto/eval_response.proto";
 
 option java_multiple_files = true;
 

--- a/evalbench/run.sh
+++ b/evalbench/run.sh
@@ -9,6 +9,8 @@ fi
 ulimit -n 4096
 
 export PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION=python
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" &> /dev/null && pwd)"
+export PYTHONPATH="${SCRIPT_DIR}"
 
 if command -v uv &> /dev/null; then
   uv run --no-sync evalbench/evalbench.py --experiment_config="$EVAL_CONFIG"

--- a/evalbench/util/setup_databases.py
+++ b/evalbench/util/setup_databases.py
@@ -10,10 +10,10 @@ Example usage:
 """
 
 
-from evalbench.evaluator.db_manager import _get_setup_values
-from evalbench.databases import get_database
-from evalbench.dataset.dataset import load_dataset_from_json, flatten_dataset
-from evalbench.util.config import load_yaml_config
+from evaluator.db_manager import _get_setup_values
+from databases import get_database
+from dataset.dataset import load_dataset_from_json, flatten_dataset
+from util.config import load_yaml_config
 import sys
 import os
 from absl import app

--- a/evalbench/util/test_setup_databases.py
+++ b/evalbench/util/test_setup_databases.py
@@ -1,14 +1,14 @@
 import unittest
 from unittest.mock import patch, MagicMock
-from evalbench.util.setup_databases import setup_databases
+from util.setup_databases import setup_databases
 import os
 
 
 class TestSetupDatabases(unittest.TestCase):
-    @patch('evalbench.util.setup_databases.get_database')
-    @patch('evalbench.util.setup_databases.load_yaml_config')
-    @patch('evalbench.util.setup_databases.load_dataset_from_json')
-    @patch('evalbench.util.setup_databases._get_setup_values')
+    @patch('util.setup_databases.get_database')
+    @patch('util.setup_databases.load_yaml_config')
+    @patch('util.setup_databases.load_dataset_from_json')
+    @patch('util.setup_databases._get_setup_values')
     def test_setup_databases_standard(self, mock_get_setup_values, mock_load_dataset, mock_load_yaml, mock_get_db):
         mock_load_yaml.side_effect = [
             {"dataset_config": "fake_ds.json", "database_configs": [

--- a/noxfile.py
+++ b/noxfile.py
@@ -1,9 +1,12 @@
 from __future__ import absolute_import
 
 import nox
+import os
 
 @nox.session
 def unittests(session):
     session.run("uv", "pip", "install", ".")
     session.run("uv", "pip", "install", "pytest")
-    session.run("pytest", "-vvv", "--capture=no", "-rX", "--ignore", "evalbenchtest/*", success_codes=[0])
+    script_dir = os.path.dirname(os.path.abspath(__file__))
+    python_path = f"{os.path.join(script_dir, 'evalbench')}"
+    session.run("pytest", "-vvv", "--capture=no", "-rX", "--ignore", "evalbenchtest/*", success_codes=[0], env={"PYTHONPATH": python_path})

--- a/run_client.sh
+++ b/run_client.sh
@@ -1,2 +1,3 @@
-export PYTHONPATH=./evalbench:./evalbench/evalproto
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" &> /dev/null && pwd)"
+export PYTHONPATH="${SCRIPT_DIR}/evalbench"
 python3 evalbench/client/eval_client.py --experiment="$EVAL_CONFIG" --endpoint="local"

--- a/run_service.sh
+++ b/run_service.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 export PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION=python
-export PYTHONPATH=./evalproto:.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" &> /dev/null && pwd)"
+export PYTHONPATH="${SCRIPT_DIR}/evalbench"
 
 # if [[ "$TYPE" == "desktop" ]]; then
 #   echo "Running on desktop"


### PR DESCRIPTION
Update various launcher scripts to consistently set PYTHONPATH to point to the evalbench directory, relative to the path of that script (so the script still works correctly if called with a current working directory of some other directory).

Update protobufs to treat evalbench as the package root, so we don't additionally have to add their directory to PYTHONPATH in code that imports compiled-protobuf files.

Update a couple places that had accidentally ended up relying on the project root being in PYTHONPATH (so imported from `evalbench.*`).