### PR TITLE
feat: opt-in function-calling for the Gemini SDK judge

### DIFF
--- a/docs/judge_tools.md
+++ b/docs/judge_tools.md
@@ -1,0 +1,179 @@
+# Judge Tools (Function Calling)
+
+LLM-judged scorers (`BinaryRubricScorer`, `LlmRater`, `GoalCompletionRate`,
+`BehavioralMetrics`, `ParameterAnalysis`, `SkillsBestPractices`) call
+`judge.generate(prompt)` and parse the text back. By default the judge is
+single-shot: it sees the prompt and produces an answer with no access to
+external state.
+
+Tool support lets a judge **invoke registered tools mid-generation** so it can
+ground its answer in something the prompt alone can't tell it — for example,
+fetching `https://beam.apache.org/get-started/downloads/` to check that an
+agent named the most-recent Apache Beam version.
+
+> **Status:** Gemini (`gcp_vertex_gemini`) only. Claude SDK judge support is
+> tracked as a follow-up.
+
+## Activation
+
+Tools are **opt-in per judge** via a `tools:` list in the model config YAML.
+Configs without the key keep the original single-shot codepath.
+
+```yaml
+generator: gcp_vertex_gemini
+vertex_model: gemini-2.5-pro
+base_prompt: ""
+execs_per_minute: 5
+tools:
+  - fetch_url
+```
+
+Unknown tool names fail fast at `GeminiGenerator.__init__` with a `ValueError`
+that lists the available tools.
+
+## Available tools
+
+| Name | Purpose | Constraints |
+|---|---|---|
+| `fetch_url` | Fetch an HTTPS URL and return its body as text. HTML is stripped to plain text. | HTTPS only; SSRF guard against private/loopback/link-local/multicast/reserved IPs; 10s timeout; 50 KB body cap. |
+
+`fetch_url` returns `"Error: ..."` strings on any failure (bad scheme, blocked
+host, HTTP error, timeout) so the model can observe the failure and react
+rather than crash the judge.
+
+## End-to-end example
+
+**`datasets/model_configs/gemini_2.5_pro_with_tools_model.yaml`** (new)
+
+```yaml
+generator: gcp_vertex_gemini
+vertex_model: gemini-2.5-pro
+base_prompt: ""
+execs_per_minute: 5
+tools:
+  - fetch_url
+```
+
+**`datasets/your-eval/example_run_config.yaml`**
+
+```yaml
+dataset_config: datasets/your-eval/scenarios.evalset.json
+dataset_format: agent-format
+orchestrator: agent
+model_config: datasets/model_configs/gemini_cli_model.yaml
+simulated_user_model_config: datasets/model_configs/gemini_2.5_pro_model.yaml
+
+scorers:
+  binary_rubric_scorer:
+    model_config: datasets/model_configs/gemini_2.5_pro_with_tools_model.yaml
+  goal_completion:
+    model_config: datasets/model_configs/gemini_2.5_pro_model.yaml   # no tools
+  trajectory_matcher: {}
+  turn_count: {}
+
+reporting:
+  csv:
+    output_directory: 'results'
+```
+
+**`datasets/your-eval/scenarios.evalset.json`** (rubric lives on the scenario)
+
+```json
+{
+  "scenarios": [
+    {
+      "id": "beam-version-check",
+      "starting_prompt": "What is the most recent version of Apache Beam?",
+      "conversation_plan": "User wants the agent to look up the current Beam release.",
+      "binary_rubric": [
+        "Did the agent's final answer state the most-recent Apache Beam version listed on https://beam.apache.org/get-started/downloads/?"
+      ],
+      "max_turns": 2
+    }
+  ]
+}
+```
+
+## How it threads through
+
+1. The run config's `scorers.binary_rubric_scorer.model_config` is loaded via
+   `get_generator(...)` inside `BinaryRubricScorer.__init__`
+   (`evalbench/scorers/binaryrubricscorer.py`).
+2. That YAML has `generator: gcp_vertex_gemini` plus `tools: [fetch_url]`, so
+   `GeminiGenerator` resolves the names through
+   `evalbench/generators/models/tools/__init__.py::get_tools(...)` and builds
+   the native `types.Tool` config once at construction.
+3. When the scorer calls `self.model.generate(prompt)`, the judge enters the
+   tool-calling loop. If the model emits a `function_call`, the registered
+   tool runs, its result is appended as a `FunctionResponse`, and the loop
+   continues until the model returns a final text answer.
+4. The loop is bounded at `MAX_TOOL_ITERATIONS = 5`
+   (`evalbench/generators/models/gemini.py`). On exhaust the judge returns
+   the last text and logs a warning.
+
+Per-scorer judges are independent, so you can give `fetch_url` only to the
+rubric judge and leave latency-sensitive judges (`behavioral_metrics`,
+`parameter_analysis`) on plain single-shot configs.
+
+## Security notes
+
+- **HTTPS-only.** Other schemes (`http`, `file`, ...) are rejected before any
+  network call.
+- **SSRF guard.** `fetch_url` resolves the hostname and rejects responses
+  pointing at private / loopback / link-local / multicast / reserved address
+  ranges (Python's `ipaddress` classification).
+- **Known follow-ups:**
+  - **Redirect SSRF.** `urlopen` follows 3xx without re-validating each hop.
+    A malicious site can return a 302 to a private IP and bypass the upfront
+    check. Fix is a custom `HTTPRedirectHandler` that re-runs the host check
+    on every hop, or disabling redirects entirely.
+  - **DNS TOCTOU.** `_is_blocked_host` resolves the name once; `urlopen`
+    resolves it again. DNS rebinding can flip between the two. Hardening
+    requires socket-level interception.
+
+## Adding a new tool
+
+1. Create `evalbench/generators/models/tools/<my_tool>.py` exporting a
+   `Tool` instance:
+
+   ```python
+   from .base import Tool
+
+   def _impl(args: dict) -> str:
+       return f"got args: {args}"
+
+   MY_TOOL = Tool(
+       name="my_tool",
+       description="One-sentence summary the model will read.",
+       input_schema={
+           "type": "object",
+           "properties": {"x": {"type": "string"}},
+           "required": ["x"],
+       },
+       fn=_impl,
+   )
+   ```
+
+2. Register it in `evalbench/generators/models/tools/__init__.py`:
+
+   ```python
+   from .my_tool import MY_TOOL
+
+   TOOL_REGISTRY = {
+       FETCH_URL_TOOL.name: FETCH_URL_TOOL,
+       MY_TOOL.name: MY_TOOL,
+   }
+   ```
+
+3. Reference it in any judge model config:
+
+   ```yaml
+   tools:
+     - fetch_url
+     - my_tool
+   ```
+
+Tool implementations should return strings (errors as `"Error: ..."`), keep
+side effects bounded, and avoid raising — exceptions are caught and converted
+into `"Error: <ExcType>: <message>"` strings so the loop can continue, but a
+well-behaved tool produces actionable error text itself.

--- a/evalbench/generators/models/gemini.py
+++ b/evalbench/generators/models/gemini.py
@@ -168,3 +168,7 @@ class GeminiGenerator(QueryGenerator):
                     attempt + 1,
                 )
                 time.sleep(2 ** attempt * 2)
+        # Unreachable: every iteration either returns or, on the final
+        # attempt, raises. Asserted explicitly so static analyzers do not
+        # flag the implicit None fallthrough.
+        raise RuntimeError("unreachable: _call_generate_content retry loop")

--- a/evalbench/generators/models/gemini.py
+++ b/evalbench/generators/models/gemini.py
@@ -1,12 +1,20 @@
-from google import genai
-from google.genai.types import GenerateContentResponse
-from util.rate_limit import ResourceExhaustedError
-from util.gcp import get_gcp_project, get_gcp_region
-from google.api_core.exceptions import ResourceExhausted
-from .generator import QueryGenerator
-from util.sanitizer import sanitize_sql
 import logging
 import os
+import time
+
+from google import genai
+from google.api_core.exceptions import ResourceExhausted
+from google.genai import types
+from google.genai.types import GenerateContentResponse
+
+from .generator import QueryGenerator
+from .tools import get_tools
+from util.gcp import get_gcp_project, get_gcp_region
+from util.rate_limit import ResourceExhaustedError
+from util.sanitizer import sanitize_sql
+
+
+MAX_TOOL_ITERATIONS = 5
 
 
 class GeminiGenerator(QueryGenerator):
@@ -22,7 +30,10 @@ class GeminiGenerator(QueryGenerator):
             # Attempt to use GEMINI_API_KEY for authentication
             api_key = os.environ.get("GEMINI_API_KEY")
             if not api_key:
-                raise ValueError("Both gcp_project_id and gcp_region must be set in config when GEMINI_API_KEY is not available.")
+                raise ValueError(
+                    "Both gcp_project_id and gcp_region must be set in "
+                    "config when GEMINI_API_KEY is not available."
+                )
             self.client = genai.Client(api_key=api_key)
         else:
             self.client = genai.Client(
@@ -34,34 +45,126 @@ class GeminiGenerator(QueryGenerator):
         self.generation_config = None
         self.base_prompt = self.base_prompt
 
+        # Opt-in tool use. Unknown names fail fast at construction.
+        tool_names = querygenerator_config.get("tools") or []
+        self.tools = get_tools(tool_names) if tool_names else []
+        self._tools_by_name = {t.name: t for t in self.tools}
+        self._genai_tool_config = self._build_genai_tools() if self.tools else None
+
+    def _build_genai_tools(self):
+        declarations = [
+            types.FunctionDeclaration(
+                name=t.name,
+                description=t.description,
+                parametersJsonSchema=t.input_schema,
+            )
+            for t in self.tools
+        ]
+        return [types.Tool(functionDeclarations=declarations)]
+
     def generate_internal(self, prompt):
-        import time
-        from google.genai.errors import ClientError
+        if self._genai_tool_config:
+            return self._generate_with_tools(prompt)
+        return self._generate_single_shot(prompt)
+
+    def _generate_single_shot(self, prompt):
+        logger = logging.getLogger(__name__)
+        try:
+            response = self._call_generate_content(
+                contents=self.base_prompt + prompt,
+            )
+        except Exception:
+            logger.exception("Unhandled exception during generate_content")
+            raise
+        if isinstance(response, GenerateContentResponse):
+            return sanitize_sql(response.text)
+        # Preserved from the original implementation, which referenced an
+        # unbound `r` on this branch and would crash with UnboundLocalError.
+        # Returning the raw response is strictly an improvement on that.
+        return response
+
+    def _generate_with_tools(self, prompt):
+        """Tool-call loop bounded by MAX_TOOL_ITERATIONS."""
+        logger = logging.getLogger(__name__)
+        contents = [
+            types.Content(
+                role="user",
+                parts=[types.Part(text=self.base_prompt + prompt)],
+            )
+        ]
+        config = types.GenerateContentConfig(tools=self._genai_tool_config)
+
+        last_text = ""
+        for iteration in range(MAX_TOOL_ITERATIONS):
+            response = self._call_generate_content(
+                contents=contents, config=config,
+            )
+            function_calls = self._extract_function_calls(response)
+
+            if not function_calls:
+                last_text = response.text or ""
+                return sanitize_sql(last_text)
+
+            contents.append(response.candidates[0].content)
+            tool_response_parts = []
+            for fc in function_calls:
+                tool = self._tools_by_name.get(fc.name)
+                if tool is None:
+                    result = f"Error: unknown tool '{fc.name}'"
+                else:
+                    try:
+                        result = tool.fn(dict(fc.args or {}))
+                    except Exception as e:
+                        logger.exception("Tool '%s' raised", fc.name)
+                        result = f"Error: {type(e).__name__}: {e}"
+                tool_response_parts.append(
+                    types.Part(
+                        functionResponse=types.FunctionResponse(
+                            name=fc.name,
+                            response={"result": result},
+                        )
+                    )
+                )
+            contents.append(types.Content(role="user", parts=tool_response_parts))
+
+        logger.warning(
+            "Gemini judge exhausted %d tool iterations; returning last text.",
+            MAX_TOOL_ITERATIONS,
+        )
+        return sanitize_sql(last_text)
+
+    def _extract_function_calls(self, response):
+        candidates = getattr(response, "candidates", None) or []
+        if not candidates:
+            return []
+        parts = getattr(candidates[0].content, "parts", None) or []
+        return [p.function_call for p in parts if getattr(p, "function_call", None)]
+
+    def _call_generate_content(self, **kwargs):
+        """Wraps models.generate_content with retry/backoff on rate limits."""
         logger = logging.getLogger(__name__)
         for attempt in range(5):
             try:
-                response = self.client.models.generate_content(
-                    model=self.vertex_model,
-                    contents=self.base_prompt + prompt,
+                return self.client.models.generate_content(
+                    model=self.vertex_model, **kwargs,
                 )
-                if isinstance(response, GenerateContentResponse):
-                    r = sanitize_sql(response.text)
-                return r
             except ResourceExhausted as e:
-                if attempt < 4:
-                    logger.warning(f"ResourceExhausted. Retrying attempt {attempt + 1} after sleep...")
-                    time.sleep(2 ** attempt * 2)
-                else:
+                if attempt >= 4:
                     raise ResourceExhaustedError(e)
+                logger.warning(
+                    "ResourceExhausted. Retrying attempt %d after sleep...",
+                    attempt + 1,
+                )
+                time.sleep(2 ** attempt * 2)
             except genai.errors.ClientError as e:
-                if "429" in str(e) or "RESOURCE_EXHAUSTED" in str(e):
-                    if attempt < 4:
-                        logger.warning(f"429/RESOURCE_EXHAUSTED. Retrying attempt {attempt + 1} after sleep...")
-                        time.sleep(2 ** attempt * 2)
-                    else:
-                        raise ResourceExhaustedError(e)
-                else:
+                msg = str(e)
+                if "429" not in msg and "RESOURCE_EXHAUSTED" not in msg:
                     raise
-            except Exception as e:
-                logger.exception("Unhandled exception during generate_content")
-                raise
+                if attempt >= 4:
+                    raise ResourceExhaustedError(e)
+                logger.warning(
+                    "429/RESOURCE_EXHAUSTED. Retrying attempt %d "
+                    "after sleep...",
+                    attempt + 1,
+                )
+                time.sleep(2 ** attempt * 2)

--- a/evalbench/generators/models/tools/__init__.py
+++ b/evalbench/generators/models/tools/__init__.py
@@ -1,0 +1,22 @@
+from typing import Dict, List
+
+from .base import Tool
+from .fetch_url import FETCH_URL_TOOL
+
+TOOL_REGISTRY: Dict[str, Tool] = {
+    FETCH_URL_TOOL.name: FETCH_URL_TOOL,
+}
+
+
+def get_tools(names: List[str]) -> List[Tool]:
+    """Resolves tool names to Tool objects. Raises on unknown names."""
+    unknown = [n for n in names if n not in TOOL_REGISTRY]
+    if unknown:
+        raise ValueError(
+            f"Unknown tools: {unknown}. "
+            f"Available: {sorted(TOOL_REGISTRY)}"
+        )
+    return [TOOL_REGISTRY[n] for n in names]
+
+
+__all__ = ["Tool", "TOOL_REGISTRY", "get_tools"]

--- a/evalbench/generators/models/tools/base.py
+++ b/evalbench/generators/models/tools/base.py
@@ -1,0 +1,20 @@
+from dataclasses import dataclass
+from typing import Any, Callable, Dict
+
+
+@dataclass
+class Tool:
+    """A function-callable tool the judge model can invoke.
+
+    `input_schema` is plain JSON Schema (object with `type`, `properties`,
+    `required`). Each judge backend translates it into its native shape.
+
+    `fn` receives the model-supplied args as a dict and returns a string
+    payload. Errors should be returned as `"Error: ..."` strings rather
+    than raised so the model can observe the failure and react.
+    """
+
+    name: str
+    description: str
+    input_schema: Dict[str, Any]
+    fn: Callable[[Dict[str, Any]], str]

--- a/evalbench/generators/models/tools/fetch_url.py
+++ b/evalbench/generators/models/tools/fetch_url.py
@@ -110,7 +110,13 @@ def fetch_url(args: Dict[str, Any]) -> str:
             extractor.feed(text)
             text = extractor.text()
         except Exception:
-            pass
+            # HTML stripping is best-effort: on a malformed document we
+            # fall back to the raw decoded body so the judge still has
+            # *something* to reason about.
+            logging.debug(
+                "fetch_url HTML extraction failed; falling back to raw text",
+                exc_info=True,
+            )
 
     if truncated:
         text += f"\n\n[truncated at {_MAX_BYTES} bytes]"

--- a/evalbench/generators/models/tools/fetch_url.py
+++ b/evalbench/generators/models/tools/fetch_url.py
@@ -1,0 +1,139 @@
+"""URL-fetching tool for the LLM judge.
+
+Fetches an HTTPS URL, strips HTML to text, and returns the result so the
+judge can ground rubric questions in external state.
+
+Defense in depth: HTTPS only, SSRF guard against private/loopback/link-local
+hosts, 10s timeout, 50KB body cap.
+"""
+
+from html.parser import HTMLParser
+from typing import Any, Dict
+from urllib.parse import urlparse
+import ipaddress
+import logging
+import socket
+import urllib.error
+import urllib.request
+
+from .base import Tool
+
+_TIMEOUT_SECONDS = 10
+_MAX_BYTES = 50_000
+_USER_AGENT = "evalbench-judge/1.0"
+
+
+class _TextExtractor(HTMLParser):
+    """Strips tags and collapses whitespace. Skips script/style content."""
+
+    _SKIP_TAGS = frozenset({"script", "style", "noscript", "svg"})
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._chunks: list[str] = []
+        self._skip_depth = 0
+
+    def handle_starttag(self, tag, attrs):
+        if tag in self._SKIP_TAGS:
+            self._skip_depth += 1
+
+    def handle_endtag(self, tag):
+        if tag in self._SKIP_TAGS and self._skip_depth > 0:
+            self._skip_depth -= 1
+
+    def handle_data(self, data):
+        if self._skip_depth == 0:
+            self._chunks.append(data)
+
+    def text(self) -> str:
+        return " ".join("".join(self._chunks).split())
+
+
+def _is_blocked_host(host: str) -> bool:
+    """True if host resolves to a private/loopback/link-local address."""
+    try:
+        addr_info = socket.getaddrinfo(host, None)
+    except socket.gaierror:
+        return True
+    for family, _, _, _, sockaddr in addr_info:
+        ip_str = sockaddr[0]
+        try:
+            ip = ipaddress.ip_address(ip_str)
+        except ValueError:
+            continue
+        if ip.is_private or ip.is_loopback or ip.is_link_local or ip.is_multicast or ip.is_reserved:
+            return True
+    return False
+
+
+def fetch_url(args: Dict[str, Any]) -> str:
+    url = args.get("url", "")
+    if not isinstance(url, str) or not url:
+        return "Error: missing required arg 'url' (string)"
+
+    parsed = urlparse(url)
+    if parsed.scheme != "https":
+        return f"Error: only https URLs are allowed (got scheme '{parsed.scheme}')"
+    if not parsed.hostname:
+        return "Error: URL has no hostname"
+    if _is_blocked_host(parsed.hostname):
+        return (
+            f"Error: refusing to fetch '{parsed.hostname}' "
+            "(private, loopback, link-local, or unresolvable)"
+        )
+
+    request = urllib.request.Request(url, headers={"User-Agent": _USER_AGENT})
+    try:
+        with urllib.request.urlopen(request, timeout=_TIMEOUT_SECONDS) as response:
+            raw = response.read(_MAX_BYTES + 1)
+            content_type = response.headers.get("Content-Type", "")
+    except urllib.error.HTTPError as e:
+        return f"Error: HTTP {e.code} fetching {url}"
+    except urllib.error.URLError as e:
+        return f"Error: URL error fetching {url}: {e.reason}"
+    except (TimeoutError, socket.timeout):
+        return f"Error: timeout after {_TIMEOUT_SECONDS}s fetching {url}"
+    except Exception as e:
+        logging.exception("fetch_url unexpected failure for %s", url)
+        return f"Error: {type(e).__name__}: {e}"
+
+    truncated = len(raw) > _MAX_BYTES
+    body = raw[:_MAX_BYTES]
+    try:
+        text = body.decode("utf-8", errors="replace")
+    except Exception:
+        text = body.decode("latin-1", errors="replace")
+
+    if "html" in content_type.lower() or "<html" in text[:200].lower():
+        extractor = _TextExtractor()
+        try:
+            extractor.feed(text)
+            text = extractor.text()
+        except Exception:
+            pass
+
+    if truncated:
+        text += f"\n\n[truncated at {_MAX_BYTES} bytes]"
+    return text
+
+
+FETCH_URL_TOOL = Tool(
+    name="fetch_url",
+    description=(
+        "Fetch the contents of an HTTPS URL and return it as text. "
+        "HTML is stripped to plain text. Only public HTTPS URLs are "
+        "allowed; private, loopback, and non-HTTPS hosts are rejected. "
+        "Response is capped at 50000 bytes."
+    ),
+    input_schema={
+        "type": "object",
+        "properties": {
+            "url": {
+                "type": "string",
+                "description": "The fully-qualified HTTPS URL to fetch.",
+            },
+        },
+        "required": ["url"],
+    },
+    fn=fetch_url,
+)

--- a/evalbench/test/gemini_tools_test.py
+++ b/evalbench/test/gemini_tools_test.py
@@ -1,0 +1,188 @@
+import os
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from google.genai import types  # noqa: E402
+
+from generators.models.gemini import GeminiGenerator, MAX_TOOL_ITERATIONS  # noqa: E402
+from generators.models.tools import TOOL_REGISTRY  # noqa: E402
+
+
+def _contents_at(client, call_index):
+    """Returns the `contents` kwarg passed to the Nth generate_content call."""
+    return client.models.generate_content.call_args_list[call_index].kwargs["contents"]
+
+
+@pytest.fixture(autouse=True)
+def _stub_genai_client():
+    """Replace genai.Client so no real Vertex traffic happens."""
+    with patch("generators.models.gemini.genai.Client") as mock_client_cls:
+        instance = MagicMock()
+        mock_client_cls.return_value = instance
+        yield instance
+
+
+def _config(tools=None):
+    cfg = {
+        "gcp_project_id": "test-project",
+        "gcp_region": "us-central1",
+        "vertex_model": "gemini-2.5-pro",
+        "base_prompt": "",
+    }
+    if tools is not None:
+        cfg["tools"] = tools
+    return cfg
+
+
+def _text_response(text):
+    """Use real types.Content so test assertions can walk the response shape
+    the same way the production code does. The fields we don't care about
+    (e.g. usage metadata) stay as MagicMocks via __getattr__."""
+    resp = MagicMock()
+    resp.text = text
+    resp.candidates = [
+        MagicMock(content=types.Content(role="model", parts=[types.Part(text=text)]))
+    ]
+    return resp
+
+
+def _function_call_response(name, args):
+    resp = MagicMock()
+    resp.text = ""
+    resp.candidates = [
+        MagicMock(
+            content=types.Content(
+                role="model",
+                parts=[types.Part(functionCall=types.FunctionCall(name=name, args=args))],
+            )
+        )
+    ]
+    return resp
+
+
+def _function_response_parts(contents):
+    """Walks a real list of types.Content and returns the FunctionResponse
+    objects. Skips non-Content entries (e.g. MagicMock pass-through from a
+    mocked response's .candidates[0].content)."""
+    out = []
+    for content in contents:
+        if not isinstance(content, types.Content):
+            continue
+        for part in content.parts or []:
+            if part.function_response is not None:
+                out.append(part.function_response)
+    return out
+
+
+def test_no_tools_uses_single_shot_path(_stub_genai_client):
+    """Config without `tools:` must hit the original single-shot path
+    with no `config=` kwarg — preserving today's behavior bit-for-bit
+    for every existing judge config."""
+    response = MagicMock(spec_set=["text"])
+    response.text = "PASS\nAll good."
+    _stub_genai_client.models.generate_content.return_value = response
+
+    # The single-shot path uses isinstance(response, GenerateContentResponse)
+    # to gate the assignment to `r`. Spoof that by patching the class in
+    # the gemini module so MagicMock passes the isinstance check.
+    with patch("generators.models.gemini.GenerateContentResponse", MagicMock):
+        gen = GeminiGenerator(_config())
+        result = gen.generate_internal("hello")
+
+    assert result == "PASS\nAll good."
+    call_args = _stub_genai_client.models.generate_content.call_args
+    assert call_args.kwargs["model"] == "gemini-2.5-pro"
+    assert call_args.kwargs["contents"] == "hello"
+    assert "config" not in call_args.kwargs
+
+
+def test_unknown_tool_name_fails_fast(_stub_genai_client):
+    with pytest.raises(ValueError, match="Unknown tools"):
+        GeminiGenerator(_config(tools=["nope_not_a_tool"]))
+
+
+def test_tools_configured_but_no_function_call_returns_text(_stub_genai_client):
+    """With tools enabled but the model emits text on the first turn, the
+    loop exits immediately with that text. No tool is invoked."""
+    _stub_genai_client.models.generate_content.return_value = _text_response(
+        "PASS\nBeam is on 2.99.0."
+    )
+
+    gen = GeminiGenerator(_config(tools=["fetch_url"]))
+    result = gen.generate_internal("rate this conversation")
+
+    assert "PASS" in result
+    assert _stub_genai_client.models.generate_content.call_count == 1
+    call_args = _stub_genai_client.models.generate_content.call_args
+    assert call_args.kwargs["config"] is not None
+
+
+def test_tool_call_loop_invokes_tool_and_returns_final_text(_stub_genai_client):
+    """Model asks for fetch_url, judge runs it, model gets the result and
+    returns a final text answer. Verifies the two-turn loop and that the
+    second SDK call carries a FunctionResponse part."""
+    _stub_genai_client.models.generate_content.side_effect = [
+        _function_call_response("fetch_url", {"url": "https://beam.apache.org/x"}),
+        _text_response("PASS\nVersion 2.99.0 was fetched."),
+    ]
+
+    fake_tool_result = "Apache Beam latest: 2.99.0"
+    with patch.object(TOOL_REGISTRY["fetch_url"], "fn", return_value=fake_tool_result) as mock_fn:
+        gen = GeminiGenerator(_config(tools=["fetch_url"]))
+        result = gen.generate_internal("what version did the agent name?")
+
+    assert "PASS" in result
+    mock_fn.assert_called_once_with({"url": "https://beam.apache.org/x"})
+
+    assert _stub_genai_client.models.generate_content.call_count == 2
+    function_responses = _function_response_parts(
+        _contents_at(_stub_genai_client, 1)
+    )
+    assert function_responses, "second SDK call must carry the FunctionResponse part"
+    assert function_responses[0].name == "fetch_url"
+    assert function_responses[0].response == {"result": fake_tool_result}
+
+
+def test_tool_loop_terminates_at_iteration_cap(_stub_genai_client):
+    """Pathological model that always emits a function_call must not hang;
+    the loop must terminate at MAX_TOOL_ITERATIONS."""
+    _stub_genai_client.models.generate_content.side_effect = [
+        _function_call_response("fetch_url", {"url": f"https://example.com/{i}"})
+        for i in range(MAX_TOOL_ITERATIONS + 5)
+    ]
+
+    with patch.object(TOOL_REGISTRY["fetch_url"], "fn", return_value="ok"):
+        gen = GeminiGenerator(_config(tools=["fetch_url"]))
+        result = gen.generate_internal("loop me")
+
+    assert _stub_genai_client.models.generate_content.call_count == MAX_TOOL_ITERATIONS
+    assert isinstance(result, str)
+
+
+def test_tool_raising_is_surfaced_as_error_string(_stub_genai_client):
+    """A tool that raises must not crash the judge; the exception is
+    converted to an `Error: ...` string and fed back to the model."""
+    _stub_genai_client.models.generate_content.side_effect = [
+        _function_call_response("fetch_url", {"url": "https://example.com/"}),
+        _text_response("FAIL\nCould not verify."),
+    ]
+
+    def boom(_):
+        raise RuntimeError("network down")
+
+    with patch.object(TOOL_REGISTRY["fetch_url"], "fn", side_effect=boom):
+        gen = GeminiGenerator(_config(tools=["fetch_url"]))
+        result = gen.generate_internal("verify")
+
+    assert "FAIL" in result
+    function_responses = _function_response_parts(
+        _contents_at(_stub_genai_client, 1)
+    )
+    assert function_responses, "second SDK call must carry the FunctionResponse part"
+    payload = function_responses[0].response["result"]
+    assert "Error: RuntimeError" in payload
+    assert "network down" in payload

--- a/evalbench/test/tools_fetch_url_test.py
+++ b/evalbench/test/tools_fetch_url_test.py
@@ -1,0 +1,142 @@
+import io
+import os
+import socket
+import sys
+import urllib.error
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from generators.models.tools.fetch_url import fetch_url  # noqa: E402
+
+
+def _public_addrinfo():
+    """getaddrinfo response for a routable public IP. Avoids documentation
+    ranges (198.51.100/24, 203.0.113/24) which Python's ipaddress module
+    classifies as private."""
+    return [(socket.AF_INET, socket.SOCK_STREAM, 0, "", ("93.184.216.34", 0))]
+
+
+def _private_addrinfo():
+    return [(socket.AF_INET, socket.SOCK_STREAM, 0, "", ("10.0.0.1", 0))]
+
+
+def _loopback_addrinfo():
+    return [(socket.AF_INET, socket.SOCK_STREAM, 0, "", ("127.0.0.1", 0))]
+
+
+def _mock_response(body: bytes, content_type: str = "text/plain"):
+    resp = MagicMock()
+    resp.read.return_value = body
+    resp.headers = {"Content-Type": content_type}
+    resp.__enter__ = lambda self: self
+    resp.__exit__ = lambda *a: False
+    return resp
+
+
+def test_missing_url_returns_error():
+    result = fetch_url({})
+    assert result.startswith("Error: missing required arg 'url'")
+
+
+def test_non_https_scheme_rejected():
+    result = fetch_url({"url": "http://example.com/foo"})
+    assert "only https URLs are allowed" in result
+
+
+def test_file_scheme_rejected():
+    result = fetch_url({"url": "file:///etc/passwd"})
+    assert "only https URLs are allowed" in result
+
+
+@patch("generators.models.tools.fetch_url.socket.getaddrinfo")
+def test_private_ip_rejected(mock_getaddrinfo):
+    mock_getaddrinfo.return_value = _private_addrinfo()
+    result = fetch_url({"url": "https://internal.corp/secret"})
+    assert "private, loopback" in result
+
+
+@patch("generators.models.tools.fetch_url.socket.getaddrinfo")
+def test_loopback_rejected(mock_getaddrinfo):
+    mock_getaddrinfo.return_value = _loopback_addrinfo()
+    result = fetch_url({"url": "https://localhost/admin"})
+    assert "private, loopback" in result
+
+
+@patch("generators.models.tools.fetch_url.socket.getaddrinfo")
+def test_unresolvable_host_rejected(mock_getaddrinfo):
+    mock_getaddrinfo.side_effect = socket.gaierror("nope")
+    result = fetch_url({"url": "https://does-not-exist.invalid/"})
+    assert "private, loopback, link-local, or unresolvable" in result
+
+
+@patch("generators.models.tools.fetch_url.urllib.request.urlopen")
+@patch("generators.models.tools.fetch_url.socket.getaddrinfo")
+def test_plain_text_response_returned(mock_getaddrinfo, mock_urlopen):
+    mock_getaddrinfo.return_value = _public_addrinfo()
+    mock_urlopen.return_value = _mock_response(
+        b"Apache Beam 2.99.0 released",
+        content_type="text/plain",
+    )
+    result = fetch_url({"url": "https://beam.apache.org/version"})
+    assert result == "Apache Beam 2.99.0 released"
+
+
+@patch("generators.models.tools.fetch_url.urllib.request.urlopen")
+@patch("generators.models.tools.fetch_url.socket.getaddrinfo")
+def test_html_response_is_stripped(mock_getaddrinfo, mock_urlopen):
+    mock_getaddrinfo.return_value = _public_addrinfo()
+    html = (
+        b"<html><head><style>body{}</style></head><body>"
+        b"<h1>Downloads</h1><p>Latest: <b>2.99.0</b></p>"
+        b"<script>alert('hi')</script></body></html>"
+    )
+    mock_urlopen.return_value = _mock_response(html, content_type="text/html")
+    result = fetch_url({"url": "https://beam.apache.org/get-started/downloads/"})
+    assert "Downloads" in result
+    assert "2.99.0" in result
+    assert "alert" not in result
+    assert "<h1>" not in result
+
+
+@patch("generators.models.tools.fetch_url.urllib.request.urlopen")
+@patch("generators.models.tools.fetch_url.socket.getaddrinfo")
+def test_oversized_body_is_truncated(mock_getaddrinfo, mock_urlopen):
+    mock_getaddrinfo.return_value = _public_addrinfo()
+    big_body = b"x" * 60_000
+    mock_urlopen.return_value = _mock_response(big_body, content_type="text/plain")
+    result = fetch_url({"url": "https://example.com/big"})
+    assert "[truncated at 50000 bytes]" in result
+    assert len(result) <= 50_000 + len("\n\n[truncated at 50000 bytes]")
+
+
+@patch("generators.models.tools.fetch_url.urllib.request.urlopen")
+@patch("generators.models.tools.fetch_url.socket.getaddrinfo")
+def test_http_error_returned_as_string(mock_getaddrinfo, mock_urlopen):
+    mock_getaddrinfo.return_value = _public_addrinfo()
+    mock_urlopen.side_effect = urllib.error.HTTPError(
+        "https://example.com/missing", 404, "Not Found", {}, io.BytesIO()
+    )
+    result = fetch_url({"url": "https://example.com/missing"})
+    assert "HTTP 404" in result
+
+
+@patch("generators.models.tools.fetch_url.urllib.request.urlopen")
+@patch("generators.models.tools.fetch_url.socket.getaddrinfo")
+def test_timeout_returned_as_string(mock_getaddrinfo, mock_urlopen):
+    mock_getaddrinfo.return_value = _public_addrinfo()
+    mock_urlopen.side_effect = socket.timeout()
+    result = fetch_url({"url": "https://example.com/slow"})
+    assert "timeout after" in result
+
+
+@patch("generators.models.tools.fetch_url.urllib.request.urlopen")
+@patch("generators.models.tools.fetch_url.socket.getaddrinfo")
+def test_url_error_returned_as_string(mock_getaddrinfo, mock_urlopen):
+    mock_getaddrinfo.return_value = _public_addrinfo()
+    mock_urlopen.side_effect = urllib.error.URLError("connection refused")
+    result = fetch_url({"url": "https://example.com/down"})
+    assert "URL error" in result
+    assert "connection refused" in result

--- a/evalbench/test/tools_fetch_url_test.py
+++ b/evalbench/test/tools_fetch_url_test.py
@@ -5,8 +5,6 @@ import sys
 import urllib.error
 from unittest.mock import MagicMock, patch
 
-import pytest
-
 sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 from generators.models.tools.fetch_url import fetch_url  # noqa: E402


### PR DESCRIPTION
## Summary

LLM-judged scorers (`BinaryRubricScorer`, `LlmRater`, `GoalCompletionRate`, etc.) currently call `self.model.generate(prompt)` and get back text. The SDK-backed Gemini judge (`gemini.py`) wraps `client.models.generate_content(...)` with no tool-use loop, so it cannot ground rubric questions in external state — e.g. *\"did the agent name the most-recent Apache Beam version listed on beam.apache.org?\"* This PR adds an **opt-in** function-calling loop to the Gemini judge with one built-in tool (`fetch_url`).

- New `generators/models/tools/` package: `Tool` dataclass + name registry + `fetch_url` implementation.
- `GeminiGenerator` reads a `tools:` list from YAML, builds the native `types.Tool` config once, and runs a loop bounded at `MAX_TOOL_ITERATIONS=5`. Configs without `tools:` take the original single-shot codepath unchanged.
- Retry/backoff on rate-limit errors is extracted into a single `_call_generate_content` helper shared by both paths.
- `fetch_url`: HTTPS only, SSRF guard via `ipaddress` against private/loopback/link-local/multicast/reserved IPs, 10s timeout, 50KB body cap, HTML→text via stdlib `html.parser`. Tool errors are returned as `\"Error: ...\"` strings so the model can react rather than crashing the judge.

## Configuration

```yaml
generator: gcp_vertex_gemini
vertex_model: gemini-2.5-pro
base_prompt: \"\"
tools:
  - fetch_url
```

Existing configs without `tools:` keep their current behavior bit-for-bit.

## Out of scope

- Any tools beyond `fetch_url`.
- Plumbing tools through the CLI generators (they have MCP).

## Known follow-ups

- **Redirect SSRF**: `urlopen` follows 3xx without re-validating each hop's IP. A malicious site can 302 to a private host and bypass the upfront check. Mitigation requires a custom `HTTPRedirectHandler` or disabling redirects. Out of scope for this PR but flagged.
- **DNS TOCTOU**: `_is_blocked_host` resolves once; `urlopen` resolves again. A rebinding attack can flip between the two. Out of scope.

## Test plan

- [x] \`uv run pytest evalbench/test/tools_fetch_url_test.py evalbench/test/gemini_tools_test.py evalbench/test/binaryrubricscorer_test.py\` — 21/21 pass
  - 12 unit tests for `fetch_url`: scheme enforcement, SSRF reject (private/loopback/unresolvable), size cap, HTML strip, HTTP error, timeout, URL error.
  - 6 unit tests for the Gemini loop: no-tools single-shot preserved, unknown tool fails fast, no-call-emit returns text, tool invoked + FunctionResponse threaded back, iteration cap, tool exception → error string.
  - 3 existing rubric tests still pass.
- [x] \`uv run pycodestyle --max-line-length 100 evalbench/generators/models/gemini.py evalbench/generators/models/tools/ evalbench/test/gemini_tools_test.py evalbench/test/tools_fetch_url_test.py\` — clean.
- [ ] Manual smoke against live Vertex with a rubric like \"did the agent's final answer mention Apache Beam version 2.x\" — not yet run.