### PR TITLE
feat(scorer/llmrater): add fallback to SQL logic comparison for empty results

### DIFF
--- a/evalbench/scorers/llmrater.py
+++ b/evalbench/scorers/llmrater.py
@@ -64,6 +64,90 @@ Provide your response in the following format:
 <Tag 2>: <One-line explanation of the specific error>
 """
 
+SQL_LOGIC_COMPARISON_PROMPT = """
+We are trying to answer this question by querying a database:
+
+QUESTION: {nl_prompt}
+
+Golden SQL (Ground Truth):
+{golden_sql}
+
+Generated SQL:
+{generated_sql}
+
+Both queries returned empty datasets, likely due to lack of test data. Therefore, you must evaluate the queries based on their SQL logic.
+
+Thinking step by step, compare the two SQL queries and look for differences in logic and structure.
+Here are steps to follow:
+
+1. Analyze the QUESTION: Does it explicitly ask for a specific sorting order or limit?
+2. Compare SQL Logic: Ensure that the Generated SQL implements the same logical operations (joins, filters, aggregations) as the Golden SQL to answer the question.
+3. Handle Variations: Allow slight variations in syntax if the logic remains equivalent.
+
+RULES & RELAXED EVALUATION CRITERIA - These MUST be strictly followed:
+
+1. Assume the Golden SQL is correct in its core logic.
+2. The mapped column names/aliases might differ, do not make any assumptions based on them.
+3. Do NOT penalize the Generated SQL if it differs from the Golden SQL for ANY of the following reasons:
+    - Column/Row Order: Differences in column names, column order, or row order when no requirements are specified in the QUESTION.
+    - Rounding: Differences in integer/decimal rounding or precision when the QUESTION lacks specific guidelines.
+    - Ambiguous Limit: The QUESTION asks for "top/highest" or "bottom/lowest" entries but doesn't specify a concrete limit, leading to different numbers of entries.
+    - Entity Representation: The QUESTION asks for a list of items but doesn't specify IDs or names, leading one output to return IDs and the other names.
+    - Extra Columns: The Generated SQL has a small number of extra columns that are not explicitly excluded and don't render the overall result incorrect.
+
+FINAL QUESTION: Is the Generated SQL logically equivalent to the Golden SQL?
+FINAL ANSWER: Choose ONLY ONE
+- EQUIVALENT -- The Generated SQL is logically equivalent to the Golden SQL and correctly handles the question (or differences fall under the acceptable relaxed criteria).
+- NOT_EQUIVALENT -- The Generated SQL has logical flaws, missing conditions, or incorrect structure compared to the Golden SQL.
+"""
+
+DATA_COMPARISON_PROMPT = """
+We are trying to answer this question by querying a database:
+
+QUESTION: {nl_prompt}
+
+The correct answer to this question is:
+
+OUTPUT #1 (Gold Standard):
+
+{golden_execution_result}
+
+
+We get the following answer from a generated query:
+
+OUTPUT #2 (Generated Result):
+
+{generated_execution_result}
+
+
+Thinking step by step, compare the two outputs and look for differences in data and presentation.
+Here are steps to follow:
+
+1. Analyze the QUESTION: Does it explicitly ask for a specific sorting order (e.g., "ordered by date", "top 5")? Does it explicitly ask for a limit?
+2. Column Mapping: Ensure that every column in OUTPUT #1 has a corresponding column in OUTPUT #2 that represents the same information. OUTPUT #2 is allowed to have additional descriptive columns.
+3. Data Comparison: Compare the data within each mapped column pair.
+4. Row Order: Ignore differences in row order UNLESS the QUESTION explicitly requested a specific sorting. Treat the data as unordered sets if no order is specified.
+5. Extra Rows: If OUTPUT #2 has extra rows but contains all of OUTPUT #1, evaluate if the extra rows violate the prompt's constraints. If the prompt was ambiguous about limits (e.g. "Identify the MSA with the highest growth" and the model returns a ranked list instead of a single row), treating it as EXTRA_INFORMATION is acceptable and correct.
+
+RULES & RELAXED EVALUATION CRITERIA - These MUST be strictly followed:
+
+1. Assume OUTPUT #1 is the gold standard and its core data values are ALWAYS mathematically/logically correct.
+2. The mapped column names might differ, do not make any assumptions based on them.
+3. Do NOT penalize OUTPUT #2 if it differs from OUTPUT #1 for ANY of the following reasons:
+    - Column/Row Order: Differences in column names, column order, or row order when no requirements are specified in the QUESTION.
+    - Rounding: Differences in integer/decimal rounding or precision when the QUESTION lacks specific guidelines.
+    - Ambiguous Limit: The QUESTION asks for "top/highest" or "bottom/lowest" entries but doesn't specify a concrete limit, leading to different numbers of entries.
+    - Entity Representation: The QUESTION asks for a list of items but doesn't specify IDs or names, leading one output to return IDs and the other names.
+    - Extra Columns: OUTPUT #2 has a small number of extra columns that are not explicitly excluded and don't render the overall result incorrect.
+
+FINAL QUESTION: Does OUTPUT #2 provide the same information as OUTPUT #1?
+FINAL ANSWER: Choose ONLY ONE
+- INFORMATION_MATCHES -- OUTPUT #1 and OUTPUT #2 provide the same core information (or differences fall under the acceptable relaxed criteria).
+- MISSING_INFORMATION -- Something important requested by the QUESTION is missing from OUTPUT #2 (e.g. data points dropped, missing expected columns).
+- EXTRA_INFORMATION -- OUTPUT #2 includes the correct answer but added non-harmful extra relevant columns, or harmless extra rows due to an ambiguous limit/sorting constraint in the QUESTION.
+- INCORRECT_INFORMATION -- OUTPUT #2 contains mathematically or logically incorrect data, wrong aggregations, bad joins, missing expected rows, or violates explicit constraints in the QUESTION.
+"""
+
 
 class LLMRater(comparator.Comparator):
     """
@@ -151,7 +235,9 @@ class LLMRater(comparator.Comparator):
         generated_eval_result: str,
         generated_error: str,
     ) -> Tuple[float, str]:
-        if self._is_exact_match(
+        is_empty_results = len(golden_execution_result) == 0 and len(generated_execution_result) == 0
+
+        if not is_empty_results and self._is_exact_match(
             nl_prompt,
             golden_query,
             query_type,
@@ -179,52 +265,18 @@ class LLMRater(comparator.Comparator):
             generated_execution_result, only_first_n
         )
 
-        prompt = f"""
-        We are trying to answer this question by querying a database:
-
-        QUESTION: {nl_prompt}
-
-        The correct answer to this question is:
-
-        OUTPUT #1 (Gold Standard):
-
-        {golden_execution_result}
-
-
-        We get the following answer from a generated query:
-
-        OUTPUT #2 (Generated Result):
-
-        {generated_execution_result}
-
-
-        Thinking step by step, compare the two outputs and look for differences in data and presentation.
-        Here are steps to follow:
-
-        1. Analyze the QUESTION: Does it explicitly ask for a specific sorting order (e.g., "ordered by date", "top 5")? Does it explicitly ask for a limit?
-        2. Column Mapping: Ensure that every column in OUTPUT #1 has a corresponding column in OUTPUT #2 that represents the same information. OUTPUT #2 is allowed to have additional descriptive columns.
-        3. Data Comparison: Compare the data within each mapped column pair.
-        4. Row Order: Ignore differences in row order UNLESS the QUESTION explicitly requested a specific sorting. Treat the data as unordered sets if no order is specified.
-        5. Extra Rows: If OUTPUT #2 has extra rows but contains all of OUTPUT #1, evaluate if the extra rows violate the prompt's constraints. If the prompt was ambiguous about limits (e.g. "Identify the MSA with the highest growth" and the model returns a ranked list instead of a single row), treating it as EXTRA_INFORMATION is acceptable and correct.
-
-        RULES & RELAXED EVALUATION CRITERIA - These MUST be strictly followed:
-
-        1. Assume OUTPUT #1 is the gold standard and its core data values are ALWAYS mathematically/logically correct.
-        2. The mapped column names might differ, do not make any assumptions based on them.
-        3. Do NOT penalize OUTPUT #2 if it differs from OUTPUT #1 for ANY of the following reasons:
-            - Column/Row Order: Differences in column names, column order, or row order when no requirements are specified in the QUESTION.
-            - Rounding: Differences in integer/decimal rounding or precision when the QUESTION lacks specific guidelines.
-            - Ambiguous Limit: The QUESTION asks for "top/highest" or "bottom/lowest" entries but doesn't specify a concrete limit, leading to different numbers of entries.
-            - Entity Representation: The QUESTION asks for a list of items but doesn't specify IDs or names, leading one output to return IDs and the other names.
-            - Extra Columns: OUTPUT #2 has a small number of extra columns that are not explicitly excluded and don't render the overall result incorrect.
-
-        FINAL QUESTION: Does OUTPUT #2 provide the same information as OUTPUT #1?
-        FINAL ANSWER: Choose ONLY ONE
-        - INFORMATION_MATCHES -- OUTPUT #1 and OUTPUT #2 provide the same core information (or differences fall under the acceptable relaxed criteria).
-        - MISSING_INFORMATION -- Something important requested by the QUESTION is missing from OUTPUT #2 (e.g. data points dropped, missing expected columns).
-        - EXTRA_INFORMATION -- OUTPUT #2 includes the correct answer but added non-harmful extra relevant columns, or harmless extra rows due to an ambiguous limit/sorting constraint in the QUESTION.
-        - INCORRECT_INFORMATION -- OUTPUT #2 contains mathematically or logically incorrect data, wrong aggregations, bad joins, missing expected rows, or violates explicit constraints in the QUESTION.
-        """
+        if is_empty_results:
+            prompt = SQL_LOGIC_COMPARISON_PROMPT.format(
+                nl_prompt=nl_prompt,
+                golden_sql=golden_query,
+                generated_sql=generated_query,
+            )
+        else:
+            prompt = DATA_COMPARISON_PROMPT.format(
+                nl_prompt=nl_prompt,
+                golden_execution_result=golden_execution_result,
+                generated_execution_result=generated_execution_result,
+            )
 
         logging.debug("\n --------- prompt:   --------- \n %s ", prompt)
 
@@ -241,12 +293,15 @@ class LLMRater(comparator.Comparator):
         logging.debug(
             "\n --------- llm_rater_output:   --------- \n %s ", response)
 
-        # Scoring Logic: Both INFORMATION_MATCHES and EXTRA_INFORMATION are rewarded as correct.
-        score = (
-            100
-            if ("INFORMATION_MATCHES" in response or "EXTRA_INFORMATION" in response)
-            else 0
-        )
+        # Scoring Logic
+        if is_empty_results:
+            score = 100 if "EQUIVALENT" in response and "NOT_EQUIVALENT" not in response else 0
+        else:
+            score = (
+                100
+                if ("INFORMATION_MATCHES" in response or "EXTRA_INFORMATION" in response)
+                else 0
+            )
 
         if score == 0:
             prompt = ERROR_CATEGORIZATION_PROMPT.format(

--- a/evalbench/test/llmrater_test.py
+++ b/evalbench/test/llmrater_test.py
@@ -1,4 +1,5 @@
 import unittest
+from unittest.mock import patch, MagicMock
 from scorers.llmrater import LLMRater
 
 
@@ -34,6 +35,87 @@ class TestLLMRater(unittest.TestCase):
         # Edge case: empty list
         result = LLMRater.take_n_uniques([], 50)
         self.assertEqual(len(result), 0)
+
+    @patch('scorers.llmrater.get_generator')
+    def test_compare_empty_results_equivalent(self, mock_get_generator):
+        mock_model = MagicMock()
+        mock_model.generate.return_value = "Reasoning: Logic matches.\nResult: EQUIVALENT"
+        mock_get_generator.return_value = mock_model
+
+        config = {"model_config": "fake_config"}
+        rater = LLMRater(config, global_models={})
+
+        score, reason = rater.compare(
+            nl_prompt="Show all users",
+            golden_query="SELECT * FROM users",
+            query_type="sql",
+            golden_execution_result=[],
+            golden_eval_result="",
+            golden_error="",
+            generated_query="SELECT * FROM users",
+            generated_execution_result=[],
+            generated_eval_result="",
+            generated_error=""
+        )
+        
+        self.assertEqual(score, 100)
+        self.assertIn("EQUIVALENT", reason)
+        mock_model.generate.assert_called_once()
+
+    @patch('scorers.llmrater.get_generator')
+    def test_compare_empty_results_not_equivalent(self, mock_get_generator):
+        mock_model = MagicMock()
+        mock_model.generate.return_value = "Reasoning: Missing condition.\nResult: NOT_EQUIVALENT"
+        mock_get_generator.return_value = mock_model
+
+        config = {"model_config": "fake_config"}
+        rater = LLMRater(config, global_models={})
+
+        score, reason = rater.compare(
+            nl_prompt="Show all users",
+            golden_query="SELECT * FROM users WHERE age > 10",
+            query_type="sql",
+            golden_execution_result=[],
+            golden_eval_result="",
+            golden_error="",
+            generated_query="SELECT * FROM users",
+            generated_execution_result=[],
+            generated_eval_result="",
+            generated_error=""
+        )
+        
+        self.assertEqual(score, 0)
+        self.assertIn("NOT_EQUIVALENT", reason)
+        self.assertEqual(mock_model.generate.call_count, 2)
+
+    @patch('scorers.llmrater.get_generator')
+    def test_compare_exact_match_shortcut(self, mock_get_generator):
+        # Should not call LLM if results match and are not empty
+        mock_model = MagicMock()
+        mock_get_generator.return_value = mock_model
+
+        config = {"model_config": "fake_config"}
+        rater = LLMRater(config, global_models={})
+
+        golden_result = [{"id": 1}]
+        generated_result = [{"id": 1}]
+
+        score, reason = rater.compare(
+            nl_prompt="Show all users",
+            golden_query="SELECT * FROM users",
+            query_type="sql",
+            golden_execution_result=golden_result,
+            golden_eval_result="",
+            golden_error="",
+            generated_query="SELECT * FROM users",
+            generated_execution_result=generated_result,
+            generated_eval_result="",
+            generated_error=""
+        )
+        
+        self.assertEqual(score, 100)
+        self.assertIn("Exact Match was found", reason)
+        mock_model.generate.assert_not_called()
 
 
 if __name__ == '__main__':

--- a/evalbench/test/llmrater_test.py
+++ b/evalbench/test/llmrater_test.py
@@ -57,7 +57,7 @@ class TestLLMRater(unittest.TestCase):
             generated_eval_result="",
             generated_error=""
         )
-        
+
         self.assertEqual(score, 100)
         self.assertIn("EQUIVALENT", reason)
         mock_model.generate.assert_called_once()
@@ -83,7 +83,7 @@ class TestLLMRater(unittest.TestCase):
             generated_eval_result="",
             generated_error=""
         )
-        
+
         self.assertEqual(score, 0)
         self.assertIn("NOT_EQUIVALENT", reason)
         self.assertEqual(mock_model.generate.call_count, 2)
@@ -112,7 +112,7 @@ class TestLLMRater(unittest.TestCase):
             generated_eval_result="",
             generated_error=""
         )
-        
+
         self.assertEqual(score, 100)
         self.assertIn("Exact Match was found", reason)
         mock_model.generate.assert_not_called()


### PR DESCRIPTION
This change implements a fallback mechanism in `LLMRater` to handle cases where both the golden and generated queries return empty datasets. Instead of defaulting to a 100% score (false positive), it now invokes the LLM to compare the SQL logic of the queries. It also refactors the hardcoded prompts into file-level constants for better maintainability and adds unit tests to verify the new behavior.
