### PR TITLE
feat: natively copy declared env_files to agent sandbox

### DIFF
--- a/evalbench/evaluator/agentevaluator.py
+++ b/evalbench/evaluator/agentevaluator.py
@@ -3,6 +3,7 @@ import datetime
 import concurrent.futures
 import logging
 import os
+import shutil
 import threading
 
 from dataset.evalgeminicliinput import EvalGeminiCliRequest
@@ -120,6 +121,25 @@ class AgentEvaluator:
         resolved_work_dir = scenario.get("resolved_work_dir")
         if resolved_work_dir:
             os.makedirs(resolved_work_dir, exist_ok=True)
+
+        # Copy declared env_files to fake_home
+        fake_home = getattr(self.generator, "fake_home", None)
+        if fake_home:
+            session_dir = os.path.dirname(fake_home)
+            env_files = scenario.get("env_files", [])
+            for env_file in env_files:
+                src_path = os.path.join(session_dir, "env_files", env_file)
+                dest_path = os.path.join(fake_home, env_file)
+                if os.path.exists(src_path):
+                    os.makedirs(os.path.dirname(dest_path), exist_ok=True)
+                    shutil.copy2(src_path, dest_path)
+                    logging.info(
+                        "Natively copied env file to sandbox: %s", dest_path
+                    )
+                else:
+                    logging.warning(
+                        "Declared env file not found in session: %s", src_path
+                    )
 
         session_id = None
         for turn in range(max_turns):

--- a/evalbench/test/agentevaluator_test.py
+++ b/evalbench/test/agentevaluator_test.py
@@ -1,0 +1,93 @@
+import os
+import shutil
+import tempfile
+import unittest
+from unittest.mock import MagicMock, patch
+from evaluator.agentevaluator import AgentEvaluator
+from generators.models.agent_cli import AgentCliGenerator
+
+
+class TestAgentEvaluatorEnvSetup(unittest.TestCase):
+    """Tests for AgentEvaluator environment file setup logic."""
+
+    def setUp(self):
+        # Create a temporary directory for the session
+        self.test_dir = tempfile.mkdtemp()
+        self.session_id = "test_session_123"
+        self.session_dir = os.path.join(self.test_dir, self.session_id)
+        self.fake_home = os.path.join(self.session_dir, "fake_home")
+
+        # Create the simulated upload directory structure
+        self.upload_env_dir = os.path.join(
+            self.session_dir, "env_files", "env"
+        )
+        os.makedirs(self.upload_env_dir, exist_ok=True)
+
+        # Create a dummy env file in the upload directory
+        self.dummy_file_path = os.path.join(self.upload_env_dir, "sleep.py")
+        with open(self.dummy_file_path, "w") as f:
+            f.write("print('mock sleep')")
+
+    def tearDown(self):
+        # Clean up the temporary directory
+        shutil.rmtree(self.test_dir)
+
+    @patch("evaluator.agentevaluator.get_generator")
+    def test_process_scenario_copies_env_files(self, mock_get_generator):
+        # 1. Setup mocks
+        mock_generator = MagicMock(spec=AgentCliGenerator)
+        # Set fake_home on the generator to point to our temp fake_home
+        mock_generator.fake_home = self.fake_home
+        mock_generator.name = "mock_agent_cli"
+        mock_get_generator.return_value = mock_generator
+
+        # 2. Initialize AgentEvaluator
+        config = {
+            "model_config": "dummy_model_config.yaml",
+            "runners": {"agent_runners": 1}
+        }
+        evaluator = AgentEvaluator(config)
+
+        # 3. Define the scenario with env_files
+        scenario = {
+            "id": "test_scenario",
+            "starting_prompt": "run sleep.py",
+            "max_turns": 1,
+            "env_files": ["env/sleep.py"]
+        }
+
+        # Mock the generator's generate/safe_generate to avoid actual CLI execution
+        mock_result = MagicMock()
+        mock_result.stdout = '{"session_id": "test_session_123"}'
+        mock_result.stderr = ''
+        mock_result.returncode = 0
+        mock_generator.safe_generate.return_value = mock_result
+        mock_generator.create_command.return_value = ["dummy_cmd"]
+        mock_generator.parse_response.return_value = {
+            "session_id": "test_session_123"
+        }
+        mock_generator.extract_tools.return_value = []
+        mock_generator.extract_skills.return_value = []
+
+        # Mock finalize_scenario to avoid scoring
+        evaluator._finalize_scenario = MagicMock()
+
+        # 4. Run process_scenario
+        eval_result = MagicMock()
+        evaluator.process_scenario(
+            scenario=scenario,
+            eval_result=eval_result,
+            job_id="job1",
+            metadata={}
+        )
+
+        # 5. Verify the file was copied into the sandbox
+        expected_copied_path = os.path.join(self.fake_home, "env/sleep.py")
+        self.assertTrue(os.path.exists(expected_copied_path))
+        with open(expected_copied_path, "r") as f:
+            content = f.read()
+        self.assertEqual(content, "print('mock sleep')")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## **Summary**
This PR introduces a server-side mechanism in `AgentEvaluator` to copy declared environment files (`env_files`) from the session directory into the agent's `fake_home` sandbox before execution starts. 

It also adds a dedicated unit test suite (`agentevaluator_test.py`) to prevent regressions.

---

## **Problem statement**
In many evaluation scenarios (such as scheduling Python scripts or running data pipelines), the agent needs access to pre-existing files in its workspace (e.g., a `sleep.py` script that it needs to schedule). 

Previously, `AgentEvaluator` did not set up these files in the sandbox. The client has to upload files directly into the server's internal `fake_home/` path, tightly coupling the client to the server's internal directory structure.

---

## **Solution**
We introduce a clean, native separation of concerns:
1.  **Scenario Declaration**: Scenarios can now declare their required files in the Scenario JSON:
    ```json
    "env_files": ["env/sleep.py"]
    ```
2.  **Generic Client Upload** (Not in this PR): The client uploads these files generically to `env_files/` in the session
3.  **Server-Side Setup (This PR)**: Before the agent turn begins, `AgentEvaluator` parses the `env_files` list, locates them in the session upload directory, and copies them into the agent's `fake_home` sandbox (preserving directory structure).

This allows us to support evaluations where the agent has to work on an existing workspace.

---

## **Changes**
*   **`evalbench/evaluator/agentevaluator.py`**:
    *   Added logic in `process_scenario` to read `env_files` from the scenario.
    *   Natively copies matching files from `/tmp_sessions/<session_id>/env_files/` to `/tmp_sessions/<session_id>/fake_home/` using `shutil.copy2`.
    *   Added logging and error handling (warning logged if a declared file is missing).
*   **`evalbench/test/agentevaluator_test.py`** *(New)*:
    *   Added a dedicated unit test suite `TestAgentEvaluatorEnvSetup`.
    *   Tests that `process_scenario` correctly copies files to `fake_home` using a mocked generator and temporary directories.

---

## **How was this tested?**

### **1. Unit Tests (Local)**
Successfully ran the new unit test suite locally in the `venv` virtual environment:
```bash
pytest -v evalbench/test/agentevaluator_test.py
```

### **2. End-to-End Integration Test**
1.  Built a local Docker image containing these changes.
2.  Launched a private `evalbench_server` container.
3.  Ran the Data Cloud VS Code evaluation client in Google3, configuring it to upload `sleep.py` to `env_files/` and pointing it to the private server.
4.  **Verifications**:
    *   Server logs confirmed: `Natively copied env file to sandbox: .../fake_home/env/sleep.py`.
    *   The agent successfully read the copied `sleep.py` and extracted the correct entry point (`half_second_sleep`) without writing/hallucinating any placeholder files.