### PR TITLE
fix(interact): count total_db_len so DB-setup progress isn't always zero

### DIFF
--- a/evalbench/dataset/evalinteractinput.py
+++ b/evalbench/dataset/evalinteractinput.py
@@ -117,6 +117,7 @@ def breakdown_datasets(total_dataset: list[EvalInteractInputRequest]):
                 datasets[dialect][input.database] = {}
             if input.query_type not in datasets[dialect][input.database]:
                 datasets[dialect][input.database][input.query_type] = []
+                total_db_len += 1
             datasets[dialect][input.database][input.query_type].append(
                 input.copy())
         total_dataset_len += 1

--- a/evalbench/evaluator/progress_reporter.py
+++ b/evalbench/evaluator/progress_reporter.py
@@ -136,7 +136,7 @@ def _report(
 
 def _colab_progress(progress_reporting):
     setup_done = (
-        progress_reporting["setup_i"].value / progress_reporting["total_dbs"]
+        progress_reporting["setup_i"].value / (progress_reporting["total_dbs"] or 1)
     ) * 100
     prompt_done = (
         progress_reporting["prompt_i"].value / progress_reporting["total"]

--- a/evalbench/test/evalinteractinput_breakdown_test.py
+++ b/evalbench/test/evalinteractinput_breakdown_test.py
@@ -1,0 +1,56 @@
+import unittest
+
+from dataset.evalinteractinput import EvalInteractInputRequest, breakdown_datasets
+
+
+def _make(id_, query_type, database, dialects):
+    return EvalInteractInputRequest(
+        id=id_,
+        amb_user_query="",
+        query_type=query_type,
+        database=database,
+        dialects=dialects,
+        eval_query=[],
+        tags=[],
+        payload={},
+    )
+
+
+class TestBreakdownDatasets(unittest.TestCase):
+
+    def test_total_db_len_counts_distinct_buckets(self):
+        """Regression: total_db_len must reflect distinct
+        (dialect, database, query_type) buckets, not stay 0."""
+        dataset = [
+            _make("1", "dql", "db_a", ["sqlite"]),
+            _make("2", "dql", "db_a", ["sqlite"]),  # same bucket as #1
+            _make("3", "dml", "db_a", ["sqlite"]),  # new query_type -> new bucket
+            _make("4", "dql", "db_b", ["sqlite"]),  # new database -> new bucket
+        ]
+
+        sub_datasets, total_dataset_len, total_db_len = breakdown_datasets(dataset)
+
+        self.assertEqual(total_db_len, 3)
+        self.assertEqual(total_dataset_len, 4)
+        self.assertEqual(len(sub_datasets["sqlite"]["db_a"]["dql"]), 2)
+        self.assertEqual(len(sub_datasets["sqlite"]["db_a"]["dml"]), 1)
+        self.assertEqual(len(sub_datasets["sqlite"]["db_b"]["dql"]), 1)
+
+    def test_multiple_dialects_create_separate_buckets(self):
+        dataset = [_make("1", "dql", "db_a", ["sqlite", "postgres"])]
+
+        sub_datasets, _, total_db_len = breakdown_datasets(dataset)
+
+        self.assertEqual(total_db_len, 2)
+        self.assertIn("sqlite", sub_datasets)
+        self.assertIn("postgres", sub_datasets)
+
+    def test_empty_dataset(self):
+        sub_datasets, total_dataset_len, total_db_len = breakdown_datasets([])
+        self.assertEqual(sub_datasets, {})
+        self.assertEqual(total_dataset_len, 0)
+        self.assertEqual(total_db_len, 0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- `breakdown_datasets` in `dataset/evalinteractinput.py` (used by the interact and dataagent orchestrators) never incremented `total_db_len`, so it always returned `0`.
- That `0` is passed to `setup_progress_reporting` as `total_dbs`. In Colab, `_colab_progress` divided `setup_i / total_dbs`, raising ZeroDivisionError and crashing the progress thread; in stdout mode the "DBs Setup" bar overshot 100%.
- Increment `total_db_len` per distinct `(dialect, database, query_type)` bucket (matching the correct oneshot version in `evalinput.py`), and add a defensive zero-guard in `_colab_progress`.
- Add `evalbench/test/evalinteractinput_breakdown_test.py`.

## Scope note
This intentionally does not touch the unused `breakdown_datasets` in `dataset/dataset.py` (dead code) or the `input.copy()` / per-input `total_dataset_len` semantics in the interact version, which are a separate question about per-dialect fan-out.

## Test plan
- New unit tests pass with the fix and fail against the buggy version (`0 != 3`).
- Run an interact/dataagent evaluation in Colab and confirm the DBs-Setup progress bar renders without ZeroDivisionError.