### PR TITLE
fix username and password issue for SA

### DIFF
--- a/evalbench/databases/mysql.py
+++ b/evalbench/databases/mysql.py
@@ -61,6 +61,8 @@ class MySQLDB(DB):
         self.use_adc = not self.username and not self.password
         if self.use_adc:
             self.username = get_adc_user_email()
+            if self.username and self.username.endswith(".gserviceaccount.com"):
+                self.username = self.username.replace(".gserviceaccount.com", "")
 
         def get_conn():
             """Callable for sqlalchemy 'creator' parameter."""

--- a/evalbench/databases/postgres.py
+++ b/evalbench/databases/postgres.py
@@ -55,11 +55,14 @@ class PGDB(DB):
             self.use_cloud_sql = (self.db_path.count(":") == 2)
 
         # Normalize password for drivers that dislike None
-        effective_password = self.password if self.password is not None else ""
+        if self.password is None:
+            self.password = ""
 
         self.use_adc = not self.username and not self.password
         if self.use_adc:
             self.username = get_adc_user_email()
+            if self.username and self.username.endswith(".gserviceaccount.com"):
+                self.username = self.username.replace(".gserviceaccount.com", "")
 
         def get_conn():
             # Only used for Cloud SQL Connector path
@@ -67,7 +70,7 @@ class PGDB(DB):
                 self.db_path,
                 "pg8000",
                 user=self.username,
-                password=effective_password,
+                password=self.password,
                 db=self.db_name,
                 enable_iam_auth=self.use_adc,
             )
@@ -87,16 +90,14 @@ class PGDB(DB):
             else:
                 # Standard local connection via URL
                 args["connect_args"]["timeout"] = 60
-                pass_str = effective_password if effective_password is not None else ""
-
                 # Check for local UNIX socket
                 socket_path = "/var/run/postgresql/.s.PGSQL.5432"
                 if self.db_path == "localhost" and os.path.exists(socket_path):
                     args["connect_args"]["unix_sock"] = socket_path
                     # Use a slash-only URL so SQLAlchemy doesn't force a TCP host
-                    url = f"postgresql+pg8000://{self.username}:{pass_str}@/{self.db_name}"
+                    url = f"postgresql+pg8000://{self.username}:{self.password}@/{self.db_name}"
                 else:
-                    url = f"postgresql+pg8000://{self.username}:{pass_str}@{self.db_path}/{self.db_name}"
+                    url = f"postgresql+pg8000://{self.username}:{self.password}@{self.db_path}/{self.db_name}"
 
             if "is_tmp_db" in db_config:
                 args["poolclass"] = NullPool


### PR DESCRIPTION
This PR addresses two issues encountered when running evaluations in Cloud Build using a Google Cloud Service Account for database connections authenticated with the SA ADC.

- Service Account Username Truncation: For IAM authentication in Cloud SQL and AlloyDB, Google Cloud requires service account usernames to omit the .gserviceaccount.com suffix.
- Driver exception on None Password: pg8000 driver raises exception with 'NoneType' object has no attribute 'decode' during the SASL authentication handshake if the password property is None. This PR applies the normalization in PGDB to parent classes.