### PR TITLE
fix: log metadata reflection failures instead of swallowing them

### DIFF
--- a/evalbench/databases/mysql.py
+++ b/evalbench/databases/mysql.py
@@ -241,8 +241,8 @@ class MySQLDB(DB):
                         columns.append(
                             {"name": column.name, "type": str(column.type)})
                     db_metadata[table.name] = columns
-        except Exception:
-            pass
+        except Exception as e:
+            logging.warning(f"Failed to reflect database metadata: {e}")
 
         return db_metadata
 

--- a/evalbench/databases/postgres.py
+++ b/evalbench/databases/postgres.py
@@ -205,8 +205,8 @@ class PGDB(DB):
                         columns.append(
                             {"name": column.name, "type": str(column.type)})
                     db_metadata[table.name] = columns
-        except Exception:
-            pass
+        except Exception as e:
+            logging.warning(f"Failed to reflect database metadata: {e}")
 
         return db_metadata
 

--- a/evalbench/databases/sqlite.py
+++ b/evalbench/databases/sqlite.py
@@ -163,8 +163,8 @@ class SQLiteDB(DB):
                         columns.append(
                             {"name": column.name, "type": str(column.type)})
                     db_metadata[table.name] = columns
-        except Exception:
-            pass
+        except Exception as e:
+            logging.warning(f"Failed to reflect database metadata: {e}")
 
         return db_metadata
 

--- a/evalbench/databases/sqlserver.py
+++ b/evalbench/databases/sqlserver.py
@@ -189,8 +189,8 @@ class SQLServerDB(DB):
                         columns.append(
                             {"name": column.name, "type": str(column.type)})
                     db_metadata[table.name] = columns
-        except Exception:
-            pass
+        except Exception as e:
+            logging.warning(f"Failed to reflect database metadata: {e}")
 
         return db_metadata
 


### PR DESCRIPTION
get_metadata in the postgres, sqlite, mysql, and sqlserver backends caught every exception and silently returned an empty dict, so a reflection failure left evals running without schema and gave no clue why. Replace the bare "except Exception: pass" with a logged warning.