### PR TITLE
Package DEA scenarios in one request for sequential execution

### DIFF
--- a/datasets/dea-tools/README.md
+++ b/datasets/dea-tools/README.md
@@ -19,14 +19,16 @@ To run the evaluation, make sure you are in the root directory of the `evalbench
 PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION=python \
 EVAL_GCP_PROJECT_ID=<YOUR_GCP_PROJECT_ID> \
 EVAL_GCP_PROJECT_REGION=<YOUR_GCP_REGION> \
-EVAL_DEA_WORKSPACE="projects/<YOUR_GCP_PROJECT_ID>/locations/<YOUR_GCP_REGION>/repositories/<YOUR_REPO_NAME>/workspaces/<YOUR_WORKSPACE_NAME>" \
+EVAL_DEA_REPOSITORY=<YOUR_REPO_NAME> \
+EVAL_DEA_WORKSPACE=<YOUR_WORKSPACE_NAME> \
 .venv/bin/python3 evalbench/evalbench.py --experiment_config=datasets/dea-tools/example_run_config.yaml
 ```
 
 ### Key Environment Variables:
 *   `EVAL_GCP_PROJECT_ID`: The GCP Project ID where your DEA agent is deployed.
 *   `EVAL_GCP_PROJECT_REGION`: The GCP Region (e.g., `us-west4`) of the agent.
-*   `EVAL_DEA_WORKSPACE`: The fully qualified resource path to the Dataform workspace where the agent will execute actions.
+*   `EVAL_DEA_REPOSITORY`: The target Dataform repository name.
+*   `EVAL_DEA_WORKSPACE`: The target Dataform workspace name.
 
 ## 4. Inspect Results
 Upon completion, results will be generated under the `results/` folder:

--- a/datasets/dea-tools/dea-live-conversational.evalset.json
+++ b/datasets/dea-tools/dea-live-conversational.evalset.json
@@ -3,14 +3,19 @@
     {
       "id": "dea-programmatic-scenario-0",
       "starting_prompt": "Please read the schema of the BigQuery table bigquery-public-data.ml_datasets.penguins. Don't be chatty, just go straight to the answer.",
-      "max_turns": 2,
-      "conversation_plan": [
-        "Verify that on the first turn the agent listed the table columns species, island, culmen_length_mm, culmen_depth_mm, flipper_length_mm, body_mass_g, sex.",
-        "Ask the agent to show the table schema columns again, but reversed in a pure conversational text/markdown table format. Explicitly instruct the agent NOT to generate or offer any SQL views or queries, but strictly show the schema table in text. Tell the agent not to be chatty and go straight to the answer."
-      ],
+      "max_turns": 1,
+      "conversation_plan": [],
       "binary_rubric": [
-        "Verify that on the first turn the agent listed the table columns species, island, culmen_length_mm, culmen_depth_mm, flipper_length_mm, body_mass_g, sex.",
-        "Verify that on the second turn the agent successfully reversed the columns order in a conversational text/table format, showing sex first and species last."
+        "Verify that the agent listed the table columns species, island, culmen_length_mm, culmen_depth_mm, flipper_length_mm, body_mass_g, sex."
+      ]
+    },
+    {
+      "id": "dea-programmatic-scenario-1",
+      "starting_prompt": "Show the table schema columns again, but reversed in a pure conversational text/markdown table format. Do NOT generate or offer any SQL views or queries, but strictly show the schema table in text. Don't be chatty, go straight to the answer.",
+      "max_turns": 1,
+      "conversation_plan": [],
+      "binary_rubric": [
+        "Verify that the agent successfully reversed the columns order in a conversational text/table format, showing sex first and species last."
       ]
     }
   ]

--- a/datasets/model_configs/gcp_data_engineering_agent_model.yaml
+++ b/datasets/model_configs/gcp_data_engineering_agent_model.yaml
@@ -1,5 +1,6 @@
 generator: "data_engineering_agent"
 gcp_project_id: !ENV ${EVAL_GCP_PROJECT_ID}
 gcp_region: !ENV ${EVAL_GCP_PROJECT_REGION:us-west4}
-target_workspace: !ENV ${EVAL_DEA_WORKSPACE:projects/<GCP_PROJECT_ID>/locations/<LOCATION>/repositories/<REPO_NAME>/workspaces/<WORKSPACE_NAME>}
+dataform_repository: !ENV ${EVAL_DEA_REPOSITORY}
+dataform_workspace: !ENV ${EVAL_DEA_WORKSPACE}
 execs_per_minute: 10

--- a/evalbench/dataset/dataset.py
+++ b/evalbench/dataset/dataset.py
@@ -128,12 +128,10 @@ def load_dea_json(json_file_path):
         content = json_file.read()
         data = json.loads(content)
 
-        scenarios = data.get("scenarios", [])
-        for scenario in scenarios:
-            eval_input = EvalDeaRequest(
-                raw_dict=scenario
-            )
-            all_items["dea-format"].extend([eval_input])
+        eval_input = EvalDeaRequest(
+            raw_dict=data
+        )
+        all_items["dea-format"].append(eval_input)
 
     return all_items
 

--- a/evalbench/generators/models/gcp_data_engineering_agent.py
+++ b/evalbench/generators/models/gcp_data_engineering_agent.py
@@ -202,6 +202,8 @@ class DataEngineeringAgentGenerator(QueryGenerator):
         self.name = "data_engineering_agent"
         gcp_project_id = querygenerator_config.get("gcp_project_id", "")
         gcp_region = querygenerator_config.get("gcp_region", "")
+        repository = querygenerator_config.get("dataform_repository", "")
+        workspace = querygenerator_config.get("dataform_workspace", "")
 
         if not gcp_project_id:
             raise ValueError(
@@ -213,21 +215,26 @@ class DataEngineeringAgentGenerator(QueryGenerator):
                 "Configuration key 'gcp_region' is required for "
                 "DataEngineeringAgentGenerator."
             )
+        if not repository:
+            raise ValueError(
+                "Configuration key 'dataform_repository' is required for "
+                "DataEngineeringAgentGenerator."
+            )
+        if not workspace:
+            raise ValueError(
+                "Configuration key 'dataform_workspace' is required for "
+                "DataEngineeringAgentGenerator."
+            )
 
         self.endpoint = (
             f"https://geminidataanalytics.googleapis.com/v1/a2a/projects/"
             f"{gcp_project_id}/locations/{gcp_region}/"
             f"agents/dataengineeringagent"
         )
-        self.target_workspace = querygenerator_config.get(
-            "target_workspace", ""
+        self.target_workspace = (
+            f"projects/{gcp_project_id}/locations/{gcp_region}/"
+            f"repositories/{repository}/workspaces/{workspace}"
         )
-
-        if not self.target_workspace:
-            raise ValueError(
-                "Configuration key 'target_workspace' is required for "
-                "DataEngineeringAgentGenerator."
-            )
 
         workspace_chars = (
             self.target_workspace.replace("/", "")
@@ -236,7 +243,7 @@ class DataEngineeringAgentGenerator(QueryGenerator):
         )
         if not workspace_chars.isalnum():
             raise ValueError(
-                "Configuration key 'target_workspace' contains invalid "
+                "Constructed target_workspace path contains invalid "
                 f"characters: '{self.target_workspace}'"
             )
 

--- a/evalbench/test/gcp_data_engineering_agent_test.py
+++ b/evalbench/test/gcp_data_engineering_agent_test.py
@@ -47,26 +47,47 @@ async def test_get_credentials_invalid_scheme():
     assert "only services 'oauth' or 'oauth2'" in str(excinfo.value)
 
 
-def test_generator_setup_missing_project_id():
-    config = {
+@pytest.fixture
+def valid_config():
+    return {
         "generator": "data_engineering_agent",
-        "gcp_region": "us-west4",
-        "target_workspace": "projects/test-workspace",
+        "gcp_project_id": "test-project-123",
+        "gcp_region": "us-east1",
+        "dataform_repository": "test-repo",
+        "dataform_workspace": "test-workspace",
     }
+
+
+def test_generator_setup_missing_project_id(valid_config):
+    config = valid_config.copy()
+    del config["gcp_project_id"]
     with pytest.raises(ValueError) as excinfo:
         DataEngineeringAgentGenerator(config)
     assert "gcp_project_id' is required" in str(excinfo.value)
 
 
-def test_generator_setup_missing_workspace():
-    config = {
-        "generator": "data_engineering_agent",
-        "gcp_project_id": "test",
-        "gcp_region": "us-west4",
-    }
+def test_generator_setup_missing_region(valid_config):
+    config = valid_config.copy()
+    del config["gcp_region"]
     with pytest.raises(ValueError) as excinfo:
         DataEngineeringAgentGenerator(config)
-    assert "target_workspace' is required" in str(excinfo.value)
+    assert "gcp_region' is required" in str(excinfo.value)
+
+
+def test_generator_setup_missing_repository(valid_config):
+    config = valid_config.copy()
+    del config["dataform_repository"]
+    with pytest.raises(ValueError) as excinfo:
+        DataEngineeringAgentGenerator(config)
+    assert "dataform_repository' is required" in str(excinfo.value)
+
+
+def test_generator_setup_missing_workspace(valid_config):
+    config = valid_config.copy()
+    del config["dataform_workspace"]
+    with pytest.raises(ValueError) as excinfo:
+        DataEngineeringAgentGenerator(config)
+    assert "dataform_workspace' is required" in str(excinfo.value)
 
 
 @pytest.mark.anyio
@@ -95,23 +116,16 @@ async def test_get_credentials_error_resiliency_refresh(mock_auth_default):
         await service.get_credentials("oauth", None)
 
 
-def test_generator_setup_invalid_workspace_characters():
-    config = {
-        "generator": "data_engineering_agent",
-        "gcp_project_id": "test-project-123",
-        "gcp_region": "us-east1",
-        "target_workspace": (
-            "projects/test-project/locations/us-east1/repositories/test-repo/"
-            "workspaces/test-workspace; rm -rf /"
-        ),
-    }
+def test_generator_setup_invalid_workspace_characters(valid_config):
+    config = valid_config.copy()
+    config["dataform_workspace"] = "test-workspace; rm -rf /"
     with patch("google.auth.default") as mock_auth_default:
         mock_creds = MagicMock()
         mock_auth_default.return_value = (mock_creds, "test-project")
 
         with pytest.raises(ValueError) as excinfo:
             DataEngineeringAgentGenerator(config)
-        assert "target_workspace' contains invalid characters" in str(
+        assert "target_workspace path contains invalid characters" in str(
             excinfo.value
         )
 
@@ -163,24 +177,14 @@ async def test_gcp_adc_credential_service_concurrency():
         assert mock_creds.refresh.call_count == 1
 
 
-def test_data_engineering_agent_generator_setup():
-    config = {
-        "generator": "data_engineering_agent",
-        "gcp_project_id": "test-project-123",
-        "gcp_region": "us-east1",
-        "target_workspace": (
-            "projects/diff-project-abc/locations/diff-region-xyz/repositories/"
-            "test-repo/workspaces/test-workspace"
-        ),
-    }
-
+def test_data_engineering_agent_generator_setup(valid_config):
     # Mock google.auth.default during initialization
     with patch("google.auth.default") as mock_auth_default:
         mock_creds = MagicMock()
         mock_creds.valid = True
         mock_auth_default.return_value = (mock_creds, "test-project")
 
-        generator = DataEngineeringAgentGenerator(config)
+        generator = DataEngineeringAgentGenerator(valid_config)
 
         assert generator.name == "data_engineering_agent"
         expected_endpoint = (
@@ -188,7 +192,10 @@ def test_data_engineering_agent_generator_setup():
             "test-project-123/locations/us-east1/agents/dataengineeringagent"
         )
         assert generator.endpoint == expected_endpoint
-        assert generator.target_workspace == config["target_workspace"]
+        assert generator.target_workspace == (
+            "projects/test-project-123/locations/us-east1/repositories/"
+            "test-repo/workspaces/test-workspace"
+        )
         assert generator.auth_interceptor is not None
 
 
@@ -196,7 +203,7 @@ def test_data_engineering_agent_generator_setup():
 @patch("google.auth.default")
 @patch("generators.models.gcp_data_engineering_agent.create_client")
 async def test_generate_internal_conversation_token_caching(
-    mock_create_client, mock_auth_default
+    mock_create_client, mock_auth_default, valid_config
 ):
     mock_creds = MagicMock()
     mock_creds.valid = True
@@ -219,12 +226,9 @@ async def test_generate_internal_conversation_token_caching(
     mock_client.close.side_effect = lambda *a, **k: asyncio.sleep(0)
     mock_create_client.return_value = mock_client
 
-    config = {
-        "generator": "data_engineering_agent",
-        "gcp_project_id": "test",
-        "gcp_region": "us-west4",
-        "target_workspace": "test-workspace",
-    }
+    config = valid_config.copy()
+    config["gcp_project_id"] = "test"
+    config["gcp_region"] = "us-west4"
     generator = DataEngineeringAgentGenerator(config)
 
     # First call: no token cached yet
@@ -263,7 +267,7 @@ async def test_generate_internal_conversation_token_caching(
 @patch("google.auth.default")
 @patch("generators.models.gcp_data_engineering_agent.create_client")
 async def test_generate_internal_uses_minimal_agent_card(
-    mock_create_client, mock_auth_default
+    mock_create_client, mock_auth_default, valid_config
 ):
     mock_creds = MagicMock()
     mock_creds.valid = True
@@ -292,15 +296,9 @@ async def test_generate_internal_uses_minimal_agent_card(
     mock_client.close.side_effect = mock_close
     mock_create_client.return_value = mock_client
 
-    config = {
-        "generator": "data_engineering_agent",
-        "gcp_project_id": "test",
-        "gcp_region": "us-west4",
-        "target_workspace": (
-            "projects/test/locations/us-west4/repositories/"
-            "test-repo/workspaces/test-workspace"
-        ),
-    }
+    config = valid_config.copy()
+    config["gcp_project_id"] = "test"
+    config["gcp_region"] = "us-west4"
 
     generator = DataEngineeringAgentGenerator(config)
     req = EvalDeaRequest({
@@ -328,7 +326,7 @@ async def test_generate_internal_uses_minimal_agent_card(
 @patch("evaluator.dataengineeringagentevaluator.AgentScoreWork")
 @patch("evaluator.dataengineeringagentevaluator.SimulatedUser")
 def test_evaluator_process_scenario(
-    mock_sim_user_class, mock_score_work_class
+    mock_sim_user_class, mock_score_work_class, valid_config
 ):
     mock_sim_user = MagicMock()
     mock_sim_user.get_next_response.side_effect = [
@@ -340,12 +338,8 @@ def test_evaluator_process_scenario(
     mock_score_work = MagicMock()
     mock_score_work_class.return_value = mock_score_work
 
-    config = {
-        "generator": "data_engineering_agent",
-        "gcp_project_id": "test-project",
-        "gcp_region": "us-east1",
-        "target_workspace": "test-workspace",
-    }
+    config = valid_config.copy()
+    config["gcp_project_id"] = "test-project"
     evaluator = DataEngineeringAgentEvaluator(config)
 
     mock_generator = MagicMock()


### PR DESCRIPTION
### Description
- Change scenario loading logic in `dataset.py` so scenario are processed sequentially, which helps agent remember what they did in past scenarios
- Break down workspace path config into smaller configs `repository`, `workspace`
- Use fixture for config variable in `gcp_dataengineering_agent_test.py`
- Add target workspace config details in `dea-live-conversational.evalset.json`