### PR TITLE
Feat: Add ability to filter to specific json scenario/examples

### DIFF
--- a/docs/configs/run-config.md
+++ b/docs/configs/run-config.md
@@ -14,7 +14,9 @@ This section defines the primary resources used during evaluation, including the
 | `databases`         | Optional          | Specifies the databases (e.g., `db_blog`, `california_schools`, etc.). This filters the dataset to the provided list of databases and ignores all other evals. If not provided, all databases found in the dataset_config json file will be tried. |
 | `query_types`         | Optional          | Specifies the query_types (`dql`, `dml`, `dd`). This filters the dataset to the list of evals that are of the query_types provided. If not provided, all eval types (dql, dml and ddl) found in the dataset_config json file will be tried. |
 | `dataset_format`      | Conditional (if needed) | Defines the dataset format, with `evalbench-standard-format` as the default. For BIRD datasets, it must be set to `bird-standard-format`.|
-| `num_trials`      | Optional     | Number of trials to run for each prompt. 
+| `num_trials`      | Optional     | Number of trials to run for each prompt. |
+| `scenarios`      | Optional     | A list of specific scenario IDs to run (only applies to scenario-based agentic datasets like `gemini-cli-format` or `cortado-format`). Defaults to empty (runs all scenarios). |
+| `scenario_pattern` | Optional     | A glob pattern of scenario IDs to run (only applies to scenario-based agentic datasets). Defaults to None (runs all scenarios). |
 ---
 
 ## 2. Prompt and Generation Modules

--- a/evalbench/dataset/dataset.py
+++ b/evalbench/dataset/dataset.py
@@ -3,6 +3,7 @@
 from typing import Any, Optional
 import json
 import logging
+import fnmatch
 from collections.abc import Sequence
 from dataset.evalinput import EvalInputRequest
 from dataset.evalinteractinput import EvalInteractInputRequest
@@ -136,7 +137,37 @@ def load_dea_json(json_file_path):
     return all_items
 
 
-def load_cortado_json(json_file_path):
+def _filter_scenarios(scenarios: list[dict], config: dict) -> list[dict]:
+    """Filters a list of scenarios based on explicit IDs or glob pattern in config."""
+    scenarios_to_run = config.get("scenarios", [])
+    scenario_pattern = config.get("scenario_pattern", None)
+
+    # If no filters are specified, return the original list (run all)
+    if not scenarios_to_run and not scenario_pattern:
+        return scenarios
+
+    filtered_scenarios = []
+    for scenario in scenarios:
+        scenario_id = scenario.get("id")
+        if not scenario_id:
+            # Drop scenarios without IDs per user feedback
+            continue
+
+        # Match explicit list of IDs
+        if scenarios_to_run and scenario_id not in scenarios_to_run:
+            continue
+
+        # Match glob pattern
+        if scenario_pattern:
+            if not fnmatch.fnmatch(scenario_id, scenario_pattern):
+                continue
+
+        filtered_scenarios.append(scenario)
+
+    return filtered_scenarios
+
+
+def load_cortado_json(json_file_path, config):
     all_items: dict[str, list[EvalCortadoRequest]] = {
         "cortado-format": [],
     }
@@ -144,7 +175,8 @@ def load_cortado_json(json_file_path):
         data = json.load(json_file)
 
         scenarios = data.get("scenarios", [])
-        for scenario in scenarios:
+        filtered_scenarios = _filter_scenarios(scenarios, config)
+        for scenario in filtered_scenarios:
             eval_input = EvalCortadoRequest(
                 raw_dict=scenario
             )
@@ -153,7 +185,7 @@ def load_cortado_json(json_file_path):
     return all_items
 
 
-def load_gemini_cli_json(json_file_path):
+def load_gemini_cli_json(json_file_path, config):
     all_items: dict[str, list[EvalGeminiCliRequest]] = {
         "gemini-cli-format": [],
     }
@@ -162,10 +194,13 @@ def load_gemini_cli_json(json_file_path):
         json_item = _expand_env_placeholders(json_item, json_file_path)
         item = json.loads(json_item)
 
-        # Resolve work_dir for scenarios
+        # Filter scenarios
         scenarios = item.get("scenarios", [])
+        item["scenarios"] = _filter_scenarios(scenarios, config)
+
+        # Resolve work_dir for scenarios
         dataset_dir = os.path.dirname(json_file_path)
-        for scenario in scenarios:
+        for scenario in item["scenarios"]:
             if "work_dir" in scenario:
                 work_dir = scenario["work_dir"]
                 # Resolve relative to dataset file
@@ -197,9 +232,9 @@ def load_dataset_from_json(json_file_path, config):
     if dataset_format == "bird-interact-format":
         all_items = load_bird_interact_dataset(json_file_path, config)
     elif dataset_format in ("gemini-cli-format", "agent-format"):
-        all_items = load_gemini_cli_json(json_file_path)
+        all_items = load_gemini_cli_json(json_file_path, config)
     elif dataset_format == "cortado-format":
-        all_items = load_cortado_json(json_file_path)
+        all_items = load_cortado_json(json_file_path, config)
     elif dataset_format == "dea-format":
         all_items = load_dea_json(json_file_path)
     else:
@@ -218,6 +253,7 @@ def load_dataset_from_json(json_file_path, config):
     elif dataset_format == "cortado-format":
         if "orchestrator" not in config:
             config["orchestrator"] = "cortado"
+        input_items = all_items
     elif dataset_format == "dea-format":
         if "orchestrator" not in config:
             config["orchestrator"] = "dea"
@@ -234,6 +270,7 @@ def load_dataset_from_json(json_file_path, config):
                            for q in ["dql", "dml", "ddl"])
         logging.info(f"Converted {totalEntries} entries to EvalInput.")
     return input_items
+
 
 
 def load_dataset_from_bird_format(dataset: Sequence[dict], config):

--- a/evalbench/dataset/dataset.py
+++ b/evalbench/dataset/dataset.py
@@ -121,13 +121,22 @@ def load_bird_interact_dataset(json_file_path, config):
     return input_items
 
 
-def load_dea_json(json_file_path):
+def load_dea_json(json_file_path, config):
     all_items: dict[str, list[EvalDeaRequest]] = {
         "dea-format": [],
     }
     with open(json_file_path, "r") as json_file:
         content = json_file.read()
         data = json.loads(content)
+
+        # Filter scenarios
+        scenarios = data.get("scenarios", [])
+        filtered_scenarios = _filter_scenarios(scenarios, config)
+        if scenarios and not filtered_scenarios:
+            return all_items
+
+        if "scenarios" in data:
+            data["scenarios"] = filtered_scenarios
 
         eval_input = EvalDeaRequest(
             raw_dict=data
@@ -140,6 +149,9 @@ def load_dea_json(json_file_path):
 def _filter_scenarios(scenarios: list[dict], config: dict) -> list[dict]:
     """Filters a list of scenarios based on explicit IDs or glob pattern in config."""
     scenarios_to_run = config.get("scenarios", [])
+    if isinstance(scenarios_to_run, str):
+        scenarios_to_run = [s.strip() for s in scenarios_to_run.split(",") if s.strip()]
+
     scenario_pattern = config.get("scenario_pattern", None)
 
     # If no filters are specified, return the original list (run all)
@@ -150,7 +162,6 @@ def _filter_scenarios(scenarios: list[dict], config: dict) -> list[dict]:
     for scenario in scenarios:
         scenario_id = scenario.get("id")
         if not scenario_id:
-            # Drop scenarios without IDs per user feedback
             continue
 
         # Match explicit list of IDs
@@ -196,7 +207,11 @@ def load_gemini_cli_json(json_file_path, config):
 
         # Filter scenarios
         scenarios = item.get("scenarios", [])
-        item["scenarios"] = _filter_scenarios(scenarios, config)
+        filtered_scenarios = _filter_scenarios(scenarios, config)
+        if scenarios and not filtered_scenarios:
+            return all_items
+
+        item["scenarios"] = filtered_scenarios
 
         # Resolve work_dir for scenarios
         dataset_dir = os.path.dirname(json_file_path)
@@ -236,7 +251,7 @@ def load_dataset_from_json(json_file_path, config):
     elif dataset_format == "cortado-format":
         all_items = load_cortado_json(json_file_path, config)
     elif dataset_format == "dea-format":
-        all_items = load_dea_json(json_file_path)
+        all_items = load_dea_json(json_file_path, config)
     else:
         all_items = load_json(json_file_path)
 
@@ -270,7 +285,6 @@ def load_dataset_from_json(json_file_path, config):
                            for q in ["dql", "dml", "ddl"])
         logging.info(f"Converted {totalEntries} entries to EvalInput.")
     return input_items
-
 
 
 def load_dataset_from_bird_format(dataset: Sequence[dict], config):

--- a/evalbench/evalbench.py
+++ b/evalbench/evalbench.py
@@ -29,6 +29,16 @@ except ImportError:
 logging.getLogger().setLevel(logging.INFO)
 
 
+_SCENARIOS = flags.DEFINE_list(
+    "scenarios",
+    [],
+    "List of scenario IDs to run. Defaults to empty (runs all scenarios).",
+)
+_SCENARIO_PATTERN = flags.DEFINE_string(
+    "scenario_pattern",
+    None,
+    "Glob pattern of scenario IDs to run. Defaults to None (runs all scenarios).",
+)
 _SUITE_CONFIG = flags.DEFINE_string(
     "suite_config",
     None,
@@ -56,6 +66,21 @@ def eval(experiment_config: str):
         if parsed_config == "":
             logging.error(f"No Eval Config Found for '{display_config}'.")
             return
+
+        # 1. Merge Environment Variables (overrides YAML)
+        env_scenarios = os.environ.get("EVAL_SCENARIOS")
+        if env_scenarios:
+            parsed_config["scenarios"] = [s.strip() for s in env_scenarios.split(",") if s.strip()]
+
+        env_pattern = os.environ.get("EVAL_SCENARIO_PATTERN")
+        if env_pattern:
+            parsed_config["scenario_pattern"] = env_pattern
+
+        # 2. Merge CLI Flags (overrides Environment Variables and YAML)
+        if _SCENARIOS.value:
+            parsed_config["scenarios"] = _SCENARIOS.value
+        if _SCENARIO_PATTERN.value:
+            parsed_config["scenario_pattern"] = _SCENARIO_PATTERN.value
 
         set_session_configs(session, parsed_config)
         # Load the configs

--- a/evalbench/evalbench.py
+++ b/evalbench/evalbench.py
@@ -77,10 +77,11 @@ def eval(experiment_config: str):
             parsed_config["scenario_pattern"] = env_pattern
 
         # 2. Merge CLI Flags (overrides Environment Variables and YAML)
-        if _SCENARIOS.value:
-            parsed_config["scenarios"] = _SCENARIOS.value
-        if _SCENARIO_PATTERN.value:
-            parsed_config["scenario_pattern"] = _SCENARIO_PATTERN.value
+        if flags.FLAGS.is_parsed():
+            if _SCENARIOS.value:
+                parsed_config["scenarios"] = _SCENARIOS.value
+            if _SCENARIO_PATTERN.value:
+                parsed_config["scenario_pattern"] = _SCENARIO_PATTERN.value
 
         set_session_configs(session, parsed_config)
         # Load the configs

--- a/evalbench/test/dataset_filter_test.py
+++ b/evalbench/test/dataset_filter_test.py
@@ -1,0 +1,134 @@
+import json
+import os
+import shutil
+import sys
+import tempfile
+import unittest
+
+sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from dataset.dataset import load_dataset_from_json
+
+
+class TestDatasetFilter(unittest.TestCase):
+    def setUp(self):
+        self.test_dir = tempfile.mkdtemp()
+
+        # 1. Create a dummy gemini-cli dataset
+        self.gemini_cli_data = {
+            "id": "gemini-cli-test",
+            "scenarios": [
+                {"id": "csql-create-01", "starting_prompt": "create database"},
+                {"id": "csql-delete-01", "starting_prompt": "delete database"},
+                {"id": "spanner-list-01", "starting_prompt": "list instances"},
+                {"id": "spanner-create-01", "starting_prompt": "create spanner"}
+            ]
+        }
+        self.gemini_cli_path = os.path.join(self.test_dir, "gemini_cli_dataset.json")
+        with open(self.gemini_cli_path, "w") as f:
+            json.dump(self.gemini_cli_data, f)
+
+        # 2. Create a dummy cortado dataset
+        self.cortado_data = {
+            "scenarios": [
+                {"id": "cortado-csql-01", "starting_prompt": "csql"},
+                {"id": "cortado-spanner-01", "starting_prompt": "spanner"},
+                {"id": "cortado-bigquery-01", "starting_prompt": "bq"}
+            ]
+        }
+        self.cortado_path = os.path.join(self.test_dir, "cortado_dataset.json")
+        with open(self.cortado_path, "w") as f:
+            json.dump(self.cortado_data, f)
+
+    def tearDown(self):
+        shutil.rmtree(self.test_dir)
+
+    def test_gemini_cli_no_filter(self):
+        config = {"dataset_format": "gemini-cli-format"}
+        result = load_dataset_from_json(self.gemini_cli_path, config)
+        self.assertIn("gemini-cli-format", result)
+        self.assertEqual(len(result["gemini-cli-format"]), 1)
+
+        payload = json.loads(result["gemini-cli-format"][0].payload)
+        scenarios = payload["scenarios"]
+        self.assertEqual(len(scenarios), 4)
+        self.assertEqual(scenarios[0]["id"], "csql-create-01")
+
+    def test_gemini_cli_filter_by_id_list(self):
+        config = {
+            "dataset_format": "gemini-cli-format",
+            "scenarios": ["csql-create-01", "spanner-list-01"]
+        }
+        result = load_dataset_from_json(self.gemini_cli_path, config)
+        payload = json.loads(result["gemini-cli-format"][0].payload)
+        scenarios = payload["scenarios"]
+        self.assertEqual(len(scenarios), 2)
+        self.assertEqual(scenarios[0]["id"], "csql-create-01")
+        self.assertEqual(scenarios[1]["id"], "spanner-list-01")
+
+    def test_gemini_cli_filter_by_pattern(self):
+        config = {
+            "dataset_format": "gemini-cli-format",
+            "scenario_pattern": "csql-*"
+        }
+        result = load_dataset_from_json(self.gemini_cli_path, config)
+        payload = json.loads(result["gemini-cli-format"][0].payload)
+        scenarios = payload["scenarios"]
+        self.assertEqual(len(scenarios), 2)
+        self.assertEqual(scenarios[0]["id"], "csql-create-01")
+        self.assertEqual(scenarios[1]["id"], "csql-delete-01")
+
+    def test_gemini_cli_filter_combined(self):
+        # Combined should do intersection (or check both conditions)
+        config = {
+            "dataset_format": "gemini-cli-format",
+            "scenarios": ["csql-create-01", "spanner-list-01"],
+            "scenario_pattern": "*list*"
+        }
+        result = load_dataset_from_json(self.gemini_cli_path, config)
+        payload = json.loads(result["gemini-cli-format"][0].payload)
+        scenarios = payload["scenarios"]
+        self.assertEqual(len(scenarios), 1)
+        self.assertEqual(scenarios[0]["id"], "spanner-list-01")
+
+    def test_gemini_cli_filter_no_match(self):
+        config = {
+            "dataset_format": "gemini-cli-format",
+            "scenarios": ["non-existent-id"]
+        }
+        result = load_dataset_from_json(self.gemini_cli_path, config)
+        payload = json.loads(result["gemini-cli-format"][0].payload)
+        scenarios = payload["scenarios"]
+        self.assertEqual(len(scenarios), 0)
+
+    def test_cortado_no_filter(self):
+        config = {"dataset_format": "cortado-format"}
+        result = load_dataset_from_json(self.cortado_path, config)
+        self.assertIn("cortado-format", result)
+        self.assertEqual(len(result["cortado-format"]), 3)
+        self.assertEqual(result["cortado-format"][0].id, "cortado-csql-01")
+
+    def test_cortado_filter_by_id_list(self):
+        config = {
+            "dataset_format": "cortado-format",
+            "scenarios": ["cortado-csql-01", "cortado-bigquery-01"]
+        }
+        result = load_dataset_from_json(self.cortado_path, config)
+        items = result["cortado-format"]
+        self.assertEqual(len(items), 2)
+        self.assertEqual(items[0].id, "cortado-csql-01")
+        self.assertEqual(items[1].id, "cortado-bigquery-01")
+
+    def test_cortado_filter_by_pattern(self):
+        config = {
+            "dataset_format": "cortado-format",
+            "scenario_pattern": "*-spanner-*"
+        }
+        result = load_dataset_from_json(self.cortado_path, config)
+        items = result["cortado-format"]
+        self.assertEqual(len(items), 1)
+        self.assertEqual(items[0].id, "cortado-spanner-01")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/evalbench/test/dataset_filter_test.py
+++ b/evalbench/test/dataset_filter_test.py
@@ -40,6 +40,18 @@ class TestDatasetFilter(unittest.TestCase):
         with open(self.cortado_path, "w") as f:
             json.dump(self.cortado_data, f)
 
+        # 3. Create a dummy dea dataset
+        self.dea_data = {
+            "scenarios": [
+                {"id": "dea-csql-01", "starting_prompt": "csql"},
+                {"id": "dea-spanner-01", "starting_prompt": "spanner"},
+                {"id": "dea-bigquery-01", "starting_prompt": "bq"}
+            ]
+        }
+        self.dea_path = os.path.join(self.test_dir, "dea_dataset.json")
+        with open(self.dea_path, "w") as f:
+            json.dump(self.dea_data, f)
+
     def tearDown(self):
         shutil.rmtree(self.test_dir)
 
@@ -97,9 +109,8 @@ class TestDatasetFilter(unittest.TestCase):
             "scenarios": ["non-existent-id"]
         }
         result = load_dataset_from_json(self.gemini_cli_path, config)
-        payload = json.loads(result["gemini-cli-format"][0].payload)
-        scenarios = payload["scenarios"]
-        self.assertEqual(len(scenarios), 0)
+        self.assertIn("gemini-cli-format", result)
+        self.assertEqual(len(result["gemini-cli-format"]), 0)
 
     def test_cortado_no_filter(self):
         config = {"dataset_format": "cortado-format"}
@@ -128,6 +139,58 @@ class TestDatasetFilter(unittest.TestCase):
         items = result["cortado-format"]
         self.assertEqual(len(items), 1)
         self.assertEqual(items[0].id, "cortado-spanner-01")
+
+    def test_scenarios_normalization_string(self):
+        # scenarios provided as a comma-separated string
+        config = {
+            "dataset_format": "gemini-cli-format",
+            "scenarios": "csql-create-01, spanner-list-01"
+        }
+        result = load_dataset_from_json(self.gemini_cli_path, config)
+        payload = json.loads(result["gemini-cli-format"][0].payload)
+        scenarios = payload["scenarios"]
+        self.assertEqual(len(scenarios), 2)
+        self.assertEqual(scenarios[0]["id"], "csql-create-01")
+        self.assertEqual(scenarios[1]["id"], "spanner-list-01")
+
+    def test_dea_no_filter(self):
+        config = {"dataset_format": "dea-format"}
+        result = load_dataset_from_json(self.dea_path, config)
+        self.assertIn("dea-format", result)
+        self.assertEqual(len(result["dea-format"]), 1)
+        scenarios = result["dea-format"][0].scenario["scenarios"]
+        self.assertEqual(len(scenarios), 3)
+        self.assertEqual(scenarios[0]["id"], "dea-csql-01")
+
+    def test_dea_filter_by_id_list(self):
+        config = {
+            "dataset_format": "dea-format",
+            "scenarios": ["dea-csql-01", "dea-bigquery-01"]
+        }
+        result = load_dataset_from_json(self.dea_path, config)
+        scenarios = result["dea-format"][0].scenario["scenarios"]
+        self.assertEqual(len(scenarios), 2)
+        self.assertEqual(scenarios[0]["id"], "dea-csql-01")
+        self.assertEqual(scenarios[1]["id"], "dea-bigquery-01")
+
+    def test_dea_filter_by_pattern(self):
+        config = {
+            "dataset_format": "dea-format",
+            "scenario_pattern": "*-spanner-*"
+        }
+        result = load_dataset_from_json(self.dea_path, config)
+        scenarios = result["dea-format"][0].scenario["scenarios"]
+        self.assertEqual(len(scenarios), 1)
+        self.assertEqual(scenarios[0]["id"], "dea-spanner-01")
+
+    def test_dea_filter_no_match_returns_empty(self):
+        config = {
+            "dataset_format": "dea-format",
+            "scenarios": ["non-existent-id"]
+        }
+        result = load_dataset_from_json(self.dea_path, config)
+        self.assertIn("dea-format", result)
+        self.assertEqual(len(result["dea-format"]), 0)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Avoid having to clobber json files when trying to test a specific scenario (which is also token intensive by agents).

Usage example:

./evalbench/evalbench.py \
  --experiment_config=core-cujs/run_gemini_cli.yaml \
  --scenarios=autoctx-expert-eval-confirm