### PR TITLE
refactor: replace if-chain with dictionary dispatch for model generators

### DIFF
--- a/evalbench/generators/models/__init__.py
+++ b/evalbench/generators/models/__init__.py
@@ -23,33 +23,24 @@ def get_generator(global_models, model_config_path: str, db: DB = None):
 
         config = load_yaml_config(model_config_path)
         # Create a new model_config
-        model: QueryGenerator | None = None
-        if config["generator"] == "gcp_vertex_gemini":
-            model = GeminiGenerator(config)
-        if config["generator"] == "gcp_vertex_claude":
-            model = ClaudeGenerator(config)
-        if config["generator"] == "noop":
-            model = NOOPGenerator(config)
-        if config["generator"] == "alloydb_ai_nl":
-            model = AlloyDBGenerator(db, config)
-        if config["generator"] == "querydata":
-            model = QueryData(config)
-        if config["generator"] == "query_data_api":
-            model = QueryDataAPIGenerator(config)
-        if config["generator"] == "grpc_proxy":
-            model = GrpcProxyModel(config)
-        if config["generator"] == "gemini_cli":
-            model = GeminiCliGenerator(config)
-        if config["generator"] == "claude_code":
-            model = ClaudeCodeGenerator(config)
-        if config["generator"] == "codex_cli":
-            model = CodexCliGenerator(config)
-        if config["generator"] == "data_engineering_agent":
-            model = DataEngineeringAgentGenerator(config)
-        if config["generator"] == "agy_cli":
-            model = AgyCliGenerator(config)
-        if not model:
-            raise ValueError(f"Unknown Generator {config['generator']}")
+        generators = {
+            "gcp_vertex_gemini": lambda: GeminiGenerator(config),
+            "gcp_vertex_claude": lambda: ClaudeGenerator(config),
+            "noop": lambda: NOOPGenerator(config),
+            "alloydb_ai_nl": lambda: AlloyDBGenerator(db, config),
+            "querydata": lambda: QueryData(config),
+            "query_data_api": lambda: QueryDataAPIGenerator(config),
+            "grpc_proxy": lambda: GrpcProxyModel(config),
+            "gemini_cli": lambda: GeminiCliGenerator(config),
+            "claude_code": lambda: ClaudeCodeGenerator(config),
+            "codex_cli": lambda: CodexCliGenerator(config),
+            "data_engineering_agent": lambda: DataEngineeringAgentGenerator(config),
+            "agy_cli": lambda: AgyCliGenerator(config),
+        }
+        generator = config["generator"]
+        if generator not in generators:
+            raise ValueError(f"Unknown Generator {generator}")
+        model = generators[generator]()
 
         global_model_configs[model_config_path] = model
     return model


### PR DESCRIPTION
This PR refactors the `get_generator` function to improve efficiency and maintainability.

**Key changes:**
* Replaces the sequential `if` statement chain with an O(1) dictionary dispatch mechanism.
* Uses `lambda` functions for the dictionary values (e.g., `lambda: GeminiGenerator(config)`) to ensure lazy evaluation, guaranteeing that only the requested model class is instantiated.
* Simplifies error handling for unknown generators by directly checking the dictionary keys.
* Makes adding future models cleaner by simply requiring a new key-value pair.
