### PR TITLE
fix(dataset): load all knowledge-base entries, not just the last line

### DIFF
--- a/evalbench/dataset/dataset.py
+++ b/evalbench/dataset/dataset.py
@@ -60,8 +60,8 @@ def load_knowledge(
                 if not line.strip():
                     continue
                 obj = json.loads(line)
-            if obj.get("id") not in exclude_ids:
-                external_kg_list.append(json.dumps(obj))
+                if obj.get("id") not in exclude_ids:
+                    external_kg_list.append(json.dumps(obj))
 
     external_kg = "\n".join(external_kg_list)
     return external_kg

--- a/evalbench/test/load_knowledge_test.py
+++ b/evalbench/test/load_knowledge_test.py
@@ -1,0 +1,88 @@
+import json
+import os
+import tempfile
+import unittest
+
+from dataset.dataset import load_knowledge
+
+
+class TestLoadKnowledge(unittest.TestCase):
+
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.dataset_dir = self._tmp.name
+        self.database = "db_blog"
+        self.db_dir = os.path.join(self.dataset_dir, self.database)
+        os.makedirs(self.db_dir)
+        self.kb_path = os.path.join(
+            self.db_dir, f"{self.database}_kb.jsonl"
+        )
+
+    def tearDown(self):
+        self._tmp.cleanup()
+
+    def _write_kb(self, lines):
+        with open(self.kb_path, "w", encoding="utf-8") as f:
+            f.write("\n".join(lines))
+
+    def _parse_result(self, result):
+        if not result:
+            return []
+        return [json.loads(line) for line in result.split("\n")]
+
+    def test_loads_all_entries(self):
+        """Regression: every line must be loaded, not just the last one."""
+        entries = [
+            {"id": "k1", "fact": "a"},
+            {"id": "k2", "fact": "b"},
+            {"id": "k3", "fact": "c"},
+        ]
+        self._write_kb([json.dumps(e) for e in entries])
+
+        result = load_knowledge(self.dataset_dir, self.database)
+
+        self.assertEqual(self._parse_result(result), entries)
+
+    def test_skips_blank_lines(self):
+        entries = [{"id": "k1", "fact": "a"}, {"id": "k2", "fact": "b"}]
+        self._write_kb(
+            [json.dumps(entries[0]), "", "   ", json.dumps(entries[1]), ""]
+        )
+
+        result = load_knowledge(self.dataset_dir, self.database)
+
+        self.assertEqual(self._parse_result(result), entries)
+
+    def test_excludes_ambiguous_ids(self):
+        entries = [
+            {"id": "k1", "fact": "a"},
+            {"id": "k2", "fact": "b"},
+            {"id": "k3", "fact": "c"},
+        ]
+        self._write_kb([json.dumps(e) for e in entries])
+        knowledge_ambiguity = [{"deleted_knowledge": "k2"}]
+
+        result = load_knowledge(
+            self.dataset_dir, self.database, knowledge_ambiguity
+        )
+
+        self.assertEqual(
+            self._parse_result(result),
+            [{"id": "k1", "fact": "a"}, {"id": "k3", "fact": "c"}],
+        )
+
+    def test_missing_file_returns_empty(self):
+        result = load_knowledge(self.dataset_dir, "nonexistent_db")
+        self.assertEqual(result, "")
+
+    def test_blank_only_file_returns_empty(self):
+        """A file with only blank lines must not raise and return ''."""
+        self._write_kb(["", "   ", ""])
+
+        result = load_knowledge(self.dataset_dir, self.database)
+
+        self.assertEqual(result, "")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
  - Fix an indentation bug in `load_knowledge`
  (`evalbench/dataset/dataset.py`) where the
    filter-and-append block sat outside the
  file-reading loop.
  - Previously only the **last** line of
  `<database>_kb.jsonl` was considered, so all other
    knowledge entries were silently dropped from
  `item["knowledge"]`. An all-blank file also
    raised `NameError` because `obj` was never
  assigned.
  - The block now runs per line, so every non-excluded
  entry is included.
  - Add `evalbench/test/load_knowledge_test.py`
  covering multi-entry loading, blank-line
    skipping, ambiguity exclusions, and the
  missing/blank-file edge cases.

  ## Impact
  Any evaluation that relies on external knowledge
  (`*_kb.jsonl`) was running with all but one
  KB entry missing, which can materially change model
  prompts and scores. No API or schema
  changes.

  ## Test plan
  - [x] New unit tests pass with the fix and fail
  against the buggy version.
  - [ ] Run an evaluation on a dataset with a
  multi-line `_kb.jsonl` and confirm
  `item["knowledge"]`
        contains all non-excluded entries.