### PR TITLE
fix: surface eval failures instead of silently terminating or crashing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -176,6 +176,7 @@ results/*
 evalbench/results/*
 db_connections/bat/db_blog.db
 datasets/bird-interact/livesqlbench-base-lite-dumps
+datasets/bird-interact/bird-interact-lite/
 datasets/bird/datasets/bird/prompts.json
 datasets/bird/db_connections/bird/california_schools.sqlite
 datasets/bird/db_connections/bird/card_games.sqlite

--- a/evalbench/eval_service.py
+++ b/evalbench/eval_service.py
@@ -44,6 +44,11 @@ from util import get_SessionManager
 SESSIONMANAGER = get_SessionManager()
 
 
+class EmptyEvalResultError(Exception):
+    """Raised when an Eval run produces no result rows — a client/config issue,
+    not a server fault. Translated to gRPC FAILED_PRECONDITION."""
+
+
 class SessionManagerInterceptor(grpc.aio.ServerInterceptor):
     def __init__(self, tag: str, rpc_id: Optional[str] = None) -> None:
         self.tag = tag
@@ -236,6 +241,12 @@ class EvalServicer(eval_service_pb2_grpc.EvalServiceServicer):
                         f"Eval: Cannot run tear_down_script, file not found at '{tear_down_script}'")
 
             return eval_response_pb2.EvalResponse(response=response, session_id=session_id)
+
+        except EmptyEvalResultError as e:
+            logging.warning(f"Eval produced no results: {e}")
+            context.set_code(grpc.StatusCode.FAILED_PRECONDITION)
+            context.set_details(str(e))
+            return eval_response_pb2.EvalResponse(session_id=session_id)
 
         except Exception as e:
             display_config = "Unknown"
@@ -451,7 +462,11 @@ def _process_results(
     )
     results = load_json(results_tf)
     results_df = report.get_dataframe(results)
-    assert not results_df.empty, "There were no matching evals in this run."
+    if results_df.empty:
+        raise EmptyEvalResultError(
+            "No matching evals were produced for this run. Check that the dataset, "
+            "dialect filters, and database configuration line up."
+        )
     report.quick_summary(results_df)
     scores = load_json(scores_tf)
     if multi_trial_scores_tf:

--- a/evalbench/evaluator/evaluator.py
+++ b/evalbench/evaluator/evaluator.py
@@ -180,12 +180,12 @@ class Evaluator:
                 self.sqlrunner.execute_work(work)
                 exec_future_to_eval[self.sqlrunner.futures[-1]] = eval_output
             except Exception as e:
-
+                exc_msg = str(e) or type(e).__name__
                 logging.error(
                     "Failed to acquire DB connection from queue for database"
-                    f" '{eval_output.get('database')}': {e}"
+                    f" '{eval_output.get('database')}': {exc_msg}"
                 )
-                eval_output["generated_error"] = f"Failed to acquire DB connection: {e}"
+                eval_output["generated_error"] = f"Failed to acquire DB connection: {exc_msg}"
                 record_successful_sql_exec(progress_reporting)
                 work = scorework.ScorerWork(
                     self.config, eval_output, scoring_results, global_models

--- a/evalbench/evaluator/simulateduser.py
+++ b/evalbench/evaluator/simulateduser.py
@@ -1,7 +1,6 @@
 import generators.models as models
 import generators.prompts as prompts
 import threading
-import logging
 
 
 class SimulatedUser:
@@ -13,8 +12,11 @@ class SimulatedUser:
             "registered_models": {}
         }
 
-        # Expect 'simulated_user_model_config' path in config
         model_config_path = config.get("simulated_user_model_config")
+        if not model_config_path:
+            raise ValueError(
+                "SimulatedUser requires 'simulated_user_model_config' in the run config; "
+                "without it every scenario terminates on turn 1.")
 
         self.prompt_generator = prompts.get_generator(
             None,
@@ -22,24 +24,16 @@ class SimulatedUser:
             "SimulatedUserPromptGenerator"
         )
 
-        self.model_generator = None
-        if model_config_path:
-            try:
-                self.model_generator = models.get_generator(
-                    global_models, model_config_path, None
-                )
-            except Exception as e:
-                logging.warning(
-                    f"Failed to load simulated user model from {model_config_path}: {e}")
-        else:
-            logging.warning(
-                "No 'simulated_user_model_config' provided. SimulatedUser will not be able to generate responses.")
+        try:
+            self.model_generator = models.get_generator(
+                global_models, model_config_path, None
+            )
+        except Exception as e:
+            raise RuntimeError(
+                f"Failed to load simulated user model from {model_config_path}: {e}"
+            ) from e
 
     def get_next_response(self, conversation_plan: str, history: list, last_agent_reply: str) -> str:
-        if not self.model_generator:
-            logging.error("Model generator not initialized.")
-            return "TERMINATE"
-
         payload = {
             "conversation_plan": conversation_plan,
             "history": history,


### PR DESCRIPTION
## Summary

Three issues surfaced in the last 24h of prod logs on `evalbench-directpath-cluster`:

- **`SimulatedUser` silently terminated every multi-turn scenario** (~115 occurrences) when `simulated_user_model_config` was missing or failed to load. The constructor warned but left `self.model_generator = None`; `get_next_response` then returned `"TERMINATE"` on every call, so scenarios appeared to "complete" on turn 1 with no visible cause. Now `__init__` raises so the misconfiguration surfaces at scenario start.

- **`_process_results` used a bare `assert`** (~13 occurrences) when no eval rows were produced. The `AssertionError` bubbled out of the `Eval` RPC as an unstructured `INTERNAL` and a client was retrying at ~10s cadence on what is actually a config-level problem. Replaced with a typed `EmptyEvalResultError` caught in the RPC handler and translated to `FAILED_PRECONDITION`, with a message pointing at dataset/dialect/database mismatch.

- **DB-queue acquire failures logged the bare exception** (~4 occurrences), which is empty for `queue.Empty` timeouts — the operator saw `... 'foo': ` with nothing after the colon. Falls back to `type(e).__name__` when `str(e)` is empty.

## Test plan

- [x] Run an existing multi-turn eval with `simulated_user_model_config` set — should behave as before
- [x] Run a multi-turn eval with `simulated_user_model_config` omitted — should raise at scenario start with a clear message instead of silently terminating
- [x] Trigger the empty-results path (e.g. dialect filter that matches nothing) — RPC should return `FAILED_PRECONDITION` with the new message instead of `INTERNAL`
- [x] Force a DB connection acquire timeout — log line should read `... 'db': Empty` rather than `... 'db': `