### PR TITLE
Refactor DataformScorer env inheritance, flatten scorer logic, and add unit tests

### DIFF
--- a/evalbench/scorers/dataformscorer.py
+++ b/evalbench/scorers/dataformscorer.py
@@ -23,28 +23,56 @@ class DataformBaseScorer(comparator.Comparator):
         for root, dirs, files in os.walk(search_root):
             # Limit search to depth 3 from search_root
             depth = root.count(os.sep) - search_root.count(os.sep)
+            # Prevent checking subdirectories with depth > 3
             if depth >= 3:
-                dirs[:] = []  # Stop recursion
-            if 'workflow_settings.yaml' in files:
+                dirs[:] = []
+            if depth <= 3 and 'workflow_settings.yaml' in files:
                 return root
         return None
 
-    def _setup_credentials(self, project_dir: str) -> str:
+    def _get_env_var_source_and_value(self, env_var_name: str, scenario_env: dict) -> Tuple[str | None, str | None]:
+        """Returns the source ('scenario', 'host', or None) and value of the env var."""
+        val = scenario_env.get(env_var_name)
+        if val:
+            return "scenario", val
+
+        val = os.environ.get(env_var_name)
+        if val:
+            return "host", val
+
+        return None, None
+
+    def _resolve_env_var(
+        self,
+        env_var_name: str,
+        scenario_env: dict,
+        target_env: dict,
+        log_messages: list
+    ) -> None:
+        """Resolves an env var from scenario or host env, logs it, and updates target_env."""
+        import logging
+        source, val = self._get_env_var_source_and_value(env_var_name, scenario_env)
+
+        if source in ("scenario", "host"):
+            target_env[env_var_name] = val
+            msg = f"[DataformScorer] got {env_var_name} from {source}: '{val}'"
+        else:
+            msg = f"[DataformScorer] {env_var_name} is missing from both scenario and host env."
+
+        logging.info(msg)
+        log_messages.append(msg)
+
+    def _setup_credentials(self, project_dir: str, project_id: str, env: dict = None) -> str:
         """Sets up .df-credentials.json in the project directory."""
-        project_res = subprocess.run(
-            ["gcloud", "config", "get-value", "project"],
-            capture_output=True, text=True, check=True
-        )
-        project_id = project_res.stdout.strip()
+        if not project_id:
+            raise ValueError("Active project ID is empty.")
 
         region_res = subprocess.run(
             ["gcloud", "config", "get-value", "compute/region"],
-            capture_output=True, text=True, check=True
+            capture_output=True, text=True, check=True,
+            env=env
         )
         region = region_res.stdout.strip() or "US"
-
-        if not project_id:
-            raise ValueError("Active project ID is empty in gcloud configuration.")
 
         credentials_path = os.path.join(project_dir, ".df-credentials.json")
         credentials_content = textwrap.dedent(f"""\
@@ -59,46 +87,82 @@ class DataformBaseScorer(comparator.Comparator):
 
     def run_dataform_command(self, command: List[str], generated_eval_result: Any = None) -> Tuple[float, str]:
         """Executes a Dataform command and returns a score and analysis."""
+        log_messages = []
         try:
             import json
+            import logging
 
-            search_root = '.'
+            # Extract env from scenario
+            parsed = {}
             if isinstance(generated_eval_result, dict):
-                search_root = generated_eval_result.get("fake_home") or '.'
+                parsed = generated_eval_result
             elif isinstance(generated_eval_result, str) and generated_eval_result:
                 try:
                     parsed = json.loads(generated_eval_result)
-                    search_root = parsed.get("fake_home") or '.'
                 except json.JSONDecodeError:
                     pass
 
+            scenario = parsed.get("scenario", {})
+            scenario_env = scenario.get("env", {})
+
+            # Initialize env with host env
+            env = os.environ.copy()
+
+            # Resolve CLOUDSDK_CORE_PROJECT
+            self._resolve_env_var(
+                env_var_name="CLOUDSDK_CORE_PROJECT",
+                scenario_env=scenario_env,
+                target_env=env,
+                log_messages=log_messages
+            )
+
+            # Resolve GOOGLE_CLOUD_PROJECT
+            self._resolve_env_var(
+                env_var_name="GOOGLE_CLOUD_PROJECT",
+                scenario_env=scenario_env,
+                target_env=env,
+                log_messages=log_messages
+            )
+
+            # Determine project_id for credentials setup (prefer CLOUDSDK_CORE_PROJECT to match gcloud default)
+            project_id = env.get("CLOUDSDK_CORE_PROJECT") or env.get("GOOGLE_CLOUD_PROJECT")
+
+            # Enforce project_id is not None
+            if not project_id:
+                return 0.0, "\n".join(log_messages) + "\nError: Both CLOUDSDK_CORE_PROJECT and GOOGLE_CLOUD_PROJECT are missing. Scorer cannot proceed."
+
+            search_root = '.'
+            if parsed:
+                search_root = parsed.get("fake_home") or '.'
+
             project_dir = self._find_project_dir(search_root)
             if project_dir is None:
-                return 0.0, f"Could not find workflow_settings.yaml in the workspace (search root: {search_root})."
+                return 0.0, "\n".join(log_messages) + f"\nCould not find workflow_settings.yaml in the workspace (search root: {search_root})."
 
             if "run" in command:
                 try:
-                    self._setup_credentials(project_dir)
+                    self._setup_credentials(project_dir, project_id, env=env)
                 except subprocess.CalledProcessError as e:
-                    return 0.0, f"Credentials setup failed. gcloud exit code: {e.returncode}. Stderr: {e.stderr.strip()}"
+                    return 0.0, "\n".join(log_messages) + f"\nCredentials setup failed. gcloud exit code: {e.returncode}. Stderr: {e.stderr.strip()}"
                 except (FileNotFoundError, ValueError) as e:
-                    return 0.0, f"Credentials setup failed: {e}"
+                    return 0.0, "\n".join(log_messages) + f"\nCredentials setup failed: {e}"
 
             result = subprocess.run(
                 command,
                 capture_output=True,
                 text=True,
                 check=False,
-                cwd=project_dir
+                cwd=project_dir,
+                env=env
             )
 
             cmd_name = " ".join(command)
             if result.returncode == 0:
-                return 100.0, f"{cmd_name.capitalize()} succeeded."
+                return 100.0, "\n".join(log_messages) + f"\n{cmd_name.capitalize()} succeeded."
             else:
-                return 0.0, f"{cmd_name.capitalize()} failed with exit code {result.returncode}.\nStderr: {result.stderr}"
+                return 0.0, "\n".join(log_messages) + f"\n{cmd_name.capitalize()} failed with exit code {result.returncode}.\nStderr: {result.stderr}"
         except Exception as e:
-            return 0.0, f"An error occurred while running {' '.join(command)}: {e}"
+            return 0.0, "\n".join(log_messages) + f"\nAn error occurred while running {' '.join(command)}: {e}"
 
 
 class DataformCompileScorer(DataformBaseScorer):

--- a/evalbench/test/dataformscorer_test.py
+++ b/evalbench/test/dataformscorer_test.py
@@ -1,0 +1,244 @@
+"""Unit tests for Dataform scorers."""
+
+import os
+import unittest
+from unittest.mock import MagicMock, patch
+
+from scorers.dataformscorer import DataformCompileScorer, DataformRunScorer
+
+
+class TestDataformScorers(unittest.TestCase):
+
+    def setUp(self):
+        self.config = {}
+        self.compile_scorer = DataformCompileScorer(self.config)
+        self.run_scorer = DataformRunScorer(self.config)
+
+        # Clear environment variables to avoid pollution from host
+        self.env_patcher = patch.dict(os.environ, {}, clear=True)
+        self.env_patcher.start()
+
+    def tearDown(self):
+        self.env_patcher.stop()
+
+    @patch("scorers.dataformscorer.os.walk")
+    def test_find_project_dir_success(self, mock_walk):
+        mock_walk.return_value = [
+            ("/tmp/fake_home", ["definitions"], ["workflow_settings.yaml"]),
+        ]
+        project_dir = self.compile_scorer._find_project_dir("/tmp/fake_home")
+        self.assertEqual(project_dir, "/tmp/fake_home")
+
+    @patch("scorers.dataformscorer.os.walk")
+    def test_find_project_dir_depth_limit(self, mock_walk):
+        mock_walk.return_value = [
+            ("/tmp/fake_home/a/b/c/d/e", [], ["workflow_settings.yaml"]),
+        ]
+        project_dir = self.compile_scorer._find_project_dir("/tmp/fake_home")
+        self.assertIsNone(project_dir)
+
+    @patch("scorers.dataformscorer.os.walk")
+    def test_find_project_dir_exact_depth_limit(self, mock_walk):
+        # Mock os.walk to yield hierarchy up to depth 3
+        mock_walk.return_value = [
+            ("/tmp/fake_home", ["a"], []),
+            ("/tmp/fake_home/a", ["b"], []),
+            ("/tmp/fake_home/a/b", ["c"], []),
+            ("/tmp/fake_home/a/b/c", [], ["workflow_settings.yaml"]),
+        ]
+        project_dir = self.compile_scorer._find_project_dir("/tmp/fake_home")
+        self.assertEqual(project_dir, "/tmp/fake_home/a/b/c")
+
+    def test_get_env_var_source_and_value_scenario(self):
+        scenario_env = {"MY_VAR": "scenario_val"}
+        source, val = self.compile_scorer._get_env_var_source_and_value("MY_VAR", scenario_env)
+        self.assertEqual(source, "scenario")
+        self.assertEqual(val, "scenario_val")
+
+    @patch.dict(os.environ, {"MY_VAR": "host_val"})
+    def test_get_env_var_source_and_value_host(self):
+        scenario_env = {}
+        source, val = self.compile_scorer._get_env_var_source_and_value("MY_VAR", scenario_env)
+        self.assertEqual(source, "host")
+        self.assertEqual(val, "host_val")
+
+    def test_get_env_var_source_and_value_none(self):
+        scenario_env = {}
+        source, val = self.compile_scorer._get_env_var_source_and_value("MY_VAR", scenario_env)
+        self.assertIsNone(source)
+        self.assertIsNone(val)
+
+    def test_resolve_env_var_from_scenario(self):
+        scenario_env = {"TEST_VAR": "val1"}
+        target_env = {}
+        log_messages = []
+        self.compile_scorer._resolve_env_var("TEST_VAR", scenario_env, target_env, log_messages)
+        self.assertEqual(target_env["TEST_VAR"], "val1")
+        self.assertTrue(any("got TEST_VAR from scenario" in msg for msg in log_messages))
+
+    @patch.dict(os.environ, {"TEST_VAR": "val2"})
+    def test_resolve_env_var_from_host(self):
+        scenario_env = {}
+        target_env = {}
+        log_messages = []
+        self.compile_scorer._resolve_env_var("TEST_VAR", scenario_env, target_env, log_messages)
+        self.assertEqual(target_env["TEST_VAR"], "val2")
+        self.assertTrue(any("got TEST_VAR from host" in msg for msg in log_messages))
+
+    def test_resolve_env_var_missing(self):
+        scenario_env = {}
+        target_env = {}
+        log_messages = []
+        self.compile_scorer._resolve_env_var("TEST_VAR", scenario_env, target_env, log_messages)
+        self.assertNotIn("TEST_VAR", target_env)
+        self.assertTrue(any("TEST_VAR is missing" in msg for msg in log_messages))
+
+    @patch("scorers.dataformscorer.subprocess.run")
+    @patch("builtins.open", new_callable=unittest.mock.mock_open)
+    def test_setup_credentials_success(self, mock_open, mock_run):
+        mock_process = MagicMock()
+        mock_process.stdout = "us-east1\n"
+        mock_run.return_value = mock_process
+
+        project_id = "my-project"
+        env = {"CLOUDSDK_CORE_PROJECT": project_id}
+
+        resolved_project = self.compile_scorer._setup_credentials("/tmp/project", project_id, env=env)
+
+        self.assertEqual(resolved_project, project_id)
+        mock_run.assert_called_once_with(
+            ["gcloud", "config", "get-value", "compute/region"],
+            capture_output=True, text=True, check=True,
+            env=env
+        )
+        mock_open.assert_called_once_with("/tmp/project/.df-credentials.json", "w")
+        # Verify content written
+        handle = mock_open()
+        written_content = handle.write.call_args[0][0]
+        self.assertIn('"projectId": "my-project"', written_content)
+        self.assertIn('"location": "us-east1"', written_content)
+
+    @patch("scorers.dataformscorer.os.walk")
+    @patch("scorers.dataformscorer.subprocess.run")
+    def test_run_dataform_command_env_inheritance_scenario(self, mock_run, mock_walk):
+        mock_walk.return_value = [
+            ("/tmp/project", [], ["workflow_settings.yaml"]),
+        ]
+        mock_process = MagicMock()
+        mock_process.returncode = 0
+        mock_process.stdout = "Success"
+        mock_run.return_value = mock_process
+
+        generated_eval_result = {
+            "fake_home": "/tmp",
+            "scenario": {
+                "env": {
+                    "CLOUDSDK_CORE_PROJECT": "scenario-sdk-proj",
+                    "GOOGLE_CLOUD_PROJECT": "scenario-gcp-proj"
+                }
+            }
+        }
+
+        score, message = self.compile_scorer.compare(
+            nl_prompt="test",
+            golden_query="test",
+            query_type="test",
+            golden_execution_result=[],
+            golden_eval_result="",
+            golden_error="",
+            generated_query="test",
+            generated_execution_result=[],
+            generated_eval_result=generated_eval_result,
+            generated_error="",
+        )
+
+        self.assertEqual(score, 100.0)
+        self.assertIn("got CLOUDSDK_CORE_PROJECT from scenario: 'scenario-sdk-proj'", message)
+        self.assertIn("got GOOGLE_CLOUD_PROJECT from scenario: 'scenario-gcp-proj'", message)
+
+        # Verify subprocess.run was called with inherited env
+        mock_run.assert_called_once()
+        _, kwargs = mock_run.call_args
+        subprocess_env = kwargs["env"]
+        self.assertEqual(subprocess_env["CLOUDSDK_CORE_PROJECT"], "scenario-sdk-proj")
+        self.assertEqual(subprocess_env["GOOGLE_CLOUD_PROJECT"], "scenario-gcp-proj")
+
+    @patch("scorers.dataformscorer.os.walk")
+    @patch("scorers.dataformscorer.subprocess.run")
+    def test_run_dataform_command_env_inheritance_host(self, mock_run, mock_walk):
+        mock_walk.return_value = [
+            ("/tmp/project", [], ["workflow_settings.yaml"]),
+        ]
+        mock_process = MagicMock()
+        mock_process.returncode = 0
+        mock_process.stdout = "Success"
+        mock_run.return_value = mock_process
+
+        # Set host env
+        os.environ["CLOUDSDK_CORE_PROJECT"] = "host-sdk-proj"
+        os.environ["GOOGLE_CLOUD_PROJECT"] = "host-gcp-proj"
+
+        generated_eval_result = {
+            "fake_home": "/tmp",
+            "scenario": {
+                "env": {}  # Empty scenario env
+            }
+        }
+
+        score, message = self.compile_scorer.compare(
+            nl_prompt="test",
+            golden_query="test",
+            query_type="test",
+            golden_execution_result=[],
+            golden_eval_result="",
+            golden_error="",
+            generated_query="test",
+            generated_execution_result=[],
+            generated_eval_result=generated_eval_result,
+            generated_error="",
+        )
+
+        self.assertEqual(score, 100.0)
+        self.assertIn("got CLOUDSDK_CORE_PROJECT from host: 'host-sdk-proj'", message)
+        self.assertIn("got GOOGLE_CLOUD_PROJECT from host: 'host-gcp-proj'", message)
+
+        # Verify subprocess.run was called with host env
+        mock_run.assert_called_once()
+        _, kwargs = mock_run.call_args
+        subprocess_env = kwargs["env"]
+        self.assertEqual(subprocess_env["CLOUDSDK_CORE_PROJECT"], "host-sdk-proj")
+        self.assertEqual(subprocess_env["GOOGLE_CLOUD_PROJECT"], "host-gcp-proj")
+
+    @patch("scorers.dataformscorer.os.walk")
+    def test_run_dataform_command_missing_all_fails(self, mock_walk):
+        mock_walk.return_value = [
+            ("/tmp/project", [], ["workflow_settings.yaml"]),
+        ]
+
+        # No scenario env, and host env is cleared by setUp patcher
+        generated_eval_result = {
+            "fake_home": "/tmp",
+            "scenario": {
+                "env": {}
+            }
+        }
+
+        score, message = self.compile_scorer.compare(
+            nl_prompt="test",
+            golden_query="test",
+            query_type="test",
+            golden_execution_result=[],
+            golden_eval_result="",
+            golden_error="",
+            generated_query="test",
+            generated_execution_result=[],
+            generated_eval_result=generated_eval_result,
+            generated_error="",
+        )
+
+        self.assertEqual(score, 0.0)
+        self.assertIn("Error: Both CLOUDSDK_CORE_PROJECT and GOOGLE_CLOUD_PROJECT are missing", message)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Summary
This PR refactors the `DataformScorer` to inherit and propagate Google Cloud environment variables (`CLOUDSDK_CORE_PROJECT` and `GOOGLE_CLOUD_PROJECT`) from the evaluation scenario configuration, falling back to the host environment if missing. 

It also flattens the scorer's environment resolution logic to improve readability, fixes a minor boundary bug in project directory searching, and introduces a comprehensive unit test suite to prevent regressions.

---

### Key Changes

#### 1. Environment Var Inheritance & Propagation
*   Updated `DataformScorer` to resolve both `CLOUDSDK_CORE_PROJECT` and `GOOGLE_CLOUD_PROJECT` independently.
*   Preferred `CLOUDSDK_CORE_PROJECT` as the source of truth when generating the `.df-credentials.json` file (aligning with `gcloud` defaults), while still propagating both variables to the Dataform subprocess environment.

#### 2. Scorer Code Flattening
*   Introduced `_get_env_var_source_and_value` to cleanly separate the logic of finding a variable and determining its source (`scenario` vs `host`).

#### 3. Bug Fix: Directory Depth Limit
*   Added a `depth <= 3` guard to the return condition in `_find_project_dir` (matching the implementation in `dbtscorer.py`). This ensures that if a directory path deeper than depth 3 is checked, the scorer will not accept it as a valid project root.

#### 4. Unit Tests
*   Created a new test suite: `evalbench/test/dataformscorer_test.py` containing **13 tests** covering:
    *   Helper methods (`_find_project_dir`, `_get_env_var_source_and_value`, `_resolve_env_var`, `_setup_credentials`).
    *   Boundary conditions (verifying project resolution at *exactly* depth 3, and failure beyond depth 3).
    *   Environment inheritance from the scenario config.
    *   Fallback to the host environment.
    *   Graceful early failure when both project variables are missing.

---

### Verification & Testing

#### 1. Unit Tests
Ran the new test suite locally. All 13 tests passed successfully:
```bash
PYTHONPATH=./evalbench python3 evalbench/test/dataformscorer_test.py
.............
----------------------------------------------------------------------
Ran 13 tests in 0.008s
OK
```

#### 2. Real-World Scenario Run
Ran a real-world evaluation using the `data_prep_ecommerce` scenario from the `datacloud_vscode` integration test cases. 

The evaluation logs confirmed that the scorer successfully and independently inherited both variables from the scenario's `env` block:
```csv
[DataformScorer] got CLOUDSDK_CORE_PROJECT from scenario: 'bq-dataworkeragent-test'
[DataformScorer] got GOOGLE_CLOUD_PROJECT from scenario: 'bq-dataworkeragent-test'
```