### PR TITLE
refactor: implement lazy initialization for SecretManager client and …

### DIFF
--- a/evalbench/databases/util.py
+++ b/evalbench/databases/util.py
@@ -8,7 +8,16 @@ import redis
 import re
 from dataclasses import dataclass, field
 
-CLIENT = secretmanager_v1.SecretManagerServiceClient()
+# CLIENT is initialized lazily to avoid blocking network calls during module import,
+# which can cause hangs in restricted environments like Cloud Build.
+CLIENT = None
+
+
+def get_client():
+    global CLIENT
+    if CLIENT is None:
+        CLIENT = secretmanager_v1.SecretManagerServiceClient()
+    return CLIENT
 
 
 @dataclass
@@ -54,7 +63,7 @@ def get_db_secret(secret):
         name=secret_path,
     )
     # Make the request
-    response = CLIENT.access_secret_version(request=request)
+    response = get_client().access_secret_version(request=request)
 
     # Return the secret
     return response.payload.data.decode("utf-8")

--- a/evalbench/eval_service.py
+++ b/evalbench/eval_service.py
@@ -161,8 +161,9 @@ class EvalServicer(eval_service_pb2_grpc.EvalServiceServicer):
             )
 
         job_id, run_time, results_tf, scores_tf = evaluator.process()
+        # Fallback to empty dict if reporting is present but null in YAML
         reporters = get_reporters(
-            config.get("reporting", {}), job_id, run_time
+            config.get("reporting") or {}, job_id, run_time
         )
 
         # Offload blocking results processing to a thread pool

--- a/evalbench/util/session.py
+++ b/evalbench/util/session.py
@@ -1,10 +1,12 @@
 import asyncio
-from google.adk.sessions import VertexAiSessionService
+
 from google.genai import types
 
 
 class EvalAgentEngineSessionMgr:
     def __init__(self, config):
+        # Import lazily to avoid blocking calls during module load in Cloud Build
+        from google.adk.sessions import VertexAiSessionService
         self.project_id = config.get("project_id")
         self.location = config.get("location")
         self.agent_engine_id = config.get("agent_engine_id")


### PR DESCRIPTION
In my cloudbuild.yaml, the evaluation server was failing to start because of two main issues. First, eager module-level imports in the server code were triggering blocking network/auth calls that caused the server to hang silently before it could bind to the port. Second, the Python polling script used to wait for port 50051 had a bug: it created the socket outside the retry loop. Once the first connection attempt failed, the socket became unusable, causing all subsequent retries to fail immediately even after the server finally booted. I resolved this by using sed commands to make the imports lazy and moving the socket creation inside the loop so it tries a fresh connection on every attempt.

