### PR TITLE
fix: allow-list files in fake home directory for Gemini CLI

### DIFF
--- a/evalbench/generators/models/gemini_cli.py
+++ b/evalbench/generators/models/gemini_cli.py
@@ -51,18 +51,21 @@ class GeminiCliGenerator(QueryGenerator):
         # after resuming the session.
         gemini_settings_path = os.path.join(self.gemini_home, "settings.json")
         os.makedirs(os.path.dirname(gemini_settings_path), exist_ok=True)
-        
+
         current_settings = {}
         if os.path.exists(gemini_settings_path):
             try:
                 with open(gemini_settings_path, "r") as f:
                     current_settings = json.load(f)
             except json.JSONDecodeError:
-                pass
-                
+                logging.warning(
+                    "Invalid JSON in Gemini settings at %s; using default settings.",
+                    gemini_settings_path,
+                )
+
         context_config = current_settings.setdefault("context", {})
         include_dirs = context_config.setdefault("includeDirectories", [])
-        
+
         if self.fake_home not in include_dirs:
             include_dirs.append(self.fake_home)
 

--- a/evalbench/generators/models/gemini_cli.py
+++ b/evalbench/generators/models/gemini_cli.py
@@ -46,6 +46,29 @@ class GeminiCliGenerator(QueryGenerator):
         os.makedirs(self.extensions_dir, exist_ok=True)
         os.makedirs(self.skills_dir, exist_ok=True)
 
+        # Allow-list the fake home directory to enable access to files under it.
+        # This is needed to ensure Gemini CLI can read files within a skill
+        # after resuming the session.
+        gemini_settings_path = os.path.join(self.gemini_home, "settings.json")
+        os.makedirs(os.path.dirname(gemini_settings_path), exist_ok=True)
+        
+        current_settings = {}
+        if os.path.exists(gemini_settings_path):
+            try:
+                with open(gemini_settings_path, "r") as f:
+                    current_settings = json.load(f)
+            except json.JSONDecodeError:
+                pass
+                
+        context_config = current_settings.setdefault("context", {})
+        include_dirs = context_config.setdefault("includeDirectories", [])
+        
+        if self.fake_home not in include_dirs:
+            include_dirs.append(self.fake_home)
+
+        with open(gemini_settings_path, "w") as f:
+            json.dump(current_settings, f, indent=2)
+
         self.env = querygenerator_config.get("env", {})
         self.env["HOME"] = self.fake_home
 


### PR DESCRIPTION
This change modifies `gemini_cli.py` to automatically add the fake_home directory to the includeDirectories list in settings.json under the context section. This allow-lists the fake home directory to be access by built-in tools such as read_file, ensuring that the Gemini CLI can still access files within it (such as those in skills) when resuming a session.