### PR TITLE
fix: pin pyopenssl<26.2 to avoid google-auth mTLS regression

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,11 @@ dependencies = [
     "dbt-bigquery",
     "dbt-postgres",
     "a2a-sdk>=1.0.3",
+    # 26.2.0 turned a long-standing deprecation into a hard error
+    # (mutating SSL.Context after use), breaking google-auth's mTLS path
+    # (urllib3.contrib.pyopenssl.inject_into_urllib3). Lift when google-auth
+    # stops using the deprecated inject pattern.
+    "pyOpenSSL<26.2",
 ]
 
 [tool.uv.sources]

--- a/uv.lock
+++ b/uv.lock
@@ -1800,7 +1800,7 @@ wheels = [
 
 [[package]]
 name = "google-evalbench"
-version = "1.7.1"
+version = "1.8.0"
 source = { editable = "." }
 dependencies = [
     { name = "a2a-sdk" },
@@ -1835,6 +1835,7 @@ dependencies = [
     { name = "pyarrow" },
     { name = "pymongo" },
     { name = "pymysql" },
+    { name = "pyopenssl" },
     { name = "ratelimit" },
     { name = "redis" },
     { name = "rich" },
@@ -1886,6 +1887,7 @@ requires-dist = [
     { name = "pyarrow" },
     { name = "pymongo" },
     { name = "pymysql" },
+    { name = "pyopenssl", specifier = "<26.2" },
     { name = "ratelimit" },
     { name = "redis" },
     { name = "rich" },


### PR DESCRIPTION
## Summary

- Pin `pyopenssl<26.2` in `pyproject.toml` to work around a regression introduced in pyopenssl `26.2.0` (2026-05-04).
- The resolver picks `26.1.0` after the pin — confirmed to avoid the breakage.

## Why

pyopenssl `26.2.0` ([changelog](https://github.com/pyca/pyopenssl/blob/main/CHANGELOG.rst)) turned a long-standing deprecation into a hard error:

> It is now an error to calling any mutating method on `OpenSSL.SSL.Context` after it has been used to create a `Connection`. This was previously deprecated and has always been unsafe.

That change breaks google-auth's mTLS code path (`urllib3.contrib.pyopenssl.inject_into_urllib3` — urllib3 then mutates `verify_mode` after the context is already in use). Users on Google corp machines with DCA certs hit `ValueError: Context has already been used to create a Connection, it cannot be mutated again` during Vertex AI `generate_content` calls, silently degrading LLM scoring quality (e.g. `llmrater: 2/4` instead of `4/4`).

## How verified

`uvx --refresh --with 'pyOpenSSL<26.2' google-evalbench@1.8.0 ...` completes cleanly with no traceback and full scoring — confirms the pin is sufficient.

## Lift condition

Remove the pin once google-auth stops using the deprecated `urllib3.contrib.pyopenssl.inject_into_urllib3()` pattern. Upstream issue to file: `googleapis/google-auth-library-python`.