### PR TITLE
feat: add Antigravity agent tab and update CLI version retrieval logic

### DIFF
--- a/viewer/main.py
+++ b/viewer/main.py
@@ -296,6 +296,7 @@ def status_component():
                 me.ButtonToggleButton(label="Gemini", value="Gemini"),
                 me.ButtonToggleButton(label="Claude", value="Claude"),
                 me.ButtonToggleButton(label="Codex", value="Codex"),
+                me.ButtonToggleButton(label="Antigravity", value="Antigravity"),
             ],
             on_change=on_agent_tab_change,
         )
@@ -367,6 +368,8 @@ def status_component():
                     summary_df = summary_df[(summary_df['model_config.generator'] == 'claude_code') | (summary_df['model_config.generator'] == 'unknown') | (summary_df['model_config.generator'] == 'N/A')]
                 elif state.status_agent_tab == "Codex":
                     summary_df = summary_df[(summary_df['model_config.generator'] == 'codex_cli')]
+                elif state.status_agent_tab == "Antigravity":
+                    summary_df = summary_df[(summary_df['model_config.generator'] == 'agy_cli')]
                 
                 # Render table similar to lists tab
                 with me.box(
@@ -580,6 +583,7 @@ def list_view_component(directories, results_dir):
                 me.ButtonToggleButton(label="Gemini", value="Gemini"),
                 me.ButtonToggleButton(label="Claude", value="Claude"),
                 me.ButtonToggleButton(label="Codex", value="Codex"),
+                me.ButtonToggleButton(label="Antigravity", value="Antigravity"),
             ],
             on_change=on_list_agent_tab_change,
         )
@@ -747,6 +751,8 @@ def list_view_component(directories, results_dir):
                 summaries = [x for x in summaries if x.get("model_config.generator") == "claude_code" or (x.get("model_config.generator") == "unknown" and 'claude' in str(x.get("product")).lower())]
             elif state.list_agent_tab == "Codex":
                 summaries = [x for x in summaries if x.get("model_config.generator") == "codex_cli"]
+            elif state.list_agent_tab == "Antigravity":
+                summaries = [x for x in summaries if x.get("model_config.generator") == "agy_cli"]
             logging.info(f"Number of summaries after tab filter: {len(summaries)}")
 
             if state.eval_id_filter:
@@ -2221,7 +2227,13 @@ def render_app_content():
                             
                         product = get_val('experiment_config.product_name')
                         requester = get_val('experiment_config.experiment_config.guitar_requester')
-                        cli_version = get_val('model_config.gemini_cli_version')
+                        cli_version = (
+                            get_val('model_config.gemini_cli_version')
+                            or get_val('model_config.claude_code_version')
+                            or get_val('model_config.codex_cli_version')
+                        )
+                        if not cli_version and get_val('model_config.generator') == 'agy_cli':
+                            cli_version = 'agy (latest)'
                         orchestrator = get_val('experiment_config.orchestrator')
                         eval_group = get_val('experiment_config.eval_group')
                         

--- a/viewer/trends.py
+++ b/viewer/trends.py
@@ -186,6 +186,8 @@ def trends_component():
         df = df[df['model_config.generator'].str.contains('claude', case=False) | ((df['model_config.generator'] == 'unknown') & df['product'].str.contains('claude', case=False))]
     elif state.trends_agent_tab == "Codex":
         df = df[df['model_config.generator'].str.contains('codex', case=False)]
+    elif state.trends_agent_tab == "Antigravity":
+        df = df[df['model_config.generator'].str.contains('agy', case=False)]
 
     # Extract unique products for dropdown
     all_products = sorted(df['product'].unique().tolist())
@@ -233,6 +235,7 @@ def trends_component():
                 me.ButtonToggleButton(label="Gemini", value="Gemini"),
                 me.ButtonToggleButton(label="Claude", value="Claude"),
                 me.ButtonToggleButton(label="Codex", value="Codex"),
+                me.ButtonToggleButton(label="Antigravity", value="Antigravity"),
             ],
             on_change=on_trends_agent_tab_change,
         )

--- a/viewer/trends.py
+++ b/viewer/trends.py
@@ -152,7 +152,7 @@ def trends_component():
                         'requester': requester,
                         'product': product,
                         'dataset': dataset,
-                        'generator': generator,
+                        'model_config.generator': generator,
                         'latency': latency,
                         'tokens': tokens,
                         'trajectory': trajectory,


### PR DESCRIPTION
## Summary

  Adds the Antigravity (agy CLI) harness to the Viewer dashboard with full parity to the existing
  Gemini/Claude/Codex harnesses, filtering on model_config.generator == "agy_cli".

  ## Changes

  - Status tab (viewer/main.py): new "Antigravity" toggle button + generator filter.
  - List tab (viewer/main.py): new "Antigravity" toggle button + generator filter.
  - Charts/Trends tab (viewer/trends.py): new "Antigravity" toggle button + generator filter.
  - CLI Version field (viewer/main.py): now falls back across gemini_cli_version →
  claude_code_version → codex_cli_version so Codex/Claude versions surface too. Since agy can't be
  version-pinned (its installer always pulls the latest and the binary self-updates), agy runs show
   a static agy (latest) label instead.

 ##  Notes

  - agy intentionally has no version field in the model config, hence the static label.
  - No backend/eval changes; this is Viewer UI only.

  ## Test plan

  - Antigravity tab appears in Status, List, and Charts views and filters to agy_cli runs.
  - An agy run shows agy (latest) in the CLI Version field.
  - Gemini/Claude/Codex tabs and version display unchanged.
  - Local UI testing: https://screenshot.googleplex.com/4mjwB6GTgipHzpM 