### PR TITLE
docs: clarify agy CLI invocation, auth, and environment configuration in testing documentation

### DIFF
--- a/datasets/model_configs/agy_cli_model.yaml
+++ b/datasets/model_configs/agy_cli_model.yaml
@@ -21,12 +21,12 @@ env:
 setup:
   mcp_servers:
     "cloud-sql":
-      # agy's MCP schema names the HTTP endpoint field "serverUrl" (the
-      # Windsurf/cortex lineage), not gemini's "httpUrl". The binary's
-      # config struct has no httpUrl field, so an httpUrl value is parsed
-      # to a nil ServerUrl -- no transport, no tools, silent fallback to
-      # gcloud shell-outs. authProviderType/oauth/headers are all native
-      # agy fields, so Google auth works without Bearer-header injection.
+      # agy's native HTTP endpoint field is "serverUrl"; "url" also works
+      # as of v1.0.5. A gemini-style "httpUrl" is auto-translated to
+      # "serverUrl" by the harness (_translate_mcp_config), so it works
+      # too -- but prefer "serverUrl" here. authProviderType/oauth/headers
+      # are native agy fields, so Google auth works without Bearer-header
+      # injection.
       serverUrl: "https://sqladmin.googleapis.com/mcp"
       authProviderType: google_credentials
       oauth:

--- a/docs/agy_cli_agent_testing.md
+++ b/docs/agy_cli_agent_testing.md
@@ -308,7 +308,7 @@ for a working example.
 | Area | Gemini CLI | Antigravity (agy) |
 |------|-----------|--------------------|
 | Install | `npm install -g @google/gemini-cli@<ver>` | `curl install.sh \| sh -- --dir <bin>` |
-| Version pinning | NPM specifier in `gemini_cli_version` | None exposed; binary self-updates (set `AGY_CLI_DISABLE_AUTO_UPDATE=true` to freeze it, as the Docker image does) |
+| Version pinning | NPM specifier in `gemini_cli_version` | No pinning mechanism; the binary self-updates in the background. Set `AGY_CLI_DISABLE_AUTO_UPDATE=true` to freeze the installed version (the Docker image does this). |
 | Invocation | `npm exec --yes @google/gemini-cli@<ver> -- ...` | `agy ...` (bare binary) |
 | Non-interactive flag | `--yolo` / `--prompt` | `--dangerously-skip-permissions` and `-p` (alias `--print`) |
 | Output format | `--output-format stream-json` (NDJSON on stdout) | Plain text on stdout; structured tool-call data lives in the per-conversation transcript JSONL (see below) |

--- a/docs/agy_cli_agent_testing.md
+++ b/docs/agy_cli_agent_testing.md
@@ -234,16 +234,10 @@ the block under the `mcpServers` key of a sandboxed
 `settings.json`) and lets agy pick it up at startup.
 
 > [!IMPORTANT]
-> **Use `serverUrl` for the HTTP endpoint.** `serverUrl` is agy's native
-> transport field, and `url` also works as of
-> v1.0.5. A Gemini-style `httpUrl` works too, because EvalBench rewrites it
-> to `serverUrl` before writing the config (`_translate_mcp_config`) -- so
-> you never depend on agy parsing `httpUrl` natively. Prefer `serverUrl` for
-> clarity. An *unrecognized* URL
-> key is accepted silently and exposes zero tools, but the setup-time probe
-> (`_verify_mcp_runtime`, below) catches that. `authProviderType`,
-> `oauth.scopes`, and `headers` are native agy fields, so Google auth works
-> without Bearer-header injection (unlike `claude_code`).
+> **Use `serverUrl` for the HTTP endpoint** (`url` also works as of v1.0.5);
+> a Gemini-style `httpUrl` is auto-translated by the harness.
+> `authProviderType`, `oauth.scopes`, and `headers` are native agy fields, so
+> Google auth works without Bearer-header injection (unlike `claude_code`).
 
 The harness pre-verifies attach: at setup it runs
 a short `agy -p` probe, then confirms each configured server discovered
@@ -398,10 +392,9 @@ The harness pre-verifies attach at setup (`_verify_mcp_runtime`): it runs a
 short `agy -p` probe and fails fast with a `RuntimeError` if a configured
 server discovered no tools. If you hit that error:
 
-- **Check the URL field:** use `serverUrl` (native) or `url` (v1.0.5+);
-  a Gemini-style `httpUrl` is auto-translated by the harness. An
-  *unrecognized* URL key is accepted silently and exposes zero tools, so a
-  typo'd key looks like a load failure.
+- **Check the URL field** (see the MCP Servers callout above): a typo'd or
+  unrecognized URL key is accepted silently and exposes zero tools, so it
+  looks like a load failure.
 - Confirm the block lives under `mcpServers` in
   `<fake_home>/.gemini/config/mcp_config.json` (not `settings.json`) after
   setup runs.

--- a/docs/agy_cli_agent_testing.md
+++ b/docs/agy_cli_agent_testing.md
@@ -96,15 +96,15 @@ generator (gemini_cli, claude_code, codex_cli, agy_cli) is chosen via the
    The installer writes a SHA-512-verified native binary; it self-updates in
    the background and does not expose a pinning flag.
 
-   > [!NOTE]
-   > **The harness does not run this host binary.** `AgyCliGenerator`
-   > installs its own copy of `agy` per session into
-   > `<fake_home>/.local/bin` (see `_ensure_agy_installed`) and always
-   > launches that one, never the host `PATH` binary. Installing on the host
-   > is only needed for the one-time interactive login (next step) that
-   > seeds the OAuth token the harness mirrors into the sandbox.
-   > Per-session install keeps concurrent evals isolated and stops agy's
-   > background self-update from swapping the binary mid-run.
+> [!NOTE]
+> **The harness does not run this host binary.** `AgyCliGenerator`
+> installs its own copy of `agy` per session into
+> `<fake_home>/.local/bin` (see `_ensure_agy_installed`) and always
+> launches that one, never the host `PATH` binary. Installing on the host
+> is only needed for the one-time interactive login (next step) that
+> seeds the OAuth token the harness mirrors into the sandbox.
+> Per-session install keeps concurrent evals isolated and stops agy's
+> background self-update from swapping the binary mid-run.
 
 3. **GCP Authentication** (ADC -- for Google-auth MCP servers' outbound
    credentials; agy's own model backend uses the first-run OAuth token, not
@@ -239,15 +239,17 @@ load-error string and `json:"mcpServers"` struct tag) and lets agy pick it
 up at startup.
 
 > [!IMPORTANT]
-> **agy's HTTP transport field is `serverUrl`, not `httpUrl`.** This is the
-> Windsurf/cortex lineage; the binary has no `httpUrl` field, so a
-> Gemini-style `httpUrl` is parsed to a nil URL and the server attaches with
-> **no transport and zero tools** -- a silent failure that makes the agent
-> fall back to `gcloud` shell-outs. EvalBench auto-translates a `httpUrl`
-> alias to `serverUrl` (`_translate_mcp_config`), but prefer writing
-> `serverUrl` directly. `authProviderType`, `oauth.scopes`, and `headers`
-> are native agy fields, so Google auth works without Bearer-header
-> injection (unlike `claude_code`).
+> **Use `serverUrl` for the HTTP endpoint.** `serverUrl` is agy's native
+> transport field (the Windsurf/cortex lineage). `url` also works as of
+> v1.0.5 (release notes: "Added support for `url` in `mcp_config.json` to
+> configure MCP servers directly via a URL"). A Gemini-style `httpUrl` works
+> too, because EvalBench rewrites it to `serverUrl` before writing the
+> config (`_translate_mcp_config`) -- so you never depend on agy parsing
+> `httpUrl` natively. Prefer `serverUrl` for clarity. An *unrecognized* URL
+> key is accepted silently and exposes zero tools, but the setup-time probe
+> (`_verify_mcp_runtime`, below) catches that. `authProviderType`,
+> `oauth.scopes`, and `headers` are native agy fields, so Google auth works
+> without Bearer-header injection (unlike `claude_code`).
 
 Unlike older notes, the harness **does** pre-verify attach: at setup it runs
 a short `agy -p` probe, then confirms each configured server discovered
@@ -329,7 +331,7 @@ for a working example.
 | Skill management | `gemini skills <link\|install\|enable\|...>` subcommands | `agy plugin install <target>` (plugin manifests carry skills); no `agy skills` subcommand |
 | Extensions | Supported via `setup.extensions` | Not modeled; drop the block |
 | MCP config location | `mcpServers` in `settings.json` | `mcpServers` in a separate `~/.gemini/config/mcp_config.json` |
-| MCP HTTP transport field | `httpUrl` | `serverUrl` (no `httpUrl` field; `httpUrl` is auto-translated by the harness) |
+| MCP HTTP transport field | `httpUrl` | `serverUrl` (native); `url` also accepted as of v1.0.5; a Gemini-style `httpUrl` is auto-translated to `serverUrl` by the harness |
 | MCP tool name format | `mcp_<server>_<tool>` (single underscore) | No per-tool functions -- every MCP call goes through a single native `call_mcp_tool` wrapper whose args carry `ServerName`/`ToolName`/`Arguments`; the harness unwraps it to the canonical `<server>__<tool>` (see `canonicalize_agy_tool_name` in `tool_naming.py`) |
 | Model selection | `GEMINI_API_MODEL` / `GEMINI_MODEL` env var | `--model` flag (agy >=1.0.5); value is a UI label (e.g. `"Gemini 3.1 Pro (High)"`), not an API id |
 | Auth | NPM auth token via `gcloud auth print-access-token` plus ADC | OAuth (keyring-backed); ADC not required by agy itself |
@@ -405,8 +407,10 @@ The harness pre-verifies attach at setup (`_verify_mcp_runtime`): it runs a
 short `agy -p` probe and fails fast with a `RuntimeError` if a configured
 server discovered no tools. If you hit that error:
 
-- **Check the URL field first:** agy uses `serverUrl`, **not** `httpUrl`. A
-  wrong field is accepted silently and exposes zero tools.
+- **Check the URL field:** use `serverUrl` (native) or `url` (v1.0.5+);
+  a Gemini-style `httpUrl` is auto-translated by the harness. An
+  *unrecognized* URL key is accepted silently and exposes zero tools, so a
+  typo'd key looks like a load failure.
 - Confirm the block lives under `mcpServers` in
   `<fake_home>/.gemini/config/mcp_config.json` (not `settings.json`) after
   setup runs.

--- a/docs/agy_cli_agent_testing.md
+++ b/docs/agy_cli_agent_testing.md
@@ -1,6 +1,6 @@
 # Antigravity (agy) CLI Evaluation Guide
 
-This guide covers how to use EvalBench for evaluating Antigravity CLI (`agy`)
+This guide covers how to use EvalBench for evaluating [Antigravity CLI](https://antigravity.google/product/antigravity-cli) (`agy`)
 agent workflows using **MCP Servers** and **Skills**. It mirrors the structure
 of [`gemini_cli_agent_testing.md`](gemini_cli_agent_testing.md) and only calls
 out where the two harnesses differ.

--- a/docs/agy_cli_agent_testing.md
+++ b/docs/agy_cli_agent_testing.md
@@ -66,12 +66,7 @@ Run Config -> AgentOrchestrator -> AgentEvaluator -> AgyCliGenerator -> agy
                                               MCP servers / skills
 ```
 
-`evaluator/__init__.py` routes both the modern `agent` keyword and the
-legacy `geminicli` keyword to `AgentOrchestrator`
-(`orchestrator_type in ("geminicli", "agent")`); use `agent` for non-gemini
-CLIs. The keyword only selects the orchestrator -- the concrete CLI
-generator (gemini_cli, claude_code, codex_cli, agy_cli) is chosen via the
-`generator` field in `model_config`.
+The `orchestrator: agent` keyword in your run config selects the `AgentOrchestrator`, while the concrete CLI generator (`agy_cli`) is chosen via the `generator` field in your `model_config`.
 
 ---
 
@@ -94,9 +89,9 @@ generator (gemini_cli, claude_code, codex_cli, agy_cli) is chosen via the
    and does not expose a pinning flag.
 
 > [!NOTE]
-> **The harness does not run this host binary.** `AgyCliGenerator`
-> installs its own copy of `agy` per session into
-> `<fake_home>/.local/bin` (see `_ensure_agy_installed`) and always
+> **The harness does not run this host binary.** The testing harness
+> installs its own isolated copy of `agy` per session into
+> `<fake_home>/.local/bin` and always
 > launches that one, never the host `PATH` binary. Installing on the host
 > is only needed for the one-time interactive login (next step) that
 > seeds the OAuth token the harness mirrors into the sandbox.
@@ -198,7 +193,7 @@ reporting:
 > environment.** Set `GOOGLE_CLOUD_PROJECT` (and optionally
 > `GOOGLE_CLOUD_LOCATION`) in the `env` block as usual; the harness writes
 > them into agy's `<appDataDir>/settings.json` under `gcp.project` /
-> `gcp.location` (`_initialize_settings_file`), which is where agy actually
+> `gcp.location`, which is where agy actually
 > reads the project from. Without that block agy returns empty responses
 > and makes no tool calls even with the env var exported. Location defaults
 > to `global` when unset.
@@ -240,12 +235,10 @@ the block under the `mcpServers` key of a sandboxed
 > Google auth works without Bearer-header injection (unlike `claude_code`).
 
 The harness pre-verifies attach: at setup it runs
-a short `agy -p` probe, then confirms each configured server discovered
-tools by checking that agy wrote per-tool schema files to
-`<appDataDir>/mcp/<server>/*.json` (the lazy-load schema cache that
-`call_mcp_tool` reads). A server that attaches no tools raises a `RuntimeError`
-with the offending server name rather than silently degrading. See
-`_verify_mcp_runtime` in `agy_cli.py`.
+a short probe, then confirms each configured server discovered
+tools by checking that agy wrote the expected per-tool schema files to
+the local app data cache. A server that attaches no tools fails the evaluation
+with the offending server name rather than silently degrading.
 
 ### Skills
 
@@ -320,43 +313,18 @@ for a working example.
 | Extensions | Supported via `setup.extensions` | Not modeled; drop the block |
 | MCP config location | `mcpServers` in `settings.json` | `mcpServers` in a separate `~/.gemini/config/mcp_config.json` |
 | MCP HTTP transport field | `httpUrl` | `serverUrl` (native); `url` also accepted as of v1.0.5; a Gemini-style `httpUrl` is auto-translated to `serverUrl` by the harness |
-| MCP tool name format | `mcp_<server>_<tool>` (single underscore) | No per-tool functions -- every MCP call goes through a single native `call_mcp_tool` wrapper whose args carry `ServerName`/`ToolName`/`Arguments`; the harness unwraps it to the canonical `<server>__<tool>` (see `canonicalize_agy_tool_name` in `tool_naming.py`) |
+| MCP tool name format | `mcp_<server>_<tool>` (single underscore) | No per-tool functions -- every MCP call goes through a single native `call_mcp_tool` wrapper whose args carry `ServerName`/`ToolName`/`Arguments`; the harness unwraps it to the canonical `<server>__<tool>` |
 | Model selection | `GEMINI_API_MODEL` / `GEMINI_MODEL` env var | `--model` flag (agy >=1.0.5); value is a UI label (e.g. `"Gemini 3.1 Pro (High)"`), not an API id |
 | Auth | NPM auth token via `gcloud auth print-access-token` plus ADC | OAuth (keyring-backed); ADC not required by agy itself |
-| Token-usage stats | Reported per request | Not exposed; transcript carries no token counts (verified through agy v1.0.5). `token_consumption` is omitted from the agy example configs since it would only ever report zero |
+| Token-usage stats | Reported per request | Not exposed; transcript carries no token counts (verified through agy v1.0.5). See [Scorers](#scorers) for the `token_consumption` implication |
 
-### Tool-call extraction (transcript JSONL)
+### Tool-call extraction
 
-Since agy has no `--output-format stream-json`, the harness reads
-structured tool-call data out of the per-conversation transcript that
-agy writes to:
-
-```
-~/.gemini/antigravity-cli/brain/<uuid>/.system_generated/logs/transcript.jsonl
-```
-
-The conversation UUID for a given working directory is looked up in:
-
-```
-~/.gemini/antigravity-cli/cache/last_conversations.json
-```
-
-Each transcript line is a step with a `type` field. Tool invocations
-appear on `PLANNER_RESPONSE` steps as a `tool_calls` array; the
-immediately following MODEL step holds the result. Native tools get a
-result step typed after the tool (e.g. `VIEW_FILE`, `RUN_COMMAND`); an MCP
-call -- always the `call_mcp_tool` wrapper -- gets a dedicated `MCP_TOOL`
-result step. The final user-visible reply is the last `PLANNER_RESPONSE`
-with `content` (no `tool_calls`). When `--continue` is used the transcript
-accumulates across turns; the parser slices from the most-recent
-`USER_INPUT` step onward to report only the current turn.
-
-The parser binds each call to the result step that immediately follows the
-planner step that emitted it. A `call_mcp_tool` wrapper is counted as a
-successful MCP execution only when it is paired with a genuine `MCP_TOOL`
-result step; a wrapper with no result, or one paired with a non-MCP result,
-is marked failed. The authoritative guarantee that MCP is wired up is the
-setup-time schema-cache check (`_verify_mcp_runtime`).
+Since agy has no `--output-format stream-json`, the harness automatically
+extracts structured tool-call data by parsing agy's per-conversation transcript
+logs. It unwraps `call_mcp_tool` invocations into the canonical `<server>__<tool>`
+format, and correctly slices the transcript to report only the current turn
+even when session resuming (`--continue`) is used.
 
 ---
 
@@ -365,8 +333,12 @@ setup-time schema-cache check (`_verify_mcp_runtime`).
 Identical to Gemini CLI -- see the
 [scorers section of the Gemini guide](gemini_cli_agent_testing.md#scorers).
 The `trajectory_matcher` default of dropping native/harness-internal tools
-also applies; the canonical-name rule it uses (`<server>__<tool>`) lives in
-`evalbench/generators/models/tool_naming.py`.
+also applies.
+
+> [!NOTE]
+> **`token_consumption` is omitted from the agy example configs.** agy's
+> transcript exposes no token-usage data, so the scorer would only ever
+> report 0. Re-add it if agy starts emitting usage data.
 
 ---
 
@@ -388,8 +360,8 @@ at a directory on your `PATH`, or symlink the binary into one.
 
 ### MCP Server Doesn't Attach
 
-The harness pre-verifies attach at setup (`_verify_mcp_runtime`): it runs a
-short `agy -p` probe and fails fast with a `RuntimeError` if a configured
+The harness pre-verifies attach at setup: it runs a
+short probe and fails fast if a configured
 server discovered no tools. If you hit that error:
 
 - **Check the URL field** (see the MCP Servers callout above): a typo'd or

--- a/docs/agy_cli_agent_testing.md
+++ b/docs/agy_cli_agent_testing.md
@@ -6,14 +6,11 @@ of [`gemini_cli_agent_testing.md`](gemini_cli_agent_testing.md) and only calls
 out where the two harnesses differ.
 
 > **Status:** the agy CLI surface targeted here was verified against the
-> v1.0.5 binary (the self-updating installer pulls the latest). Model
-> selection is passed via agy's `--model` flag, and the value must be the
-> exact agy UI label (see the model-selection note below and the comment in
-> `datasets/model_configs/agy_cli_model.yaml`).
+> v1.0.5 binary (the self-updating installer pulls the latest).
 
 > [!IMPORTANT]
 > **First-run auth:** agy uses an OAuth consumer flow backed by the system
-> keyring (file-backed under SSH). Before evals can run, complete `agy`
+> keyring. Before evals can run, complete `agy`
 > login interactively at least once on the host so a refreshable token
 > exists. After that, the harness can run non-interactively.
 
@@ -93,8 +90,8 @@ generator (gemini_cli, claude_code, codex_cli, agy_cli) is chosen via the
    agy --version  # sanity check
    ```
 
-   The installer writes a SHA-512-verified native binary; it self-updates in
-   the background and does not expose a pinning flag.
+   The installer writes a native binary; it self-updates in the background
+   and does not expose a pinning flag.
 
 > [!NOTE]
 > **The harness does not run this host binary.** `AgyCliGenerator`
@@ -234,24 +231,21 @@ identical baseline.
 Configured under `setup.mcp_servers` in the model config. EvalBench writes
 the block under the `mcpServers` key of a sandboxed
 `<fake_home>/.gemini/config/mcp_config.json` (a separate file from
-`settings.json`; both path and key are confirmed from the v1.0.5 binary's
-load-error string and `json:"mcpServers"` struct tag) and lets agy pick it
-up at startup.
+`settings.json`) and lets agy pick it up at startup.
 
 > [!IMPORTANT]
 > **Use `serverUrl` for the HTTP endpoint.** `serverUrl` is agy's native
-> transport field (the Windsurf/cortex lineage). `url` also works as of
-> v1.0.5 (release notes: "Added support for `url` in `mcp_config.json` to
-> configure MCP servers directly via a URL"). A Gemini-style `httpUrl` works
-> too, because EvalBench rewrites it to `serverUrl` before writing the
-> config (`_translate_mcp_config`) -- so you never depend on agy parsing
-> `httpUrl` natively. Prefer `serverUrl` for clarity. An *unrecognized* URL
+> transport field, and `url` also works as of
+> v1.0.5. A Gemini-style `httpUrl` works too, because EvalBench rewrites it
+> to `serverUrl` before writing the config (`_translate_mcp_config`) -- so
+> you never depend on agy parsing `httpUrl` natively. Prefer `serverUrl` for
+> clarity. An *unrecognized* URL
 > key is accepted silently and exposes zero tools, but the setup-time probe
 > (`_verify_mcp_runtime`, below) catches that. `authProviderType`,
 > `oauth.scopes`, and `headers` are native agy fields, so Google auth works
 > without Bearer-header injection (unlike `claude_code`).
 
-Unlike older notes, the harness **does** pre-verify attach: at setup it runs
+The harness pre-verifies attach: at setup it runs
 a short `agy -p` probe, then confirms each configured server discovered
 tools by checking that agy wrote per-tool schema files to
 `<appDataDir>/mcp/<server>/*.json` (the lazy-load schema cache that
@@ -363,15 +357,12 @@ with `content` (no `tool_calls`). When `--continue` is used the transcript
 accumulates across turns; the parser slices from the most-recent
 `USER_INPUT` step onward to report only the current turn.
 
-The parser binds each call only to the result step that immediately follows
-the planner step that emitted it (strict adjacency); the pending window resets
-at every planner step and any intervening step, so a call that never produced
-an adjacent result step is not credited with a later call's result. As a guard against forged transcript lines, a `call_mcp_tool`
-wrapper is only counted as a successful MCP execution when it is paired with
-a genuine `MCP_TOOL` result step; a wrapper with no result, or one paired
-with a non-MCP result, is marked failed. This bounds but cannot fully
-prevent crediting forged lines -- the authoritative guarantee that MCP is
-wired up is the setup-time schema-cache check (`_verify_mcp_runtime`).
+The parser binds each call to the result step that immediately follows the
+planner step that emitted it. A `call_mcp_tool` wrapper is counted as a
+successful MCP execution only when it is paired with a genuine `MCP_TOOL`
+result step; a wrapper with no result, or one paired with a non-MCP result,
+is marked failed. The authoritative guarantee that MCP is wired up is the
+setup-time schema-cache check (`_verify_mcp_runtime`).
 
 ---
 
@@ -421,8 +412,6 @@ server discovered no tools. If you hit that error:
   (used for outbound credentials to the MCP server -- agy's own auth is
   separate OAuth).
 - Verify OAuth scopes and project ID in the headers.
-- If you suspect the path or key is wrong, search the agy binary with
-  `strings <agy-binary> | grep -i mcp_config` to confirm what it reads.
 
 ### Skill Not Picked Up
 

--- a/docs/agy_cli_agent_testing.md
+++ b/docs/agy_cli_agent_testing.md
@@ -291,7 +291,7 @@ for a working example.
 | Area | Gemini CLI | Antigravity (agy) |
 |------|-----------|--------------------|
 | Install | `npm install -g @google/gemini-cli@<ver>` | `curl install.sh \| sh -- --dir <bin>` |
-| Version pinning | NPM specifier in `gemini_cli_version` | No pinning mechanism; the latest binary is installed dynamically at runtime. Set `AGY_CLI_DISABLE_AUTO_UPDATE=true` to freeze the installed version (the Docker image does this). |
+| Version pinning | NPM specifier in `gemini_cli_version` | No pinning mechanism; the latest binary is installed dynamically at runtime. |
 | Invocation | `npm exec --yes @google/gemini-cli@<ver> -- ...` | `agy ...` (bare binary) |
 | Non-interactive flag | `--yolo` / `--prompt` | `--dangerously-skip-permissions` and `-p` (alias `--print`) |
 | Output format | `--output-format stream-json` (NDJSON on stdout) | Plain text on stdout; structured tool-call data lives in the per-conversation transcript JSONL (see below) |

--- a/docs/agy_cli_agent_testing.md
+++ b/docs/agy_cli_agent_testing.md
@@ -291,7 +291,7 @@ for a working example.
 | Area | Gemini CLI | Antigravity (agy) |
 |------|-----------|--------------------|
 | Install | `npm install -g @google/gemini-cli@<ver>` | `curl install.sh \| sh -- --dir <bin>` |
-| Version pinning | NPM specifier in `gemini_cli_version` | No pinning mechanism; the binary self-updates in the background. Set `AGY_CLI_DISABLE_AUTO_UPDATE=true` to freeze the installed version (the Docker image does this). |
+| Version pinning | NPM specifier in `gemini_cli_version` | No pinning mechanism; the latest binary is installed dynamically at runtime. Set `AGY_CLI_DISABLE_AUTO_UPDATE=true` to freeze the installed version (the Docker image does this). |
 | Invocation | `npm exec --yes @google/gemini-cli@<ver> -- ...` | `agy ...` (bare binary) |
 | Non-interactive flag | `--yolo` / `--prompt` | `--dangerously-skip-permissions` and `-p` (alias `--print`) |
 | Output format | `--output-format stream-json` (NDJSON on stdout) | Plain text on stdout; structured tool-call data lives in the per-conversation transcript JSONL (see below) |

--- a/docs/agy_cli_agent_testing.md
+++ b/docs/agy_cli_agent_testing.md
@@ -5,9 +5,6 @@ agent workflows using **MCP Servers** and **Skills**. It mirrors the structure
 of [`gemini_cli_agent_testing.md`](gemini_cli_agent_testing.md) and only calls
 out where the two harnesses differ.
 
-> **Status:** the agy CLI surface targeted here was verified against the
-> v1.0.5 binary (the self-updating installer pulls the latest).
-
 > [!IMPORTANT]
 > **First-run auth:** agy uses an OAuth consumer flow backed by the system
 > keyring. Before evals can run, complete `agy`

--- a/docs/agy_cli_agent_testing.md
+++ b/docs/agy_cli_agent_testing.md
@@ -155,7 +155,7 @@ non-gemini CLIs.
 | `model_config` | Yes | Path to the agy CLI model config YAML |
 | `simulated_user_model_config` | Yes | Path to the model config for the simulated user LLM |
 | `scorers` | Yes | Dictionary of scorer configurations |
-| `reporting` | Optional | CSV and/or BigQuery output options |
+| `reporting` | Yes | CSV and/or BigQuery output options |
 
 **Example** ([example_run_config.yaml](/datasets/agy-cli-tools/example_run_config.yaml)):
 
@@ -189,14 +189,7 @@ reporting:
 | `setup` | Optional | Tool setup block containing `mcp_servers`, `skills`, or `fake_mcp_servers` |
 
 > [!IMPORTANT]
-> **agy reads its Vertex project from `settings.json`, not the
-> environment.** Set `GOOGLE_CLOUD_PROJECT` (and optionally
-> `GOOGLE_CLOUD_LOCATION`) in the `env` block as usual; the harness writes
-> them into agy's `<appDataDir>/settings.json` under `gcp.project` /
-> `gcp.location`, which is where agy actually
-> reads the project from. Without that block agy returns empty responses
-> and makes no tool calls even with the env var exported. Location defaults
-> to `global` when unset.
+> **Explicit Project Configuration Required:** agy does not read GCP project details from the host environment. You **must** explicitly set `GOOGLE_CLOUD_PROJECT` and `GOOGLE_CLOUD_LOCATION` in the `env` block of your model config. If omitted, agy will return empty responses and fail to make tool calls, even if those variables are exported in your shell.
 
 > [!NOTE]
 > **Model selection uses the `--model` flag; use a UI label.** The harness

--- a/docs/agy_cli_agent_testing.md
+++ b/docs/agy_cli_agent_testing.md
@@ -385,9 +385,12 @@ server discovered no tools. If you hit that error:
   `<fake_home>/.gemini/config/plugins/<name>/` was materialized after
   setup runs. The setup log line `agy registered plugins: [...]` reports
   what `agy plugin install` recorded.
-- If `agy plugin install` failed, check the logged `rc=` and stderr --
-  a bad target (wrong path, missing `plugin.json` manifest, unreachable
-  git URL) is the usual cause.
+- If `agy plugin install` failed, the harness logs an `agy plugin install
+  '<target>' failed` line with the install command's exit code and stderr --
+  read that line for the reason. A bad target is the usual cause: a wrong
+  path, an unreachable git URL, or a directory with no valid plugin manifest
+  (agy accepts Claude/Gemini/Codex manifest formats, e.g. `plugin.json` or
+  `gemini-extension.json`).
 - If you have an `action: link` / `enable` / `install` entry in your
   config, drop it -- those gemini-cli-style actions are not supported
   here and are logged-and-skipped. Use a string target or

--- a/docs/agy_cli_agent_testing.md
+++ b/docs/agy_cli_agent_testing.md
@@ -69,9 +69,12 @@ Run Config -> AgentOrchestrator -> AgentEvaluator -> AgyCliGenerator -> agy
                                               MCP servers / skills
 ```
 
-The dispatch keyword in `evaluator/__init__.py` is still `geminicli`; that
-string covers all agent-style CLI generators (gemini_cli, claude_code,
-codex_cli, agy_cli). The concrete CLI is chosen via `model_config`.
+`evaluator/__init__.py` routes both the modern `agent` keyword and the
+legacy `geminicli` keyword to `AgentOrchestrator`
+(`orchestrator_type in ("geminicli", "agent")`); use `agent` for non-gemini
+CLIs. The keyword only selects the orchestrator -- the concrete CLI
+generator (gemini_cli, claude_code, codex_cli, agy_cli) is chosen via the
+`generator` field in `model_config`.
 
 ---
 
@@ -83,7 +86,7 @@ codex_cli, agy_cli). The concrete CLI is chosen via `model_config`.
    uv sync
    ```
 
-2. **Antigravity CLI installed and on `PATH`**:
+2. **Antigravity CLI installed (for the one-time interactive auth)**:
    ```bash
    curl -fsSL https://antigravity.google/cli/install.sh | sh -s -- --dir ~/.local/bin
    export PATH="$HOME/.local/bin:$PATH"
@@ -91,11 +94,21 @@ codex_cli, agy_cli). The concrete CLI is chosen via `model_config`.
    ```
 
    The installer writes a SHA-512-verified native binary; it self-updates in
-   the background and does not expose a pinning flag. The Docker image at
-   `evalbench_service/Dockerfile` does the equivalent install into
-   `/usr/local/bin`.
+   the background and does not expose a pinning flag.
 
-3. **GCP Authentication** (for Vertex AI models and MCP servers):
+   > [!NOTE]
+   > **The harness does not run this host binary.** `AgyCliGenerator`
+   > installs its own copy of `agy` per session into
+   > `<fake_home>/.local/bin` (see `_ensure_agy_installed`) and always
+   > launches that one, never the host `PATH` binary. Installing on the host
+   > is only needed for the one-time interactive login (next step) that
+   > seeds the OAuth token the harness mirrors into the sandbox.
+   > Per-session install keeps concurrent evals isolated and stops agy's
+   > background self-update from swapping the binary mid-run.
+
+3. **GCP Authentication** (ADC -- for Google-auth MCP servers' outbound
+   credentials; agy's own model backend uses the first-run OAuth token, not
+   ADC):
    ```bash
    gcloud auth application-default login
    ```
@@ -183,19 +196,24 @@ reporting:
 | `env` | Optional | Environment variables passed to the CLI process |
 | `setup` | Optional | Tool setup block containing `mcp_servers`, `skills`, or `fake_mcp_servers` |
 
+> [!IMPORTANT]
+> **agy reads its Vertex project from `settings.json`, not the
+> environment.** Set `GOOGLE_CLOUD_PROJECT` (and optionally
+> `GOOGLE_CLOUD_LOCATION`) in the `env` block as usual; the harness writes
+> them into agy's `<appDataDir>/settings.json` under `gcp.project` /
+> `gcp.location` (`_initialize_settings_file`), which is where agy actually
+> reads the project from. Without that block agy returns empty responses
+> and makes no tool calls even with the env var exported. Location defaults
+> to `global` when unset.
+
 > [!NOTE]
 > **Model selection uses the `--model` flag; use a UI label.** The harness
 > passes the configured `model` via agy's `--model` flag (agy >=1.0.5). The
 > value must be the **exact agy UI label** (e.g. `"Gemini 3.1 Pro (High)"`,
 > `"Gemini 3.5 Flash (Medium)"`), not an API id like `gemini-2.5-pro` -- an
 > unrecognized value is silently ignored and agy falls back to its default
-> model. List the valid labels with `agy models`. A non-interactive `agy -p`
-> run honors the label (the backend log shows `Propagating selected model
-> override to backend: label="..."`), even though the unrelated
-> `FetchAvailableModels` poll may fail on project-auth accounts. Omit the key
-> to leave the flag off, so agy uses its own default model. Note: the
-> transcript never echoes the real model, so the EvalBench stats bucket is
-> keyed by the configured label (or `agy` when unset).
+> model. List the valid labels with `agy models`. Omit the key to leave the
+> flag off, so agy uses its own default model.
 
 ---
 
@@ -300,7 +318,7 @@ for a working example.
 | Area | Gemini CLI | Antigravity (agy) |
 |------|-----------|--------------------|
 | Install | `npm install -g @google/gemini-cli@<ver>` | `curl install.sh \| sh -- --dir <bin>` |
-| Version pinning | NPM specifier in `gemini_cli_version` | None exposed; binary self-updates |
+| Version pinning | NPM specifier in `gemini_cli_version` | None exposed; binary self-updates (set `AGY_CLI_DISABLE_AUTO_UPDATE=true` to freeze it, as the Docker image does) |
 | Invocation | `npm exec --yes @google/gemini-cli@<ver> -- ...` | `agy ...` (bare binary) |
 | Non-interactive flag | `--yolo` / `--prompt` | `--dangerously-skip-permissions` and `-p` (alias `--print`) |
 | Output format | `--output-format stream-json` (NDJSON on stdout) | Plain text on stdout; structured tool-call data lives in the per-conversation transcript JSONL (see below) |
@@ -376,8 +394,10 @@ BigQuery under `reporting.bigquery.gcp_project_id`.
 
 ### `agy: command not found`
 
-The CLI is not on `PATH`. Re-run the installer with `--dir` pointing at a
-directory that's on your `PATH`, or symlink the binary into one.
+This affects the **host** `agy` command -- used for the first-run auth and
+for `agy models` / `agy --version` -- not the eval run, which launches the
+harness's own per-session binary. Re-run the installer with `--dir` pointing
+at a directory on your `PATH`, or symlink the binary into one.
 
 ### MCP Server Doesn't Attach
 

--- a/evalbench/generators/models/agy_cli.py
+++ b/evalbench/generators/models/agy_cli.py
@@ -38,10 +38,7 @@ class AgyCliGenerator(QueryGenerator):
     ``agy -p <prompt> --dangerously-skip-permissions [--model <label>]
     [--continue]``. The on-disk layout lives under
     ``~/.gemini/antigravity-cli/`` (the binary calls this ``appDataDir``).
-    Skills are delivered via plugins: ``agy plugin install <target>`` reads a
-    plugin manifest (Claude/Gemini/Codex formats), materializes any bundled
-    skills under ``<HOME>/.gemini/config/plugins/<name>/`` and records the
-    install in ``<HOME>/.gemini/config/import_manifest.json``. There is no
+    Skills are delivered via plugins (see _setup_skills). There is no
     ``--output-format`` flag and no stdout stream protocol; structured
     tool-call data is read out of the per-conversation JSONL transcript at
     ``<appDataDir>/brain/<uuid>/.system_generated/logs/transcript.jsonl``.
@@ -54,21 +51,15 @@ class AgyCliGenerator(QueryGenerator):
         self.name = "agy_cli"
 
         # Parity with gemini_cli_version/codex_cli_version/claude_code_version:
-        # the evaluator reads this as agent_version. agy has no version pinning
-        # (the binary self-updates), so this is fixed to the bare command name
-        # as a stable label and is intentionally not config-overridable. The
-        # executable actually launched is the per-session install at
-        # self.agy_bin (see _ensure_agy_installed), not this value.
+        # the evaluator reads this as agent_version. Fixed to the bare command
+        # name (see AGY_CLI) and intentionally not config-overridable.
         self.agy_cli_version = AGY_CLI
 
         self.env = querygenerator_config.get("env") or {}
 
-        # Top-level `model` key. Passed per-invocation via agy's `--model`
-        # flag (agy >=1.0.5) -- see _base_agy_command. The value must be the
-        # exact agy UI label (e.g. "Gemini 3.1 Pro (High)", as listed by
-        # `agy models`), not an API id; an unrecognized value is silently
-        # ignored and agy falls back to its default model. None -> the flag is
-        # omitted and agy uses its default.
+        # Top-level `model` key, applied per-invocation via agy's `--model`
+        # flag (None -> flag omitted). See _base_agy_command for the value
+        # format and resolution semantics.
         self.model = querygenerator_config.get("model")
 
         # Order is load-bearing: paths/dirs must exist before the binary
@@ -952,10 +943,7 @@ class AgyCliGenerator(QueryGenerator):
         per-conversation JSONL transcript that agy writes under
         ``<appDataDir>/brain/<uuid>/.system_generated/logs/``.
 
-        Only the most-recent turn is reported -- the transcript
-        accumulates across turns when ``--continue`` is used, so the
-        slice from the last ``USER_INPUT`` step onward is the new
-        material from this invocation.
+        Only the most-recent turn is reported (see _slice_current_turn).
         """
         # Transcripts don't carry token counts; downstream
         # token_consumption scorers will see zeros.

--- a/evalbench/generators/models/agy_cli.py
+++ b/evalbench/generators/models/agy_cli.py
@@ -514,7 +514,8 @@ class AgyCliGenerator(QueryGenerator):
                 f"agy MCP server(s) {failed} attached no tools "
                 f"(no schemas under {mcp_schema_root}/<server>/). The "
                 "server likely failed to load -- check the URL field "
-                "(agy uses 'serverUrl', not 'httpUrl'), auth, and "
+                "(use 'serverUrl' or 'url'; a gemini-style 'httpUrl' is "
+                "auto-translated), auth, and "
                 "reachability. agy degrades silently to shell-outs when "
                 "MCP tools are missing."
             )
@@ -754,9 +755,11 @@ class AgyCliGenerator(QueryGenerator):
     def _translate_mcp_config(config: dict) -> dict:
         """Normalizes a cross-harness MCP server config into agy's schema.
 
-        Maps the common gemini-style ``httpUrl`` alias to ``serverUrl``, which
-        agy reliably accepts. Other fields like ``authProviderType``,
-        ``oauth.scopes``, and stdio fields pass through natively.
+        Maps the common gemini-style ``httpUrl`` alias to ``serverUrl``, agy's
+        native field. ``serverUrl`` and ``url`` (v1.0.5+) are accepted by agy
+        directly and need no translation. Other fields like
+        ``authProviderType``, ``oauth.scopes``, and stdio fields pass through
+        natively.
         """
         if "httpUrl" in config and "serverUrl" not in config:
             config["serverUrl"] = config.pop("httpUrl")

--- a/evalbench/test/agy_cli_test.py
+++ b/evalbench/test/agy_cli_test.py
@@ -894,7 +894,8 @@ def test_verify_mcp_runtime_unreadable_probe_log_does_not_mask_failure(
 
 def test_translate_mcp_config_maps_httpurl_to_serverurl():
     """The gemini-style ``httpUrl`` alias is rewritten to agy's ``serverUrl``
-    (a wrong URL field attaches a transportless server with zero tools)."""
+    (left untranslated, agy ignores it and attaches a transportless server
+    with zero tools)."""
     out = AgyCliGenerator._translate_mcp_config({"httpUrl": "https://x/mcp"})
 
     assert out == {"serverUrl": "https://x/mcp"}


### PR DESCRIPTION
**Summary**
This PR updates the Antigravity (agy) CLI evaluation documentation, model configs, and generator code to clarify setup requirements, authentication, and MCP server configuration.

**Key Changes**
* **Execution & Auth:** Clarified that the testing harness installs an isolated copy of agy per session to prevent background updates from swapping the binary mid-run. Also noted that the host installation is only needed for the one-time interactive login to seed the OAuth token.
* **Environment Configuration:** Added a requirement to explicitly set `GOOGLE_CLOUD_PROJECT` and `GOOGLE_CLOUD_LOCATION` in the `env` block of the model config, as agy does not read these from the host environment.
* **MCP Server Setup:** Updated docs and config comments to specify that agy's native HTTP endpoint field is `serverUrl` (or `url` as of v1.0.5). A Gemini-style `httpUrl` alias is still auto-translated to `serverUrl` by the harness.
* **Troubleshooting:** Expanded guidance on "command not found" errors and MCP server attach failures, clarifying that the harness pre-verifies tool discovery at setup.
* **Clean-up:** Updated related Python generator comments and test docstrings to align with the v1.0.5 behavior.
