### PR TITLE
fix(databases/alloydb): restore correct use_adc flag behavior

### DIFF
--- a/evalbench/databases/alloydb.py
+++ b/evalbench/databases/alloydb.py
@@ -17,7 +17,6 @@ class AlloyDB(PGDB):
         """
         super().__init__(db_config)
         self.nl_config = db_config['nl_config']
-        self.use_adc = not self.username and not self.password
 
         if 'api_endpoint' in db_config:
             CONNECTOR._alloydb_api_endpoint = db_config['api_endpoint']

--- a/evalbench/test/alloydb_test.py
+++ b/evalbench/test/alloydb_test.py
@@ -2,12 +2,13 @@ import unittest
 from unittest.mock import patch
 from evalbench.databases.alloydb import AlloyDB
 
+
 class TestAlloyDB(unittest.TestCase):
 
     @patch('evalbench.databases.postgres.get_adc_user_email')
     def test_adc_init(self, mock_get_email):
         mock_get_email.return_value = "dummy@google.com"
-        
+
         db_config = {
             "database_path": "projects/p/locations/l/clusters/c/instances/i",
             "database_name": "db",
@@ -15,13 +16,14 @@ class TestAlloyDB(unittest.TestCase):
             "max_executions_per_minute": 10,
             "nl_config": {}
         }
-        
+
         alloydb = AlloyDB(db_config)
-        
+
         # Verify that use_adc is True (inherited from PGDB)
         self.assertTrue(alloydb.use_adc)
         # Verify that username is set to the ADC email
         self.assertEqual(alloydb.username, "dummy@google.com")
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/evalbench/test/alloydb_test.py
+++ b/evalbench/test/alloydb_test.py
@@ -1,0 +1,27 @@
+import unittest
+from unittest.mock import patch
+from evalbench.databases.alloydb import AlloyDB
+
+class TestAlloyDB(unittest.TestCase):
+
+    @patch('evalbench.databases.postgres.get_adc_user_email')
+    def test_adc_init(self, mock_get_email):
+        mock_get_email.return_value = "dummy@google.com"
+        
+        db_config = {
+            "database_path": "projects/p/locations/l/clusters/c/instances/i",
+            "database_name": "db",
+            "db_type": "alloydb",
+            "max_executions_per_minute": 10,
+            "nl_config": {}
+        }
+        
+        alloydb = AlloyDB(db_config)
+        
+        # Verify that use_adc is True (inherited from PGDB)
+        self.assertTrue(alloydb.use_adc)
+        # Verify that username is set to the ADC email
+        self.assertEqual(alloydb.username, "dummy@google.com")
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Fixed a bug in the `AlloyDB` connector where the `use_adc` flag was being recalculated and overridden after superclass initialization. This caused ADC/IAM authentication to be disabled even when credentials were not provided, leading to authentication errors.