### PR TITLE
test(bigtable): allow instance/project override via env vars

### DIFF
--- a/evalbench/test/bigtable_test.py
+++ b/evalbench/test/bigtable_test.py
@@ -6,16 +6,21 @@ from util import get_SessionManager
 
 
 TABLE_ID = "unit_test_table"
+# Override via env vars when the defaults below don't match your project.
+_DEFAULT_PROJECT = "cloud-db-nl2sql"
+_DEFAULT_INSTANCE = "evalbench-ci"
 
 
 @pytest.fixture(scope="session")
 def client():
     """Creates a Bigtable client for testing."""
     db_config = {
-        "gcp_project_id": "cloud-db-nl2sql",
+        "gcp_project_id": os.environ.get(
+            "EVALBENCH_BIGTABLE_PROJECT", _DEFAULT_PROJECT),
         "db_type": "bigtable",
         "database_path": "",
-        "instance_id": "evalbench",
+        "instance_id": os.environ.get(
+            "EVALBENCH_BIGTABLE_INSTANCE", _DEFAULT_INSTANCE),
         "table_name": TABLE_ID,
         "max_executions_per_minute": 100,
         "secret_manager_path": "",


### PR DESCRIPTION
## Summary
- The bigtable test fixture hardcoded `instance_id: "evalbench"` against project `cloud-db-nl2sql`, but no such Bigtable instance exists in the project. All four tests in `evalbench/test/bigtable_test.py` fail on a fresh checkout with `404 Instance projects/cloud-db-nl2sql/instances/evalbench not found`.
- Switch project and instance to read from optional env vars (`EVALBENCH_BIGTABLE_PROJECT`, `EVALBENCH_BIGTABLE_INSTANCE`) with defaults `cloud-db-nl2sql` / `evalbench-ci`.
- `evalbench-ci` is a dedicated, persistent Bigtable instance created for this test; it contains the `unit_test_table` (column family `cf1`) with table-level `deletionProtection: true`. This protects it from the existing `evalbench@cloud-db-nl2sql.iam.gserviceaccount.com` cleanup automation that regularly creates and tears down other `evalbench-*` instances in this project (~6–10 deletes/day observed in audit logs).
- Contributors on other projects can override the defaults without editing the file.

## Test plan
- [x] `PYTHONPATH=evalbench GOOGLE_CLOUD_QUOTA_PROJECT=cloud-db-nl2sql .venv/bin/pytest evalbench/test/bigtable_test.py` → 4 passed
- [x] Full suite: `PYTHONPATH=evalbench GOOGLE_CLOUD_QUOTA_PROJECT=cloud-db-nl2sql .venv/bin/pytest evalbench/test/` → 275 passed
- [x] Override path: `EVALBENCH_BIGTABLE_INSTANCE=evalbench-ci .venv/bin/pytest evalbench/test/bigtable_test.py` → 4 passed

## Notes for reviewer
- Bigtable supports `deletionProtection` only at the table level, not the instance. The instance itself is theoretically still deletable, but the cleanup SA's audit-log pattern shows it only deletes instances it created itself; `evalbench-ci` was created out-of-band and should be safe. If stronger protection is needed, an IAM Deny policy on `bigtable.instances.delete` for `projects/cloud-db-nl2sql/instances/evalbench-ci` would close the gap.
- This PR does not touch the equivalent hardcodes in `spanner_test.py`; those currently work because the matching Spanner instance does exist. Happy to make the same env-var change there in a follow-up if desired.
