### PR TITLE
fix(generators/query_data_api): add retry support for transient API errors

### DIFF
--- a/evalbench/generators/models/query_data_api.py
+++ b/evalbench/generators/models/query_data_api.py
@@ -2,6 +2,8 @@ from .generator import QueryGenerator
 import google.cloud.geminidataanalytics_v1beta as gda
 import logging
 from typing import Dict, Any
+from google.api_core.exceptions import ResourceExhausted, ServiceUnavailable, DeadlineExceeded
+from util.rate_limit import ResourceExhaustedError
 
 
 class QueryDataAPIGenerator(QueryGenerator):
@@ -75,6 +77,8 @@ class QueryDataAPIGenerator(QueryGenerator):
             }
             return result
 
+        except (ResourceExhausted, ServiceUnavailable, DeadlineExceeded) as e:
+            raise ResourceExhaustedError(e)
         except Exception as e:
             logger.exception("Unhandled exception during QueryData API call")
             raise

--- a/evalbench/test/query_data_api_test.py
+++ b/evalbench/test/query_data_api_test.py
@@ -1,6 +1,8 @@
 import unittest
 from unittest.mock import patch, MagicMock
 from generators.models.query_data_api import QueryDataAPIGenerator
+from google.api_core.exceptions import ResourceExhausted, ServiceUnavailable, DeadlineExceeded
+from util.rate_limit import ResourceExhaustedError
 
 
 class TestQueryDataAPIGenerator(unittest.TestCase):
@@ -64,6 +66,48 @@ class TestQueryDataAPIGenerator(unittest.TestCase):
             generator.generate_internal("What is in test?")
 
         self.assertIn("API error", str(context.exception))
+
+    @patch('generators.models.query_data_api.gda')
+    def test_generate_internal_resource_exhausted(self, mock_gda):
+        mock_client_instance = MagicMock()
+        mock_gda.DataChatServiceClient.return_value = mock_client_instance
+        mock_client_instance.query_data.side_effect = ResourceExhausted("Quota exceeded")
+
+        config = {
+            "project_id": "test-project"
+        }
+        generator = QueryDataAPIGenerator(config)
+
+        with self.assertRaises(ResourceExhaustedError):
+            generator.generate_internal("What is in test?")
+
+    @patch('generators.models.query_data_api.gda')
+    def test_generate_internal_service_unavailable(self, mock_gda):
+        mock_client_instance = MagicMock()
+        mock_gda.DataChatServiceClient.return_value = mock_client_instance
+        mock_client_instance.query_data.side_effect = ServiceUnavailable("Service unavailable")
+
+        config = {
+            "project_id": "test-project"
+        }
+        generator = QueryDataAPIGenerator(config)
+
+        with self.assertRaises(ResourceExhaustedError):
+            generator.generate_internal("What is in test?")
+
+    @patch('generators.models.query_data_api.gda')
+    def test_generate_internal_deadline_exceeded(self, mock_gda):
+        mock_client_instance = MagicMock()
+        mock_gda.DataChatServiceClient.return_value = mock_client_instance
+        mock_client_instance.query_data.side_effect = DeadlineExceeded("Deadline exceeded")
+
+        config = {
+            "project_id": "test-project"
+        }
+        generator = QueryDataAPIGenerator(config)
+
+        with self.assertRaises(ResourceExhaustedError):
+            generator.generate_internal("What is in test?")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Added retry support for `QueryDataAPIGenerator` by catching `ResourceExhausted`, `ServiceUnavailable`, and `DeadlineExceeded` exceptions from the Google Cloud Gemini Data Analytics SDK and raising the project's custom `ResourceExhaustedError`. This allows the base class `QueryGenerator` to perform retries with exponential backoff when these transient errors or rate limits are hit.