### PR TITLE
## Fix Sandbox Isolation Violation (cwd omission) in Codex CLI Generator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -196,11 +196,11 @@ viewer/version.txt
 .jetskicli/project.json
 
 # Local testing datasets/configs (do not commit)
-datasets/bqml/Bullseye_PCA.json
-datasets/bqml/Bullseye_PCA_config.yaml
+datasets/bqml/
 datasets/model_configs/gemini_cli_test_model.yaml
 datasets/model_configs/gemini_2.5_pro_test_model.yaml
 datasets/model_configs/gemini_3_flash_test_model.yaml
+datasets/model_configs/codex_cli_dak_model.yaml
 
 
 

--- a/evalbench/generators/models/codex_cli.py
+++ b/evalbench/generators/models/codex_cli.py
@@ -41,12 +41,13 @@ def _fetch_secret_manager(path: str) -> str:
 
 
 class CLICommand:
-    def __init__(self, cli, prompt, env=None, resume=False, session_id=None):
+    def __init__(self, cli, prompt, env=None, resume=False, session_id=None, cwd=None):
         self.cli = cli
         self.prompt = prompt
         self.env = env if env else {}
         self.resume = resume
         self.session_id = session_id
+        self.cwd = cwd
 
 
 class CodexCliGenerator(AgentCliGenerator):
@@ -588,7 +589,7 @@ class CodexCliGenerator(AgentCliGenerator):
     )
 
     def _execute_cli_command(
-        self, command: list[str], env: dict[str, str] | None = None,
+        self, command: list[str], env: dict[str, str] | None = None, cwd: str | None = None,
     ) -> tuple[subprocess.CompletedProcess, dict[str, int]]:
         """Runs the Codex CLI with line-streamed stdout so we can stamp the
         wall-clock time at which each NDJSON event arrives.
@@ -601,7 +602,7 @@ class CodexCliGenerator(AgentCliGenerator):
         """
         try:
             proc = subprocess.Popen(
-                command, env=env, text=True,
+                command, env=env, cwd=cwd or self.fake_home, text=True,
                 stdin=subprocess.DEVNULL,
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
@@ -728,7 +729,7 @@ class CodexCliGenerator(AgentCliGenerator):
         logging.info(f"Running Codex CLI: {' '.join(command)}")
 
         start_ms = time.monotonic()
-        result, tool_durations = self._execute_cli_command(command, env=env)
+        result, tool_durations = self._execute_cli_command(command, env=env, cwd=cli_cmd.cwd)
         duration_ms = int((time.monotonic() - start_ms) * 1000)
         if result.stdout:
             result.stdout = self._parse_stream_json(
@@ -1173,5 +1174,5 @@ class CodexCliGenerator(AgentCliGenerator):
             merged_env.update(env)
         return CLICommand(
             cli=cli, prompt=prompt, env=merged_env,
-            resume=resume, session_id=session_id,
+            resume=resume, session_id=session_id, cwd=cwd,
         )

--- a/evalbench/test/codex_cli_test.py
+++ b/evalbench/test/codex_cli_test.py
@@ -1,0 +1,61 @@
+import os
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from generators.models.codex_cli import CodexCliGenerator, CLICommand
+
+
+@patch('generators.models.codex_cli.subprocess.Popen')
+def test_execute_cli_command_passes_cwd(mock_popen, monkeypatch):
+    monkeypatch.setenv("HOME", "/fake/real_home")
+
+    with (
+        patch('generators.models.codex_cli.os.makedirs'),
+        patch('generators.models.codex_cli.open', create=True),
+    ):
+        generator = CodexCliGenerator({"model": "gpt-4"})
+
+    mock_proc = MagicMock()
+    mock_proc.stdout = []
+    mock_proc.stderr = []
+    mock_proc.returncode = 0
+    mock_popen.return_value = mock_proc
+
+    cli_cmd = generator.create_command("codex", "do something", cwd="/some/custom/cwd")
+    assert cli_cmd.cwd == "/some/custom/cwd"
+
+    generator.safe_generate(cli_cmd)
+
+    mock_popen.assert_called_once()
+    kwargs = mock_popen.call_args.kwargs
+    assert kwargs.get("cwd") == "/some/custom/cwd"
+
+
+@patch('generators.models.codex_cli.subprocess.Popen')
+def test_execute_cli_command_default_cwd(mock_popen, monkeypatch):
+    monkeypatch.setenv("HOME", "/fake/real_home")
+
+    with (
+        patch('generators.models.codex_cli.os.makedirs'),
+        patch('generators.models.codex_cli.open', create=True),
+    ):
+        generator = CodexCliGenerator({"model": "gpt-4"})
+
+    mock_proc = MagicMock()
+    mock_proc.stdout = []
+    mock_proc.stderr = []
+    mock_proc.returncode = 0
+    mock_popen.return_value = mock_proc
+
+    cli_cmd = generator.create_command("codex", "do something")
+    assert cli_cmd.cwd is None
+
+    generator.safe_generate(cli_cmd)
+
+    mock_popen.assert_called_once()
+    kwargs = mock_popen.call_args.kwargs
+    assert kwargs.get("cwd") == generator.fake_home

--- a/evalbench/test/codex_cli_test.py
+++ b/evalbench/test/codex_cli_test.py
@@ -2,11 +2,9 @@ import os
 import sys
 from unittest.mock import MagicMock, patch
 
-import pytest
-
 sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
-from generators.models.codex_cli import CodexCliGenerator, CLICommand
+from generators.models.codex_cli import CodexCliGenerator
 
 
 @patch('generators.models.codex_cli.subprocess.Popen')


### PR DESCRIPTION
## Fix Sandbox Isolation Violation (cwd omission) in Codex CLI Generator

### Problem
When the Codex CLI generator executed commands (`codex exec`), it did not forward the working directory (`cwd`) parameter to the underlying `subprocess.Popen` invocation. As a result, Codex CLI executed commands and produced side-effects (such as generating files and notebook outputs) in the host project's root directory instead of within the isolated sandbox directory (`.venv/fake_home_codex`).

### Comparison with Other Generators
Other CLI-based generators like `GeminiCliGenerator` and `ClaudeCodeGenerator` correctly accept the `cwd` argument in their commands and forward it to `subprocess.run`/`subprocess.Popen` (defaulting to their respective sandboxed fake home directories). The `CodexCliGenerator` was an outlier failing to do so.

### Changes Made
1. **Added `cwd` parameter**: Added support for the `cwd` parameter to `CLICommand` and `CodexCliGenerator.create_command`.
2. **Passed `cwd` to `subprocess.Popen`**: Updated `CodexCliGenerator._execute_cli_command` to receive the `cwd` argument and pass it to `subprocess.Popen`, defaulting to `self.fake_home` if not specified.
3. **Ignored local testing configs**: Updated `.gitignore` to exclude the entire `datasets/bqml/` folder from version control.

### Tests
Created a new unit test suite [codex_cli_test.py](file:///usr/local/google/home/silviojr/git/evalbench/evalbench/test/codex_cli_test.py) validating that:
* The CLI command correctly runs inside the custom `cwd` when one is explicitly provided.
* The CLI command defaults to executing inside the generator's `self.fake_home` directory when `cwd` is omitted.