### PR TITLE
Feature/trajectory matcher with claude

### DIFF
--- a/evalbench/scorers/score.py
+++ b/evalbench/scorers/score.py
@@ -18,6 +18,7 @@ from scorers import toolcalllatency
 from scorers import tokenconsumption
 from dataset.evaloutput import EvalOutput
 import logging
+import yaml
 
 
 def compare(
@@ -58,7 +59,16 @@ def compare(
         )
     if "trajectory_matcher" in scorers:
         model_config_path = experiment_config.get("model_config", "")
-        agent_type = "claude" if "claude" in model_config_path else "gemini-cli"
+        agent_type = "gemini-cli"
+        if model_config_path:
+            try:
+                with open(model_config_path, "r") as f:
+                    model_config = yaml.safe_load(f)
+                    if model_config.get("generator") == "claude_code":
+                        agent_type = "claude"
+            except Exception as e:
+                logging.warning(f"Failed to load model config from {model_config_path}: {e}")
+        
         comparators.append(
             trajectorymatcher.TrajectoryMatcher(scorers["trajectory_matcher"], agent_type=agent_type)
         )

--- a/evalbench/scorers/score.py
+++ b/evalbench/scorers/score.py
@@ -59,7 +59,7 @@ def compare(
         )
     if "trajectory_matcher" in scorers:
         model_config_path = experiment_config.get("model_config", "")
-        generator = "gemini-cli"
+        generator = None
         if model_config_path:
             try:
                 with open(model_config_path, "r") as f:

--- a/evalbench/scorers/score.py
+++ b/evalbench/scorers/score.py
@@ -18,7 +18,6 @@ from scorers import toolcalllatency
 from scorers import tokenconsumption
 from dataset.evaloutput import EvalOutput
 import logging
-import yaml
 
 
 def compare(
@@ -58,19 +57,8 @@ def compare(
             executablesql.ExecutableGenerationScore(scorers["executable_sql"])
         )
     if "trajectory_matcher" in scorers:
-        model_config_path = experiment_config.get("model_config", "")
-        generator = None
-        if model_config_path:
-            try:
-                with open(model_config_path, "r") as f:
-                    model_config = yaml.safe_load(f)
-                    if model_config.get("generator") == "claude_code":
-                        generator = "claude_code"
-            except Exception as e:
-                logging.warning(f"Failed to load model config from {model_config_path}: {e}")
-
         comparators.append(
-            trajectorymatcher.TrajectoryMatcher(scorers["trajectory_matcher"], generator=generator)
+            trajectorymatcher.TrajectoryMatcher(scorers["trajectory_matcher"])
         )
     if "goal_completion" in scorers:
         comparators.append(

--- a/evalbench/scorers/score.py
+++ b/evalbench/scorers/score.py
@@ -59,18 +59,18 @@ def compare(
         )
     if "trajectory_matcher" in scorers:
         model_config_path = experiment_config.get("model_config", "")
-        agent_type = "gemini-cli"
+        generator = "gemini-cli"
         if model_config_path:
             try:
                 with open(model_config_path, "r") as f:
                     model_config = yaml.safe_load(f)
                     if model_config.get("generator") == "claude_code":
-                        agent_type = "claude"
+                        generator = "claude_code"
             except Exception as e:
                 logging.warning(f"Failed to load model config from {model_config_path}: {e}")
         
         comparators.append(
-            trajectorymatcher.TrajectoryMatcher(scorers["trajectory_matcher"], agent_type=agent_type)
+            trajectorymatcher.TrajectoryMatcher(scorers["trajectory_matcher"], generator=generator)
         )
     if "goal_completion" in scorers:
         comparators.append(

--- a/evalbench/scorers/score.py
+++ b/evalbench/scorers/score.py
@@ -57,8 +57,10 @@ def compare(
             executablesql.ExecutableGenerationScore(scorers["executable_sql"])
         )
     if "trajectory_matcher" in scorers:
+        model_config_path = experiment_config.get("model_config", "")
+        agent_type = "claude" if "claude" in model_config_path else "gemini-cli"
         comparators.append(
-            trajectorymatcher.TrajectoryMatcher(scorers["trajectory_matcher"])
+            trajectorymatcher.TrajectoryMatcher(scorers["trajectory_matcher"], agent_type=agent_type)
         )
     if "goal_completion" in scorers:
         comparators.append(

--- a/evalbench/scorers/score.py
+++ b/evalbench/scorers/score.py
@@ -68,7 +68,7 @@ def compare(
                         generator = "claude_code"
             except Exception as e:
                 logging.warning(f"Failed to load model config from {model_config_path}: {e}")
-        
+
         comparators.append(
             trajectorymatcher.TrajectoryMatcher(scorers["trajectory_matcher"], generator=generator)
         )

--- a/evalbench/scorers/trajectorymatcher.py
+++ b/evalbench/scorers/trajectorymatcher.py
@@ -16,11 +16,11 @@ class TrajectoryMatcher(comparator.Comparator):
     Jaccard Similarity for flexible ordering or Levenshtein distance for strict order enforcement.
     """
 
-    def __init__(self, config: dict, agent_type: str = None):
+    def __init__(self, config: dict, generator: str = None):
         self.name = "trajectory_matcher"
         self.config = config
         self.enforce_order = config.get("enforce_order", False)
-        self.agent_type = agent_type or config.get("agent_type", "")
+        self.generator = generator or config.get("generator", "")
 
     def _levenshtein_distance(self, seq1: List[str], seq2: List[str]) -> int:
         n, m = len(seq1), len(seq2)
@@ -59,7 +59,7 @@ class TrajectoryMatcher(comparator.Comparator):
         
         normalized = []
         for tool in trajectory:
-            if self.agent_type == "claude":
+            if self.generator == "claude_code":
                 if tool == "ToolSearch":
                     continue
                 if tool.startswith("mcp__"):

--- a/evalbench/scorers/trajectorymatcher.py
+++ b/evalbench/scorers/trajectorymatcher.py
@@ -56,7 +56,7 @@ class TrajectoryMatcher(comparator.Comparator):
     def _normalize_trajectory(self, trajectory: List[str]) -> List[str]:
         if not trajectory:
             return []
-        
+
         normalized = []
         for tool in trajectory:
             if self.generator == "claude_code":

--- a/evalbench/scorers/trajectorymatcher.py
+++ b/evalbench/scorers/trajectorymatcher.py
@@ -16,10 +16,11 @@ class TrajectoryMatcher(comparator.Comparator):
     Jaccard Similarity for flexible ordering or Levenshtein distance for strict order enforcement.
     """
 
-    def __init__(self, config: dict):
+    def __init__(self, config: dict, agent_type: str = None):
         self.name = "trajectory_matcher"
         self.config = config
         self.enforce_order = config.get("enforce_order", False)
+        self.agent_type = agent_type or config.get("agent_type", "")
 
     def _levenshtein_distance(self, seq1: List[str], seq2: List[str]) -> int:
         n, m = len(seq1), len(seq2)
@@ -52,6 +53,30 @@ class TrajectoryMatcher(comparator.Comparator):
             return 1.0  # Both are empty
         return intersection / union
 
+    def _normalize_trajectory(self, trajectory: List[str]) -> List[str]:
+        if not trajectory:
+            return []
+        
+        normalized = []
+        for tool in trajectory:
+            if self.agent_type == "claude":
+                if tool == "ToolSearch":
+                    continue
+                if tool.startswith("mcp__"):
+                    # Drop the prefix "mcp__<mcp_server>__"
+                    # Assuming the format is mcp__server_name__tool_name
+                    parts = tool.split("__", 2)
+                    if len(parts) == 3:
+                        normalized.append(parts[2])
+                    else:
+                        # If it doesn't match expected parts, just strip the prefix
+                        normalized.append(tool.replace("mcp__", "", 1))
+                else:
+                    normalized.append(tool)
+            else:
+                normalized.append(tool)
+        return normalized
+
     def compare(
         self,
         nl_prompt: str,
@@ -80,6 +105,9 @@ class TrajectoryMatcher(comparator.Comparator):
 
         expected = golden_execution_result or []
         actual = generated_execution_result or []
+
+        expected = self._normalize_trajectory(expected)
+        actual = self._normalize_trajectory(actual)
 
         if not isinstance(expected, list) or not isinstance(actual, list):
             return 0.0, "Trajectory data must be lists."

--- a/evalbench/scorers/trajectorymatcher.py
+++ b/evalbench/scorers/trajectorymatcher.py
@@ -16,11 +16,11 @@ class TrajectoryMatcher(comparator.Comparator):
     Jaccard Similarity for flexible ordering or Levenshtein distance for strict order enforcement.
     """
 
-    def __init__(self, config: dict, generator: str = None):
+    def __init__(self, config: dict):
         self.name = "trajectory_matcher"
         self.config = config
         self.enforce_order = config.get("enforce_order", False)
-        self.generator = generator or config.get("generator", "")
+        self.generator = config.get("generator", "")
 
     def _levenshtein_distance(self, seq1: List[str], seq2: List[str]) -> int:
         n, m = len(seq1), len(seq2)

--- a/evalbench/test/trajectory_matcher_test.py
+++ b/evalbench/test/trajectory_matcher_test.py
@@ -1,0 +1,82 @@
+import unittest
+import sys
+import os
+
+# Add the parent directory to sys.path to find scorers
+sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from scorers.trajectorymatcher import TrajectoryMatcher
+
+class TestTrajectoryMatcher(unittest.TestCase):
+
+    def test_default_behavior_no_normalization(self):
+        config = {"agent_type": "gemini-cli"}
+        matcher = TrajectoryMatcher(config)
+        
+        expected = ["ToolA", "ToolB", "ToolSearch"]
+        actual = ["ToolA", "ToolB", "ToolSearch"]
+        
+        score, explanation = matcher.compare(None, None, None, expected, None, None, None, actual, None, None)
+        self.assertEqual(score, 100.0)
+        self.assertIn("Jaccard Similarity Score: 100.00", explanation)
+
+    def test_claude_behavior_remove_toolsearch(self):
+        config = {"agent_type": "claude"}
+        matcher = TrajectoryMatcher(config)
+        
+        expected = ["ToolA", "ToolSearch", "ToolB"]
+        actual = ["ToolA", "ToolB"]
+        
+        # After normalization, expected should become ["ToolA", "ToolB"]
+        # So it should match actual exactly.
+        score, explanation = matcher.compare(None, None, None, expected, None, None, None, actual, None, None)
+        self.assertEqual(score, 100.0)
+
+    def test_claude_behavior_strip_mcp_prefix(self):
+        config = {"agent_type": "claude"}
+        matcher = TrajectoryMatcher(config)
+        
+        expected = ["mcp__server__toolA", "ToolB"]
+        actual = ["toolA", "ToolB"]
+        
+        # After normalization, expected should become ["toolA", "ToolB"]
+        score, explanation = matcher.compare(None, None, None, expected, None, None, None, actual, None, None)
+        self.assertEqual(score, 100.0)
+
+    def test_claude_behavior_combined(self):
+        config = {"agent_type": "claude"}
+        matcher = TrajectoryMatcher(config)
+        
+        expected = ["mcp__server__toolA", "ToolSearch", "ToolB"]
+        actual = ["toolA", "ToolB"]
+        
+        score, explanation = matcher.compare(None, None, None, expected, None, None, None, actual, None, None)
+        self.assertEqual(score, 100.0)
+
+    def test_flexible_ordering(self):
+        config = {"agent_type": "claude"}
+        matcher = TrajectoryMatcher(config)
+        
+        expected = ["mcp__server__toolA", "ToolB"]
+        actual = ["ToolB", "toolA"]
+        
+        # Jaccard similarity should ignore order
+        score, explanation = matcher.compare(None, None, None, expected, None, None, None, actual, None, None)
+        self.assertEqual(score, 100.0)
+
+    def test_strict_ordering(self):
+        config = {"agent_type": "claude", "enforce_order": True}
+        matcher = TrajectoryMatcher(config)
+        
+        expected = ["mcp__server__toolA", "ToolB"]
+        actual = ["ToolB", "toolA"]
+        
+        # Levenshtein distance will consider order.
+        # expected normalized: ["toolA", "ToolB"]
+        # actual normalized: ["ToolB", "toolA"]
+        # They are different.
+        score, explanation = matcher.compare(None, None, None, expected, None, None, None, actual, None, None)
+        self.assertLess(score, 100.0)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/evalbench/test/trajectory_matcher_test.py
+++ b/evalbench/test/trajectory_matcher_test.py
@@ -11,7 +11,7 @@ from scorers.trajectorymatcher import TrajectoryMatcher
 class TestTrajectoryMatcher(unittest.TestCase):
 
     def test_default_behavior_no_normalization(self):
-        config = {"generator": "gemini-cli"}
+        config = {}
         matcher = TrajectoryMatcher(config)
         
         expected = ["ToolA", "ToolB", "ToolSearch"]

--- a/evalbench/test/trajectory_matcher_test.py
+++ b/evalbench/test/trajectory_matcher_test.py
@@ -8,15 +8,16 @@ sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 from scorers.trajectorymatcher import TrajectoryMatcher
 
+
 class TestTrajectoryMatcher(unittest.TestCase):
 
     def test_default_behavior_no_normalization(self):
         config = {}
         matcher = TrajectoryMatcher(config)
-        
+
         expected = ["ToolA", "ToolB", "ToolSearch"]
         actual = ["ToolA", "ToolB", "ToolSearch"]
-        
+
         score, explanation = matcher.compare(None, None, None, expected, None, None, None, actual, None, None)
         self.assertEqual(score, 100.0)
         self.assertIn("Jaccard Similarity Score: 100.00", explanation)
@@ -24,10 +25,10 @@ class TestTrajectoryMatcher(unittest.TestCase):
     def test_claude_behavior_remove_toolsearch(self):
         config = {"generator": "claude_code"}
         matcher = TrajectoryMatcher(config)
-        
+
         expected = ["ToolA", "ToolSearch", "ToolB"]
         actual = ["ToolA", "ToolB"]
-        
+
         # After normalization, expected should become ["ToolA", "ToolB"]
         # So it should match actual exactly.
         score, explanation = matcher.compare(None, None, None, expected, None, None, None, actual, None, None)
@@ -36,10 +37,10 @@ class TestTrajectoryMatcher(unittest.TestCase):
     def test_claude_behavior_strip_mcp_prefix(self):
         config = {"generator": "claude_code"}
         matcher = TrajectoryMatcher(config)
-        
+
         expected = ["mcp__server__toolA", "ToolB"]
         actual = ["toolA", "ToolB"]
-        
+
         # After normalization, expected should become ["toolA", "ToolB"]
         score, explanation = matcher.compare(None, None, None, expected, None, None, None, actual, None, None)
         self.assertEqual(score, 100.0)
@@ -47,20 +48,20 @@ class TestTrajectoryMatcher(unittest.TestCase):
     def test_claude_behavior_combined(self):
         config = {"generator": "claude_code"}
         matcher = TrajectoryMatcher(config)
-        
+
         expected = ["mcp__server__toolA", "ToolSearch", "ToolB"]
         actual = ["toolA", "ToolB"]
-        
+
         score, explanation = matcher.compare(None, None, None, expected, None, None, None, actual, None, None)
         self.assertEqual(score, 100.0)
 
     def test_flexible_ordering(self):
         config = {"generator": "claude_code"}
         matcher = TrajectoryMatcher(config)
-        
+
         expected = ["mcp__server__toolA", "ToolB"]
         actual = ["ToolB", "toolA"]
-        
+
         # Jaccard similarity should ignore order
         score, explanation = matcher.compare(None, None, None, expected, None, None, None, actual, None, None)
         self.assertEqual(score, 100.0)
@@ -68,10 +69,10 @@ class TestTrajectoryMatcher(unittest.TestCase):
     def test_strict_ordering(self):
         config = {"generator": "claude_code", "enforce_order": True}
         matcher = TrajectoryMatcher(config)
-        
+
         expected = ["mcp__server__toolA", "ToolB"]
         actual = ["ToolB", "toolA"]
-        
+
         # Levenshtein distance will consider order.
         # expected normalized: ["toolA", "ToolB"]
         # actual normalized: ["ToolB", "toolA"]
@@ -79,54 +80,56 @@ class TestTrajectoryMatcher(unittest.TestCase):
         score, explanation = matcher.compare(None, None, None, expected, None, None, None, actual, None, None)
         self.assertLess(score, 100.0)
 
+
 class TestScoreTrajectoryMatcherIntegration(unittest.TestCase):
 
     @patch("builtins.open", new_callable=mock_open, read_data="generator: claude_code")
     @patch("yaml.safe_load")
     def test_score_detects_claude_from_config(self, mock_yaml_load, mock_file):
         mock_yaml_load.return_value = {"generator": "claude_code"}
-        
+
         from scorers import score
         from dataset.evaloutput import EvalOutput
-        
+
         class DummyEvalInput:
             def __init__(self, data):
                 self.__dict__.update(data)
-        
+
         dummy_input = DummyEvalInput({
-            "id": 1, 
-            "generated_sql": "SELECT 1", 
-            "golden_sql": "SELECT 1", 
-            "query_type": "dql", 
-            "golden_result": [], 
-            "golden_error": "", 
-            "generated_result": [], 
-            "generated_error": "", 
-            "dialects": [], 
-            "database": "", 
-            "job_id": "", 
-            "eval_results": "", 
+            "id": 1,
+            "generated_sql": "SELECT 1",
+            "golden_sql": "SELECT 1",
+            "query_type": "dql",
+            "golden_result": [],
+            "golden_error": "",
+            "generated_result": [],
+            "generated_error": "",
+            "dialects": [],
+            "database": "",
+            "job_id": "",
+            "eval_results": "",
             "golden_eval_results": ""
         })
         eval_output = EvalOutput(dummy_input)
-        
+
         experiment_config = {
             "model_config": "dummy_path.yaml",
             "scorers": {
                 "trajectory_matcher": {}
             }
         }
-        
+
         scoring_results = []
-        
+
         # We need to patch TrajectoryMatcher to check if it was called with generator="claude_code"
         with patch("scorers.trajectorymatcher.TrajectoryMatcher") as MockMatcher:
             score.compare(eval_output, experiment_config, scoring_results, None)
-            
+    
             # Check if TrajectoryMatcher was called with generator="claude_code"
             MockMatcher.assert_called_once()
             kwargs = MockMatcher.call_args.kwargs
             self.assertEqual(kwargs.get("generator"), "claude_code")
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/evalbench/test/trajectory_matcher_test.py
+++ b/evalbench/test/trajectory_matcher_test.py
@@ -11,7 +11,7 @@ from scorers.trajectorymatcher import TrajectoryMatcher
 class TestTrajectoryMatcher(unittest.TestCase):
 
     def test_default_behavior_no_normalization(self):
-        config = {"agent_type": "gemini-cli"}
+        config = {"generator": "gemini-cli"}
         matcher = TrajectoryMatcher(config)
         
         expected = ["ToolA", "ToolB", "ToolSearch"]
@@ -22,7 +22,7 @@ class TestTrajectoryMatcher(unittest.TestCase):
         self.assertIn("Jaccard Similarity Score: 100.00", explanation)
 
     def test_claude_behavior_remove_toolsearch(self):
-        config = {"agent_type": "claude"}
+        config = {"generator": "claude_code"}
         matcher = TrajectoryMatcher(config)
         
         expected = ["ToolA", "ToolSearch", "ToolB"]
@@ -34,7 +34,7 @@ class TestTrajectoryMatcher(unittest.TestCase):
         self.assertEqual(score, 100.0)
 
     def test_claude_behavior_strip_mcp_prefix(self):
-        config = {"agent_type": "claude"}
+        config = {"generator": "claude_code"}
         matcher = TrajectoryMatcher(config)
         
         expected = ["mcp__server__toolA", "ToolB"]
@@ -45,7 +45,7 @@ class TestTrajectoryMatcher(unittest.TestCase):
         self.assertEqual(score, 100.0)
 
     def test_claude_behavior_combined(self):
-        config = {"agent_type": "claude"}
+        config = {"generator": "claude_code"}
         matcher = TrajectoryMatcher(config)
         
         expected = ["mcp__server__toolA", "ToolSearch", "ToolB"]
@@ -55,7 +55,7 @@ class TestTrajectoryMatcher(unittest.TestCase):
         self.assertEqual(score, 100.0)
 
     def test_flexible_ordering(self):
-        config = {"agent_type": "claude"}
+        config = {"generator": "claude_code"}
         matcher = TrajectoryMatcher(config)
         
         expected = ["mcp__server__toolA", "ToolB"]
@@ -66,7 +66,7 @@ class TestTrajectoryMatcher(unittest.TestCase):
         self.assertEqual(score, 100.0)
 
     def test_strict_ordering(self):
-        config = {"agent_type": "claude", "enforce_order": True}
+        config = {"generator": "claude_code", "enforce_order": True}
         matcher = TrajectoryMatcher(config)
         
         expected = ["mcp__server__toolA", "ToolB"]
@@ -119,14 +119,14 @@ class TestScoreTrajectoryMatcherIntegration(unittest.TestCase):
         
         scoring_results = []
         
-        # We need to patch TrajectoryMatcher to check if it was called with agent_type="claude"
+        # We need to patch TrajectoryMatcher to check if it was called with generator="claude_code"
         with patch("scorers.trajectorymatcher.TrajectoryMatcher") as MockMatcher:
             score.compare(eval_output, experiment_config, scoring_results, None)
             
-            # Check if TrajectoryMatcher was called with agent_type="claude"
+            # Check if TrajectoryMatcher was called with generator="claude_code"
             MockMatcher.assert_called_once()
             kwargs = MockMatcher.call_args.kwargs
-            self.assertEqual(kwargs.get("agent_type"), "claude")
+            self.assertEqual(kwargs.get("generator"), "claude_code")
 
 if __name__ == '__main__':
     unittest.main()

--- a/evalbench/test/trajectory_matcher_test.py
+++ b/evalbench/test/trajectory_matcher_test.py
@@ -124,7 +124,6 @@ class TestScoreTrajectoryMatcherIntegration(unittest.TestCase):
         # We need to patch TrajectoryMatcher to check if it was called with generator="claude_code"
         with patch("scorers.trajectorymatcher.TrajectoryMatcher") as MockMatcher:
             score.compare(eval_output, experiment_config, scoring_results, None)
-    
             # Check if TrajectoryMatcher was called with generator="claude_code"
             MockMatcher.assert_called_once()
             kwargs = MockMatcher.call_args.kwargs

--- a/evalbench/test/trajectory_matcher_test.py
+++ b/evalbench/test/trajectory_matcher_test.py
@@ -81,8 +81,5 @@ class TestTrajectoryMatcher(unittest.TestCase):
         self.assertLess(score, 100.0)
 
 
-
-
-
 if __name__ == '__main__':
     unittest.main()

--- a/evalbench/test/trajectory_matcher_test.py
+++ b/evalbench/test/trajectory_matcher_test.py
@@ -81,53 +81,7 @@ class TestTrajectoryMatcher(unittest.TestCase):
         self.assertLess(score, 100.0)
 
 
-class TestScoreTrajectoryMatcherIntegration(unittest.TestCase):
 
-    @patch("builtins.open", new_callable=mock_open, read_data="generator: claude_code")
-    @patch("yaml.safe_load")
-    def test_score_detects_claude_from_config(self, mock_yaml_load, mock_file):
-        mock_yaml_load.return_value = {"generator": "claude_code"}
-
-        from scorers import score
-        from dataset.evaloutput import EvalOutput
-
-        class DummyEvalInput:
-            def __init__(self, data):
-                self.__dict__.update(data)
-
-        dummy_input = DummyEvalInput({
-            "id": 1,
-            "generated_sql": "SELECT 1",
-            "golden_sql": "SELECT 1",
-            "query_type": "dql",
-            "golden_result": [],
-            "golden_error": "",
-            "generated_result": [],
-            "generated_error": "",
-            "dialects": [],
-            "database": "",
-            "job_id": "",
-            "eval_results": "",
-            "golden_eval_results": ""
-        })
-        eval_output = EvalOutput(dummy_input)
-
-        experiment_config = {
-            "model_config": "dummy_path.yaml",
-            "scorers": {
-                "trajectory_matcher": {}
-            }
-        }
-
-        scoring_results = []
-
-        # We need to patch TrajectoryMatcher to check if it was called with generator="claude_code"
-        with patch("scorers.trajectorymatcher.TrajectoryMatcher") as MockMatcher:
-            score.compare(eval_output, experiment_config, scoring_results, None)
-            # Check if TrajectoryMatcher was called with generator="claude_code"
-            MockMatcher.assert_called_once()
-            kwargs = MockMatcher.call_args.kwargs
-            self.assertEqual(kwargs.get("generator"), "claude_code")
 
 
 if __name__ == '__main__':

--- a/evalbench/test/trajectory_matcher_test.py
+++ b/evalbench/test/trajectory_matcher_test.py
@@ -1,6 +1,7 @@
 import unittest
 import sys
 import os
+from unittest.mock import patch, mock_open
 
 # Add the parent directory to sys.path to find scorers
 sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
@@ -77,6 +78,55 @@ class TestTrajectoryMatcher(unittest.TestCase):
         # They are different.
         score, explanation = matcher.compare(None, None, None, expected, None, None, None, actual, None, None)
         self.assertLess(score, 100.0)
+
+class TestScoreTrajectoryMatcherIntegration(unittest.TestCase):
+
+    @patch("builtins.open", new_callable=mock_open, read_data="generator: claude_code")
+    @patch("yaml.safe_load")
+    def test_score_detects_claude_from_config(self, mock_yaml_load, mock_file):
+        mock_yaml_load.return_value = {"generator": "claude_code"}
+        
+        from scorers import score
+        from dataset.evaloutput import EvalOutput
+        
+        class DummyEvalInput:
+            def __init__(self, data):
+                self.__dict__.update(data)
+        
+        dummy_input = DummyEvalInput({
+            "id": 1, 
+            "generated_sql": "SELECT 1", 
+            "golden_sql": "SELECT 1", 
+            "query_type": "dql", 
+            "golden_result": [], 
+            "golden_error": "", 
+            "generated_result": [], 
+            "generated_error": "", 
+            "dialects": [], 
+            "database": "", 
+            "job_id": "", 
+            "eval_results": "", 
+            "golden_eval_results": ""
+        })
+        eval_output = EvalOutput(dummy_input)
+        
+        experiment_config = {
+            "model_config": "dummy_path.yaml",
+            "scorers": {
+                "trajectory_matcher": {}
+            }
+        }
+        
+        scoring_results = []
+        
+        # We need to patch TrajectoryMatcher to check if it was called with agent_type="claude"
+        with patch("scorers.trajectorymatcher.TrajectoryMatcher") as MockMatcher:
+            score.compare(eval_output, experiment_config, scoring_results, None)
+            
+            # Check if TrajectoryMatcher was called with agent_type="claude"
+            MockMatcher.assert_called_once()
+            kwargs = MockMatcher.call_args.kwargs
+            self.assertEqual(kwargs.get("agent_type"), "claude")
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Adds support for Claude-specific tool trajectory normalization in `TrajectoryMatcher` to handle differences in tool naming conventions.
## Key Changes
- **TrajectoryMatcher**: When `generator` is `"claude_code"`, it removes `"ToolSearch"` and strips `"mcp__<server>__"` prefixes from tool names.
- **Auto-detection**: Updated `score.py` to read the model configuration file and auto-detect the `generator: claude_code` setting.
