### PR TITLE
refactor: introduce AgentCliGenerator base to unify CLI generator handling

### DIFF
--- a/evalbench/evaluator/agentevaluator.py
+++ b/evalbench/evaluator/agentevaluator.py
@@ -56,7 +56,7 @@ class AgentEvaluator:
             return self._evaluate_agent_cli(dataset, job_id, run_time)
         else:
             raise NotImplementedError(
-                "This evaluator currently only supports AgentCliGenerator subclasses")
+                "This evaluator currently only supports GeminiCliGenerator, ClaudeCodeGenerator, CodexCliGenerator and AgyCliGenerator")
 
     def _evaluate_agent_cli(
         self,

--- a/evalbench/evaluator/agentevaluator.py
+++ b/evalbench/evaluator/agentevaluator.py
@@ -7,10 +7,7 @@ import threading
 
 from dataset.evalgeminicliinput import EvalGeminiCliRequest
 from generators.models import get_generator
-from generators.models.gemini_cli import GeminiCliGenerator
-from generators.models.claude_code import ClaudeCodeGenerator
-from generators.models.codex_cli import CodexCliGenerator
-from generators.models.agy_cli import AgyCliGenerator
+from generators.models.agent_cli import AgentCliGenerator
 from mp import mprunner
 from work.agentgenwork import AgentGenWork
 from evaluator.simulateduser import SimulatedUser
@@ -38,19 +35,12 @@ class AgentEvaluator:
         }
         self.generator = get_generator(global_models, model_config_path)
 
-        if isinstance(self.generator, ClaudeCodeGenerator):
-            self.agent_version = self.generator.claude_code_version
-        elif isinstance(self.generator, GeminiCliGenerator):
-            self.agent_version = self.generator.gemini_cli_version
-        elif isinstance(self.generator, CodexCliGenerator):
-            self.agent_version = self.generator.codex_cli_version
-        elif isinstance(self.generator, AgyCliGenerator):
-            self.agent_version = self.generator.agy_cli_version
-        else:
+        if not isinstance(self.generator, AgentCliGenerator):
             raise ValueError(
-                f"AgentEvaluator only supports gemini_cli, claude_code, "
-                f"codex_cli, and agy_cli generators, got "
+                f"AgentEvaluator only supports agent CLI generators "
+                f"(gemini_cli, claude_code, codex_cli, agy_cli), got "
                 f"{type(self.generator).__name__}")
+        self.agent_version = self.generator.version
 
         runner_config = self.config.get("runners", {})
         self.agent_runners = runner_config.get("agent_runners", 10)
@@ -62,11 +52,11 @@ class AgentEvaluator:
         job_id: str,
         run_time: datetime.datetime,
     ):
-        if isinstance(self.generator, (GeminiCliGenerator, ClaudeCodeGenerator, CodexCliGenerator, AgyCliGenerator)):
+        if isinstance(self.generator, AgentCliGenerator):
             return self._evaluate_agent_cli(dataset, job_id, run_time)
         else:
             raise NotImplementedError(
-                "This evaluator currently only supports GeminiCliGenerator, ClaudeCodeGenerator, CodexCliGenerator and AgyCliGenerator")
+                "This evaluator currently only supports AgentCliGenerator subclasses")
 
     def _evaluate_agent_cli(
         self,
@@ -135,32 +125,15 @@ class AgentEvaluator:
         for turn in range(max_turns):
             logging.info(
                 f"Turn {turn + 1}/{max_turns} - Prompt: {current_prompt}")
-            if isinstance(self.generator, (GeminiCliGenerator, ClaudeCodeGenerator, CodexCliGenerator, AgyCliGenerator)):
-                if isinstance(self.generator, ClaudeCodeGenerator):
-                    cli_cmd = self.generator.create_command(
-                        cli=self.agent_version,
-                        prompt=current_prompt,
-                        env=env,
-                        resume=(turn > 0),
-                        session_id=session_id,
-                        cwd=resolved_work_dir,
-                    )
-                elif isinstance(self.generator, CodexCliGenerator):
-                    cli_cmd = self.generator.create_command(
-                        cli=self.agent_version,
-                        prompt=current_prompt,
-                        env=env,
-                        resume=(turn > 0),
-                        session_id=session_id
-                    )
-                else:
-                    cli_cmd = self.generator.create_command(
-                        cli=self.agent_version,
-                        prompt=current_prompt,
-                        env=env,
-                        resume=(turn > 0),
-                        cwd=resolved_work_dir
-                    )
+            if isinstance(self.generator, AgentCliGenerator):
+                cli_cmd = self.generator.create_command(
+                    cli=self.agent_version,
+                    prompt=current_prompt,
+                    env=env,
+                    resume=(turn > 0),
+                    session_id=session_id,
+                    cwd=resolved_work_dir,
+                )
                 try:
                     result = self.generator.safe_generate(cli_cmd)
                     if result.stdout:
@@ -184,12 +157,12 @@ class AgentEvaluator:
             self._log_cli_result(turn, max_turns, result)
 
             tools = []
-            if isinstance(self.generator, (GeminiCliGenerator, ClaudeCodeGenerator, CodexCliGenerator, AgyCliGenerator)):
+            if isinstance(self.generator, AgentCliGenerator):
                 tools = self.generator.extract_tools(result.stdout)
             accumulated_tools.extend(tools)
 
             # Extract skills from generator output
-            if isinstance(self.generator, (GeminiCliGenerator, ClaudeCodeGenerator, CodexCliGenerator, AgyCliGenerator)):
+            if isinstance(self.generator, AgentCliGenerator):
                 skills = self.generator.extract_skills(result.stdout)
                 accumulated_skills.extend(skills)
 

--- a/evalbench/generators/models/agent_cli.py
+++ b/evalbench/generators/models/agent_cli.py
@@ -1,0 +1,44 @@
+from abc import abstractmethod
+
+from .generator import QueryGenerator
+
+
+class AgentCliGenerator(QueryGenerator):
+    """Shared base for CLI-driven agent generators (gemini_cli, claude_code,
+    codex_cli, agy_cli).
+
+    The evaluator treats every subclass uniformly: build a command with
+    ``create_command``, run it with ``safe_generate``, then read structured
+    data with ``parse_response`` / ``extract_tools`` / ``extract_skills``. The
+    reported agent version label is exposed via the ``version`` property.
+    Membership in this class is what ``AgentEvaluator`` keys off of, so a new
+    CLI generator only needs to subclass this -- no evaluator changes.
+    """
+
+    @property
+    @abstractmethod
+    def version(self) -> str:
+        raise NotImplementedError("Subclasses must implement this property")
+
+    @abstractmethod
+    def create_command(
+        self, cli: str, prompt: str, env: dict = None, resume: bool = False,
+        session_id: str = None, cwd: str = None,
+    ):
+        raise NotImplementedError("Subclasses must implement this method")
+
+    @abstractmethod
+    def safe_generate(self, cli_cmd):
+        raise NotImplementedError("Subclasses must implement this method")
+
+    @abstractmethod
+    def parse_response(self, stdout: str) -> dict:
+        raise NotImplementedError("Subclasses must implement this method")
+
+    @abstractmethod
+    def extract_tools(self, stdout: str) -> list:
+        raise NotImplementedError("Subclasses must implement this method")
+
+    @abstractmethod
+    def extract_skills(self, stdout: str) -> list:
+        raise NotImplementedError("Subclasses must implement this method")

--- a/evalbench/generators/models/agy_cli.py
+++ b/evalbench/generators/models/agy_cli.py
@@ -1,4 +1,4 @@
-from .generator import QueryGenerator
+from .agent_cli import AgentCliGenerator
 from .tool_naming import canonicalize_agy_tool_name, parse_agy_mcp_tool_call
 import collections
 import subprocess
@@ -31,7 +31,7 @@ class CLICommand:
         self.cwd = cwd
 
 
-class AgyCliGenerator(QueryGenerator):
+class AgyCliGenerator(AgentCliGenerator):
     """Generator that queries via the Antigravity CLI (``agy``).
 
     Surface targeted here is what the v1.0.5 binary actually exposes:
@@ -1181,6 +1181,10 @@ class AgyCliGenerator(QueryGenerator):
             return 0
         return int((t1 - t0).total_seconds() * 1000)
 
+    @property
+    def version(self) -> str:
+        return self.agy_cli_version
+
     def parse_response(self, stdout: str) -> dict:
         if not stdout:
             return {}
@@ -1234,7 +1238,7 @@ class AgyCliGenerator(QueryGenerator):
 
     def create_command(
         self, cli: str, prompt: str, env: dict = None, resume: bool = False,
-        cwd: str = None,
+        session_id: str = None, cwd: str = None,
     ) -> CLICommand:
         # The executable is always this session's sandbox binary
         # (self.agy_bin); the ``cli`` argument -- the agent_version label "agy"

--- a/evalbench/generators/models/claude_code.py
+++ b/evalbench/generators/models/claude_code.py
@@ -1,4 +1,4 @@
-from .generator import QueryGenerator
+from .agent_cli import AgentCliGenerator
 from .tool_naming import canonicalize_claude_tool_name
 import subprocess
 import os
@@ -22,7 +22,7 @@ class CLICommand:
         self.cwd = cwd
 
 
-class ClaudeCodeGenerator(QueryGenerator):
+class ClaudeCodeGenerator(AgentCliGenerator):
     """Generator queries using Claude Code CLI."""
 
     def __init__(self, querygenerator_config):
@@ -690,6 +690,10 @@ class ClaudeCodeGenerator(QueryGenerator):
                 logging.debug(f"Failed to parse stream JSON line: {e}")
 
         return json.dumps(final_obj, indent=2)
+
+    @property
+    def version(self) -> str:
+        return self.claude_code_version
 
     def parse_response(self, stdout: str) -> dict:
         if not stdout:

--- a/evalbench/generators/models/codex_cli.py
+++ b/evalbench/generators/models/codex_cli.py
@@ -1,4 +1,4 @@
-from .generator import QueryGenerator
+from .agent_cli import AgentCliGenerator
 from .tool_naming import canonical_tool_name
 import subprocess
 import os
@@ -49,7 +49,7 @@ class CLICommand:
         self.session_id = session_id
 
 
-class CodexCliGenerator(QueryGenerator):
+class CodexCliGenerator(AgentCliGenerator):
     """Generator queries using OpenAI Codex CLI (`codex exec`)."""
 
     def __init__(self, querygenerator_config):
@@ -1007,6 +1007,10 @@ class CodexCliGenerator(QueryGenerator):
                 return {"raw": value}
         return value or {}
 
+    @property
+    def version(self) -> str:
+        return self.codex_cli_version
+
     def parse_response(self, stdout: str) -> dict:
         if not stdout:
             return {}
@@ -1123,7 +1127,7 @@ class CodexCliGenerator(QueryGenerator):
 
     def create_command(
         self, cli: str, prompt: str, env: dict = None, resume: bool = False,
-        session_id: str = None,
+        session_id: str = None, cwd: str = None,
     ) -> CLICommand:
         merged_env = self.env.copy()
         if env:

--- a/evalbench/generators/models/gemini_cli.py
+++ b/evalbench/generators/models/gemini_cli.py
@@ -1,4 +1,4 @@
-from .generator import QueryGenerator
+from .agent_cli import AgentCliGenerator
 from .tool_naming import canonicalize_gemini_tool_name
 import subprocess
 import os
@@ -20,7 +20,7 @@ class CLICommand:
         self.cwd = cwd
 
 
-class GeminiCliGenerator(QueryGenerator):
+class GeminiCliGenerator(AgentCliGenerator):
     """Generator queries using Gemini CLI."""
 
     def __init__(self, querygenerator_config):
@@ -1025,6 +1025,10 @@ class GeminiCliGenerator(QueryGenerator):
 
         return json.dumps(final_obj, indent=2)
 
+    @property
+    def version(self) -> str:
+        return self.gemini_cli_version
+
     def parse_response(self, stdout: str) -> dict:
         if not stdout:
             return {}
@@ -1083,7 +1087,8 @@ class GeminiCliGenerator(QueryGenerator):
         return result
 
     def create_command(
-        self, cli: str, prompt: str, env: dict = None, resume: bool = False, cwd: str = None
+        self, cli: str, prompt: str, env: dict = None, resume: bool = False,
+        session_id: str = None, cwd: str = None,
     ) -> CLICommand:
         merged_env = self.env.copy()
 


### PR DESCRIPTION
 ## Summary
  - Add `AgentCliGenerator` base class (ABC) that the four CLI generators
    (gemini_cli, claude_code, codex_cli, agy_cli) now inherit from, declaring
    the shared interface: `version`, `create_command`, `safe_generate`,
    `parse_response`, `extract_tools`, `extract_skills`.
  - Unify `create_command` to one signature across all four generators so the
    evaluator no longer branches on concrete type.
  - Simplify `AgentEvaluator`: collapse the four `isinstance(...4-tuple...)`
    checks to a single `isinstance(self.generator, AgentCliGenerator)`, replace
    the per-type version chain with `self.generator.version`, and drop all
    concrete CLI imports.

  ## Why
  Each new CLI generator previously required edits at ~6 sites in the evaluator.
  Keying off the base class makes adding a generator zero-touch in the evaluator,
  and the ABC enforces the interface at instantiation.

  ## Test plan
  - [x] `pytest test/agy_cli_test.py test/gemini_cli_test.py` — 52 passed
  - [x] All four subclasses report no remaining abstract methods
  - [x] `agentevaluator.py` imports cleanly, no concrete CLI references
  - [x] Dockerised run logs: https://paste.googleplex.com/4915247398912000 