### PR TITLE
docs: fix mismatched quickstart config link text in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ export EVAL_GCP_PROJECT_REGION=your_region_here
 
 For a quick start, let's run NL2SQL on some sqlite DQL queries.
 
-1. First, read through [sqlite/run_dql.yaml](/datasets/bat/example_run_config.yaml) and see the configuration settings we will be running.
+1. First, read through [datasets/bat/example_run_config.yaml](/datasets/bat/example_run_config.yaml) and see the configuration settings we will be running.
 
 Now, configure your evaluation by setting the `EVAL_CONFIG` environment variable. For example, to run a configuration using the `db_blog` dataset on SQLite:
 


### PR DESCRIPTION
The link text read "sqlite/run_dql.yaml" while pointing to /datasets/bat/example_run_config.yaml. Align the text with the actual target file to avoid confusion.