### PR TITLE
fix(scorers): correct digit regex in behavioral metrics scorer

### DIFF
--- a/evalbench/scorers/behavioralmetrics.py
+++ b/evalbench/scorers/behavioralmetrics.py
@@ -71,12 +71,12 @@ class BehavioralMetrics(comparator.Comparator):
                 clarifications = 0
 
                 hallucination_match = re.search(
-                    r'Hallucination Count:\s*(\\d+)', response_text)
+                    r'Hallucination Count:\s*(\d+)', response_text)
                 if hallucination_match:
                     hallucinations = int(hallucination_match.group(1))
 
                 clarification_match = re.search(
-                    r'Clarification Count:\s*(\\d+)', response_text)
+                    r'Clarification Count:\s*(\d+)', response_text)
                 if clarification_match:
                     clarifications = int(clarification_match.group(1))
 


### PR DESCRIPTION
## Summary
  - The behavioral metrics scorer used raw-string regex r'(\\d+)' to parse
    hallucination and clarification counts from the LLM response.
  - In a raw string, \\d matches a literal backslash followed by 'd' — never
    a digit. Counts never parsed, stayed 0, penalty was 0, scorer always
    returned 100.
  - Fixed by using r'(\d+)' in both behavioralmetrics.py:74 and :79.

  ## Test plan
  - [x] Verified corrected pattern extracts digits from sample output.
  - [ ] Run an eval exercising BehavioralMetrics; confirm non-100 scores
        when hallucinations/clarifications are present.