### PR TITLE
feat: add support for custom host configuration and insecure gRPC channels via environment variables

### DIFF
--- a/evalbench/client/eval_client.py
+++ b/evalbench/client/eval_client.py
@@ -1,4 +1,5 @@
 import asyncio
+import os
 from aiologger import Logger
 import grpc
 from evalproto import eval_request_pb2, eval_connect_pb2, eval_config_pb2
@@ -28,7 +29,6 @@ class EvalbenchClient:
     def __init__(self, endpoint: str):
         self.endpoint = endpoint
         if self.endpoint == "local":
-            import os
             host = os.getenv("EVALBENCH_HOST", "localhost")
             address = f"{host}:50051"
             if os.getenv("EVALBENCH_INSECURE", "").lower() == "true":

--- a/evalbench/client/eval_client.py
+++ b/evalbench/client/eval_client.py
@@ -28,9 +28,14 @@ class EvalbenchClient:
     def __init__(self, endpoint: str):
         self.endpoint = endpoint
         if self.endpoint == "local":
-            address = "localhost:50051"
-            channel_creds = grpc.alts_channel_credentials()
-            self.channel = grpc.aio.secure_channel(address, channel_creds)
+            import os
+            host = os.getenv("EVALBENCH_HOST", "localhost")
+            address = f"{host}:50051"
+            if os.getenv("EVALBENCH_INSECURE", "").lower() == "true":
+                self.channel = grpc.aio.insecure_channel(address)
+            else:
+                channel_creds = grpc.alts_channel_credentials()
+                self.channel = grpc.aio.secure_channel(address, channel_creds)
         else:
             address = f"{self.endpoint}:443"
             id_token = get_id_token(f"https://{self.endpoint}")

--- a/evalbench/client/eval_client.py
+++ b/evalbench/client/eval_client.py
@@ -30,7 +30,8 @@ class EvalbenchClient:
         self.endpoint = endpoint
         if self.endpoint == "local":
             host = os.getenv("EVALBENCH_HOST", "localhost")
-            address = f"{host}:50051"
+            port = os.getenv("PORT", "50051")
+            address = f"{host}:{port}"
             if os.getenv("EVALBENCH_INSECURE", "").lower() == "true":
                 self.channel = grpc.aio.insecure_channel(address)
             else:

--- a/evalbench/eval_server.py
+++ b/evalbench/eval_server.py
@@ -84,7 +84,7 @@ async def _serve():
         logging.info("Using ALTS server credentials")
         creds = grpc.alts_server_credentials()
         bound_port = server.add_secure_port(f"{host}:{PORT}", creds)
-    
+
     if bound_port == 0:
         raise RuntimeError(f"Failed to bind to port {PORT} on host {host}!")
     await server.start()

--- a/evalbench/eval_server.py
+++ b/evalbench/eval_server.py
@@ -76,13 +76,17 @@ async def _serve():
     server = grpc.aio.server(interceptors=interceptors)
     servicer = EvalServicer()
     eval_service_pb2_grpc.add_EvalServiceServicer_to_server(servicer, server)
+    host = os.getenv("EVALBENCH_HOST", "[::]")
     if _LOCALHOST.value or CLOUD_RUN:
         logging.info("Using localhost server insecure credentials per flag")
-        server.add_insecure_port("[::]:%s" % PORT)
+        bound_port = server.add_insecure_port(f"{host}:{PORT}")
     else:
         logging.info("Using ALTS server credentials")
         creds = grpc.alts_server_credentials()
-        server.add_secure_port("[::]:%s" % PORT, creds)
+        bound_port = server.add_secure_port(f"{host}:{PORT}", creds)
+    
+    if bound_port == 0:
+        raise RuntimeError(f"Failed to bind to port {PORT} on host {host}!")
     await server.start()
     logging.info("Server started")
 


### PR DESCRIPTION
# Add environment variable overrides for gRPC server binding and insecure credentials

## Context & Problem
In containerized CI environments (such as Google Cloud Build), network configurations often do not route IPv6 loopback (`[::]`) or require binding to all available IPv4 interfaces (`0.0.0.0`) for reliable inter-process communication. 

Previously, `eval_server.py` and `eval_client.py` strictly hardcoded the gRPC server interface to `[::]` and mandated secure ALTS channel credentials for local endpoints. This required inline `sed` patching in downstream repository CI pipelines to execute integration tests successfully.

## Solution
This PR introduces native environment variable overrides to support flexible network bindings without requiring code patching downstream:

1. **Configurable Server Host:**  
   - Added support for `EVALBENCH_HOST` in `eval_server.py` (defaults to `[::]`). Setting this to `0.0.0.0` binds the server to all network interfaces.
   - Added an explicit check to raise a `RuntimeError` if port binding fails, enabling fail-fast behavior in CI pipelines.

2. **Insecure Local Credentials Override:**  
   - Added support for `EVALBENCH_INSECURE=true` in `eval_client.py` to bypass ALTS channel credentials when running locally or in offline test environments.