### PR TITLE
Feat/mcp readability generator

### DIFF
--- a/datasets/mcp_readability/endpoints.yaml
+++ b/datasets/mcp_readability/endpoints.yaml
@@ -20,9 +20,12 @@ endpoints:
     endpoint_type: DEV
     tools_source:
       type: stdio
+      # MCP Toolbox for Databases, run over stdio via its npm wrapper.
       command: "npx"
-      args: ["-y", "<toolbox-package>", "--prebuilt", "bigquery", "--stdio"]
-      # env: { ... }                   # optional process env (creds, config)
+      args: ["-y", "@toolbox-sdk/server", "--prebuilt=bigquery", "--stdio"]
+      # Needs BigQuery credentials in the environment (ADC + project), e.g.:
+      # env:
+      #   BIGQUERY_PROJECT: "your-gcp-project"
 
   - product_name: "Sample (offline)"
     endpoint_type: DEV

--- a/datasets/mcp_readability/endpoints.yaml
+++ b/datasets/mcp_readability/endpoints.yaml
@@ -1,0 +1,31 @@
+# Sample MCP endpoints. Each entry has: product_name, endpoint_type
+# (PROD | AUTOPUSH | STAGING | DEV), and a pluggable tools_source.
+#
+# An endpoint's identity for reporting is (product_name, endpoint_type). The
+# source is defined entirely by tools_source — there is no top-level endpoint_url.
+# tools_source.type selects how tools are obtained (independent of endpoint_type,
+# which is just the deployment channel / reporting metadata):
+#   http  - live tools/list over Streamable HTTP; url is the endpoint address
+#   stdio - launch a local MCP server and speak MCP over its stdio pipes
+#   file  - read a raw tools/list JSON dump (offline / deterministic)
+
+endpoints:
+  - product_name: "Cloud SQL"
+    endpoint_type: PROD
+    tools_source:
+      type: http
+      url: "https://sqladmin.googleapis.com/mcp"
+
+  - product_name: "MCP Toolbox (BigQuery)"
+    endpoint_type: DEV
+    tools_source:
+      type: stdio
+      command: "npx"
+      args: ["-y", "<toolbox-package>", "--prebuilt", "bigquery", "--stdio"]
+      # env: { ... }                   # optional process env (creds, config)
+
+  - product_name: "Sample (offline)"
+    endpoint_type: DEV
+    tools_source:
+      type: file
+      path: datasets/mcp_readability/sample_tools.json

--- a/datasets/mcp_readability/exceptions.yaml
+++ b/datasets/mcp_readability/exceptions.yaml
@@ -1,0 +1,14 @@
+# Per-endpoint rule waivers (sample). A waived rule is excluded from the
+# P0/P1/P2 counts and reported separately under "waived". Matchers (all present
+# must match; absent field or "*" = match-all):
+#   product_name, endpoint_type.
+# rule_id references a style-guide rule's {#tag} anchor.
+
+exceptions:
+  - product_name: "Cloud SQL"          # waive one rule for one product
+    rule_id: "tool-names"
+    reason: "Legacy tool names retained for backward compatibility."
+
+  - endpoint_type: AUTOPUSH            # waive a rule across a whole channel
+    rule_id: "use-enums"
+    reason: "Autopush builds defer enum constraints until promotion to prod."

--- a/datasets/mcp_readability/run_config.yaml
+++ b/datasets/mcp_readability/run_config.yaml
@@ -1,0 +1,44 @@
+############################################################
+### MCP Readability — sample run config
+############################################################
+# Drives the `mcp_readability` orchestrator: for each endpoint, fetch its tools
+# (rendered as a man-page), score them against the style guide with an LLM, and
+# emit one result row per endpoint to the shared EvalBench reporters.
+#
+# NOTE: this is a sample/illustrative config. The `mcp_tools` generator (this PR)
+# already consumes `endpoints.yaml` and each entry's `tools_source`. The
+# `mcp_readability` orchestrator and the LLM judge referenced below land in a
+# follow-up PR.
+
+orchestrator: mcp_readability
+
+# Inputs (paths relative to the repo root / run cwd).
+endpoints_config: datasets/mcp_readability/endpoints.yaml
+exceptions_config: datasets/mcp_readability/exceptions.yaml          # optional
+tools_generator_config: datasets/mcp_readability/tools_generator.yaml
+
+# Token budget for token_budget_used_percent (endpoints may override per-entry).
+token_budget: 200000
+
+# Optional filter: only check endpoints whose endpoint_type is in this list.
+# Empty = check all. e.g. [PROD]
+endpoint_types: []
+
+# LLM judge: consumes a model config and the style-guide path. Reuses the
+# shared repo model config.
+readability_judge:
+  model_config: datasets/model_configs/gemini_2.5_pro_model.yaml
+  style_guide: datasets/mcp_readability/style_guide.md
+
+# Per-endpoint check concurrency.
+runners:
+  endpoint_runners: 4
+
+# Shared EvalBench reporters. CSV writes results/<job_id>/evals.csv; uncomment
+# bigquery to also append rows to <gcp_project_id>.evalbench.results
+# (schema auto-evolves).
+reporting:
+  csv:
+    output_directory: 'results'
+  # bigquery:
+  #   gcp_project_id: your-gcp-project

--- a/datasets/mcp_readability/sample_tools.json
+++ b/datasets/mcp_readability/sample_tools.json
@@ -1,0 +1,51 @@
+{
+  "tools": [
+    {
+      "name": "list_datasets",
+      "description": "List all BigQuery datasets in the given project.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "project_id": {
+            "type": "string",
+            "description": "The Google Cloud project ID."
+          },
+          "page_size": {
+            "type": "integer",
+            "description": "Maximum number of datasets to return.",
+            "default": 50
+          },
+          "page_token": {
+            "type": "string",
+            "description": "Opaque token from a previous response for the next page."
+          }
+        },
+        "required": ["project_id"]
+      }
+    },
+    {
+      "name": "get_job_state",
+      "description": "Return the current state of a BigQuery job.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "project_id": {
+            "type": "string",
+            "description": "The Google Cloud project ID."
+          },
+          "job_id": {
+            "type": "string",
+            "description": "The BigQuery job identifier."
+          },
+          "view": {
+            "type": "string",
+            "description": "How much job detail to return.",
+            "enum": ["BASIC", "FULL"],
+            "default": "BASIC"
+          }
+        },
+        "required": ["project_id", "job_id"]
+      }
+    }
+  ]
+}

--- a/datasets/mcp_readability/style_guide.md
+++ b/datasets/mcp_readability/style_guide.md
@@ -1,0 +1,31 @@
+# Data Cloud MCP Tool Style Guide (sample)
+
+This is a small, illustrative style guide for the MCP readability check. Each rule
+heading is annotated with a priority (`<!-- priority: pX -->`) and a stable
+`{#tag}` anchor. The readability judge uses the priority to assign severity
+(`p0`→P0, `p1`→P1, `p2`→P2) and uses the `{#tag}` anchor as the `rule_id`, so
+waivers in `exceptions.yaml` stay valid even when a heading is reworded.
+
+### Tool Names <!-- priority: p1 --> {#tool-names}
+
+Tool names should be `snake_case` and read as `<action>_<resource>` (e.g.
+`list_datasets`, `get_instance`). Avoid abbreviations or internal jargon an agent
+is unlikely to recognize.
+
+### Concise, Complete Descriptions <!-- priority: p1 --> {#descriptions}
+
+Every tool and every parameter must have a description that says what it does and
+when to use it. Descriptions should be concise but self-contained — the agent
+should not need external documentation to call the tool correctly.
+
+### Use Enums for Closed Sets <!-- priority: p2 --> {#use-enums}
+
+When a parameter accepts a fixed set of values, declare them as an `enum` in the
+input schema rather than describing the options in prose, so the agent always
+picks a valid value.
+
+### Safe Pagination <!-- priority: p0 --> {#safe-pagination}
+
+List operations that can return large result sets must expose pagination (for
+example `page_size` and `page_token`) so an agent can page through results safely
+instead of requesting an unbounded response.

--- a/datasets/mcp_readability/tools_generator.yaml
+++ b/datasets/mcp_readability/tools_generator.yaml
@@ -1,0 +1,4 @@
+# Config for the mcp_tools generator (the system-under-test fetcher).
+# Selected by `tools_generator_config` in the run config; built via get_generator.
+generator: mcp_tools
+timeout: 30

--- a/evalbench/generators/models/__init__.py
+++ b/evalbench/generators/models/__init__.py
@@ -12,6 +12,7 @@ from .claude_code import ClaudeCodeGenerator
 from .codex_cli import CodexCliGenerator
 from .gcp_data_engineering_agent import DataEngineeringAgentGenerator
 from .agy_cli import AgyCliGenerator
+from .mcp_tools import McpToolsGenerator
 from util.config import load_yaml_config
 
 
@@ -36,6 +37,7 @@ def get_generator(global_models, model_config_path: str, db: DB = None):
             "codex_cli": lambda: CodexCliGenerator(config),
             "data_engineering_agent": lambda: DataEngineeringAgentGenerator(config),
             "agy_cli": lambda: AgyCliGenerator(config),
+            "mcp_tools": lambda: McpToolsGenerator(config),
         }
         generator = config["generator"]
         if generator not in generators:

--- a/evalbench/generators/models/mcp_tools.py
+++ b/evalbench/generators/models/mcp_tools.py
@@ -8,10 +8,9 @@ readability *scorer* then evaluates against the style guide.
 The source is pluggable per endpoint via ``tools_source.type``. The type names
 the *transport*, not the protocol -- ``http`` and ``stdio`` both speak MCP:
   - ``http``: live MCP ``tools/list`` over Streamable HTTP using the official
-    ``mcp`` Python SDK. The fetch URL is ``tools_source.url`` (falling back to
-    the endpoint's ``endpoint_url``). No authentication is configured -- the
-    public endpoints are reached unauthenticated; auth can be added back later
-    if a future endpoint requires it.
+    ``mcp`` Python SDK. The fetch URL is ``tools_source.url``. No authentication
+    is configured -- the public endpoints are reached unauthenticated; auth can
+    be added back later if a future endpoint requires it.
   - ``stdio``: launch a local MCP server via a command and speak MCP over its
     stdio pipes (official ``mcp`` SDK). The process is started before fetching,
     ``tools/list`` is called, then it is shut down. For local / command-launched
@@ -74,7 +73,7 @@ class McpToolsGenerator(QueryGenerator):
         if source_type == "file":
             tools = self._from_file(source)
         elif source_type == "http":
-            tools = self._from_http(source, endpoint)
+            tools = self._from_http(source)
         elif source_type == "stdio":
             tools = self._from_stdio(source)
         else:
@@ -112,12 +111,10 @@ class McpToolsGenerator(QueryGenerator):
     # ------------------------------------------------------------------
     # http source (official SDK over Streamable HTTP, no auth)
     # ------------------------------------------------------------------
-    def _from_http(self, source: dict, endpoint: dict) -> list[mcp_types.Tool]:
-        raw_url = source.get("url") or endpoint.get("endpoint_url")
+    def _from_http(self, source: dict) -> list[mcp_types.Tool]:
+        raw_url = source.get("url")
         if not raw_url:
-            raise McpToolsError(
-                "tools_source.type 'http' requires a 'url' (or endpoint_url)"
-            )
+            raise McpToolsError("tools_source.type 'http' requires a 'url'")
         url = self.sanitize_url(raw_url)
         try:
             return anyio.run(functools.partial(self._async_fetch_tools, url))

--- a/evalbench/generators/models/mcp_tools.py
+++ b/evalbench/generators/models/mcp_tools.py
@@ -1,0 +1,230 @@
+"""Generator that fetches an MCP endpoint's tools and renders man-page markup.
+
+This plays the EvalBench *generator* role for the MCP readability check: instead
+of asking a model to produce an artifact, it fetches the tool listing from the
+"system under test" (an MCP endpoint) and renders the man-page markup that the
+readability *scorer* then evaluates against the style guide.
+
+The source is pluggable per endpoint via ``tools_source.type``. The type names
+the *transport*, not the protocol -- ``http`` and ``stdio`` both speak MCP:
+  - ``http``: live MCP ``tools/list`` over Streamable HTTP using the official
+    ``mcp`` Python SDK. The fetch URL is ``tools_source.url`` (falling back to
+    the endpoint's ``endpoint_url``). No authentication is configured -- the
+    public endpoints are reached unauthenticated; auth can be added back later
+    if a future endpoint requires it.
+  - ``stdio``: launch a local MCP server via a command and speak MCP over its
+    stdio pipes (official ``mcp`` SDK). The process is started before fetching,
+    ``tools/list`` is called, then it is shut down. For local / command-launched
+    servers such as MCP Toolbox.
+  - ``file``: read a local spec in the raw ``tools/list`` format
+    (``{"tools": [...]}``); dependency-free, for offline / deterministic runs.
+"""
+
+import functools
+import json
+import logging
+import os
+
+import anyio
+
+from mcp import types as mcp_types
+from mcp import StdioServerParameters
+from mcp.client.session import ClientSession
+from mcp.client.stdio import stdio_client
+from mcp.client.streamable_http import streamablehttp_client
+
+from .generator import QueryGenerator
+from .mcp_tool_formatter import format_tools_to_man_page
+
+
+class McpToolsError(Exception):
+    """Raised when a tools spec cannot be fetched or parsed."""
+
+
+class McpToolsGenerator(QueryGenerator):
+    """Fetches an MCP endpoint's tools and renders them as man-page markup."""
+
+    def __init__(self, querygenerator_config):
+        super().__init__(querygenerator_config)
+        self.name = "mcp_tools"
+        cfg = querygenerator_config or {}
+        self.timeout = cfg.get("timeout", 30)
+
+    # The abstract base requires generate_internal; the orchestrator calls
+    # fetch_tools directly, but we keep this so the class is a valid generator.
+    def generate_internal(self, prompt):
+        if isinstance(prompt, dict):
+            _, man_page = self.fetch_tools(prompt)
+            return man_page
+        return ""
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+    def fetch_tools(self, endpoint: dict) -> tuple[list[mcp_types.Tool], str]:
+        """Fetch tools for ``endpoint`` and render man-page markup.
+
+        Returns ``(tools, man_page)`` where ``tools`` is a list of
+        ``mcp.types.Tool`` (used by the metrics scorer) and ``man_page`` is the
+        rendered markup string (fed to the readability scorer).
+        """
+        source = self._resolve_source(endpoint)
+        source_type = (source.get("type") or "http").lower()
+
+        if source_type == "file":
+            tools = self._from_file(source)
+        elif source_type == "http":
+            tools = self._from_http(source, endpoint)
+        elif source_type == "stdio":
+            tools = self._from_stdio(source)
+        else:
+            raise McpToolsError(f"Unknown tools_source.type '{source_type}'")
+
+        return tools, format_tools_to_man_page(tools)
+
+    # ------------------------------------------------------------------
+    # Source resolution
+    # ------------------------------------------------------------------
+    @staticmethod
+    def _resolve_source(endpoint: dict) -> dict:
+        """The endpoint's ``tools_source`` (or ``{}`` to default to ``http``)."""
+        return dict(endpoint.get("tools_source") or {})
+
+    @staticmethod
+    def sanitize_url(url: str) -> str:
+        """Ensure the URL has a scheme and ends with ``/mcp``.
+
+        ``/mcp`` is the conventional path where the MCP protocol is exposed.
+        """
+        stripped_url = (url or "").strip()
+        if stripped_url.startswith(("http://", "https://")):
+            url_with_scheme = stripped_url
+        elif "localhost" in stripped_url:
+            url_with_scheme = f"http://{stripped_url}"
+        else:
+            url_with_scheme = f"https://{stripped_url}"
+
+        rstripped_url = url_with_scheme.rstrip("/")
+        if not rstripped_url.endswith("/mcp"):
+            return f"{rstripped_url}/mcp"
+        return rstripped_url
+
+    # ------------------------------------------------------------------
+    # http source (official SDK over Streamable HTTP, no auth)
+    # ------------------------------------------------------------------
+    def _from_http(self, source: dict, endpoint: dict) -> list[mcp_types.Tool]:
+        raw_url = source.get("url") or endpoint.get("endpoint_url")
+        if not raw_url:
+            raise McpToolsError(
+                "tools_source.type 'http' requires a 'url' (or endpoint_url)"
+            )
+        url = self.sanitize_url(raw_url)
+        try:
+            return anyio.run(functools.partial(self._async_fetch_tools, url))
+        except McpToolsError:
+            raise
+        except Exception as e:
+            raise McpToolsError(f"Failed to fetch tools from {url}: {e}") from e
+
+    async def _async_fetch_tools(self, url: str) -> list[mcp_types.Tool]:
+        """Connect to the MCP server over Streamable HTTP and list its tools."""
+        async with streamablehttp_client(url, timeout=self.timeout) as streams:
+            reader, writer, _ = streams
+            async with ClientSession(reader, writer) as session:
+                await session.initialize()
+                tools_response = await session.list_tools()
+        return list(tools_response.tools)
+
+    # ------------------------------------------------------------------
+    # stdio source (official SDK over a launched local process)
+    # ------------------------------------------------------------------
+    def _from_stdio(self, source: dict) -> list[mcp_types.Tool]:
+        command = source.get("command")
+        if not command:
+            raise McpToolsError("tools_source.type 'stdio' requires a 'command'")
+        args = list(source.get("args") or [])
+        # Merge the current environment with any per-source overrides so the
+        # launched server inherits PATH etc. but can be given extra config.
+        env = source.get("env")
+        if env is not None:
+            merged_env = dict(os.environ)
+            merged_env.update({str(k): str(v) for k, v in env.items()})
+            env = merged_env
+        cwd = source.get("cwd")
+        server_params = StdioServerParameters(
+            command=command, args=args, env=env, cwd=cwd
+        )
+        try:
+            return anyio.run(
+                functools.partial(self._async_fetch_tools_stdio, server_params)
+            )
+        except McpToolsError:
+            raise
+        except Exception as e:
+            raise McpToolsError(
+                f"Failed to fetch tools from stdio server '{command}': {e}"
+            ) from e
+
+    async def _async_fetch_tools_stdio(
+        self, server_params: StdioServerParameters
+    ) -> list[mcp_types.Tool]:
+        """Launch the local MCP server and list its tools over stdio."""
+        async with stdio_client(server_params) as (reader, writer):
+            async with ClientSession(reader, writer) as session:
+                await session.initialize()
+                tools_response = await session.list_tools()
+        return list(tools_response.tools)
+
+    # ------------------------------------------------------------------
+    # file source
+    # ------------------------------------------------------------------
+    def _from_file(self, source: dict) -> list[mcp_types.Tool]:
+        path = source.get("path")
+        if not path:
+            raise McpToolsError("tools_source.type 'file' requires a 'path'")
+        if not os.path.exists(path):
+            raise McpToolsError(f"Tools file not found: {path}")
+        try:
+            with open(path, "r") as f:
+                parsed = json.loads(f.read())  # raw tools/list JSON dump
+        except Exception as e:
+            raise McpToolsError(f"Could not parse tools file {path}: {e}") from e
+        if not parsed:
+            raise McpToolsError(f"Empty or unreadable tools file: {path}")
+        return self._to_tools(parsed)
+
+    @staticmethod
+    def _to_tools(raw) -> list[mcp_types.Tool]:
+        """Build ``mcp.types.Tool`` objects from a raw ``tools/list`` spec.
+
+        The spec must match the raw ``tools/list`` output: an object with a
+        top-level ``tools`` array, each entry a tool with ``name``,
+        ``description``, and ``inputSchema`` (JSON Schema).
+        """
+        if not isinstance(raw, dict) or not isinstance(raw.get("tools"), list):
+            raise McpToolsError(
+                "tools file must be the raw tools/list output: a JSON object "
+                "with a top-level 'tools' array"
+            )
+        tools = raw["tools"]
+        if not tools:
+            raise McpToolsError("tools/list spec contains no tools")
+
+        built: list[mcp_types.Tool] = []
+        for t in tools:
+            if not isinstance(t, dict):
+                raise McpToolsError(f"Invalid tool entry (not an object): {t!r}")
+            schema = t.get("inputSchema") or {}
+            if not isinstance(schema, dict):
+                schema = {}
+            try:
+                built.append(
+                    mcp_types.Tool(
+                        name=t.get("name", ""),
+                        description=t.get("description") or "",
+                        inputSchema=schema,
+                    )
+                )
+            except Exception as e:
+                raise McpToolsError(f"Invalid tool entry {t!r}: {e}") from e
+        return built

--- a/evalbench/test/mcp_tools_test.py
+++ b/evalbench/test/mcp_tools_test.py
@@ -107,18 +107,20 @@ class McpToolsGeneratorTest(unittest.TestCase):
         )
 
     # ---- http source (mocked, no network) -----------------------------
-    def test_http_source_defaults_url_to_endpoint_url(self):
+    def test_http_source_uses_tools_source_url(self):
         captured = {}
 
-        def fake_from_http(source, endpoint):
-            captured["url"] = source.get("url") or endpoint.get("endpoint_url")
+        def fake_from_http(source):
+            captured["url"] = source.get("url")
             return [
                 mcp_types.Tool(name="t", description="d", inputSchema={})
             ]
 
         endpoint = {
-            "endpoint_url": "https://svc.googleapis.com/mcp",
-            "tools_source": {"type": "http"},
+            "tools_source": {
+                "type": "http",
+                "url": "https://svc.googleapis.com/mcp",
+            },
         }
         with patch.object(self.gen, "_from_http", side_effect=fake_from_http):
             tools, man_page = self.gen.fetch_tools(endpoint)

--- a/evalbench/test/mcp_tools_test.py
+++ b/evalbench/test/mcp_tools_test.py
@@ -1,0 +1,146 @@
+"""Unit tests for the MCP tools generator (file source + URL/error handling).
+
+The ``file`` source is exercised end-to-end (offline, deterministic). The
+``http`` path is covered via a mocked async fetch so no network is required.
+``stdio`` launches a real subprocess so it is left to integration testing.
+"""
+
+import json
+import os
+import tempfile
+import unittest
+from unittest.mock import patch
+
+from mcp import types as mcp_types
+
+from generators.models.mcp_tools import McpToolsError, McpToolsGenerator
+
+
+_TOOLS_SPEC = {
+    "tools": [
+        {
+            "name": "list_datasets",
+            "description": "List all BigQuery datasets in the given project.",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "project_id": {
+                        "type": "string",
+                        "description": "The Google Cloud project ID.",
+                    }
+                },
+                "required": ["project_id"],
+            },
+        }
+    ]
+}
+
+
+class McpToolsGeneratorTest(unittest.TestCase):
+
+    def setUp(self):
+        self.gen = McpToolsGenerator({})
+
+    def _write_spec(self, obj) -> str:
+        fd, path = tempfile.mkstemp(suffix=".json")
+        with os.fdopen(fd, "w") as f:
+            json.dump(obj, f)
+        self.addCleanup(os.remove, path)
+        return path
+
+    # ---- file source --------------------------------------------------
+    def test_file_source_returns_tools_and_man_page(self):
+        path = self._write_spec(_TOOLS_SPEC)
+        endpoint = {"tools_source": {"type": "file", "path": path}}
+        tools, man_page = self.gen.fetch_tools(endpoint)
+        self.assertEqual(len(tools), 1)
+        self.assertIsInstance(tools[0], mcp_types.Tool)
+        self.assertEqual(tools[0].name, "list_datasets")
+        self.assertIn("TOOL: list_datasets", man_page)
+        self.assertIn("project_id (string) [REQUIRED]", man_page)
+
+    def test_file_missing_path_raises(self):
+        endpoint = {"tools_source": {"type": "file"}}
+        with self.assertRaises(McpToolsError):
+            self.gen.fetch_tools(endpoint)
+
+    def test_file_not_found_raises(self):
+        endpoint = {"tools_source": {"type": "file", "path": "/no/such/file.json"}}
+        with self.assertRaises(McpToolsError):
+            self.gen.fetch_tools(endpoint)
+
+    def test_file_wrong_shape_raises(self):
+        path = self._write_spec({"not_tools": []})
+        endpoint = {"tools_source": {"type": "file", "path": path}}
+        with self.assertRaises(McpToolsError):
+            self.gen.fetch_tools(endpoint)
+
+    def test_file_empty_tools_raises(self):
+        path = self._write_spec({"tools": []})
+        endpoint = {"tools_source": {"type": "file", "path": path}}
+        with self.assertRaises(McpToolsError):
+            self.gen.fetch_tools(endpoint)
+
+    # ---- source resolution / unknown type -----------------------------
+    def test_unknown_source_type_raises(self):
+        endpoint = {"tools_source": {"type": "carrier-pigeon"}}
+        with self.assertRaises(McpToolsError):
+            self.gen.fetch_tools(endpoint)
+
+    # ---- url sanitization --------------------------------------------
+    def test_sanitize_url_adds_scheme_and_mcp_suffix(self):
+        self.assertEqual(
+            self.gen.sanitize_url("example.googleapis.com"),
+            "https://example.googleapis.com/mcp",
+        )
+
+    def test_sanitize_url_localhost_uses_http(self):
+        self.assertEqual(
+            self.gen.sanitize_url("localhost:8080"),
+            "http://localhost:8080/mcp",
+        )
+
+    def test_sanitize_url_preserves_existing_mcp_suffix(self):
+        self.assertEqual(
+            self.gen.sanitize_url("https://x.dev/mcp/"),
+            "https://x.dev/mcp",
+        )
+
+    # ---- http source (mocked, no network) -----------------------------
+    def test_http_source_defaults_url_to_endpoint_url(self):
+        captured = {}
+
+        def fake_from_http(source, endpoint):
+            captured["url"] = source.get("url") or endpoint.get("endpoint_url")
+            return [
+                mcp_types.Tool(name="t", description="d", inputSchema={})
+            ]
+
+        endpoint = {
+            "endpoint_url": "https://svc.googleapis.com/mcp",
+            "tools_source": {"type": "http"},
+        }
+        with patch.object(self.gen, "_from_http", side_effect=fake_from_http):
+            tools, man_page = self.gen.fetch_tools(endpoint)
+        self.assertEqual(captured["url"], "https://svc.googleapis.com/mcp")
+        self.assertEqual(len(tools), 1)
+        self.assertIn("TOOL: t", man_page)
+
+    def test_http_missing_url_raises(self):
+        endpoint = {"tools_source": {"type": "http"}}
+        with self.assertRaises(McpToolsError):
+            self.gen.fetch_tools(endpoint)
+
+    # ---- generate_internal passthrough --------------------------------
+    def test_generate_internal_returns_man_page(self):
+        path = self._write_spec(_TOOLS_SPEC)
+        endpoint = {"tools_source": {"type": "file", "path": path}}
+        out = self.gen.generate_internal(endpoint)
+        self.assertIn("TOOL: list_datasets", out)
+
+    def test_generate_internal_non_dict_returns_empty(self):
+        self.assertEqual(self.gen.generate_internal("hello"), "")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Adds `McpToolsGenerator`, the fetch half of the MCP readability check. It
  obtains an endpoint's tools and renders them as man-page markup (via the
  formatter from #463) for the readability scorer.
  
  The system-under-test is pluggable via `tools_source.type`:
  - **http** — live `tools/list` over Streamable HTTP (official `mcp` SDK), no auth
  - **stdio** — launch a local MCP server and speak MCP over its stdio pipes
  - **file** — load a raw `tools/list` JSON dump (offline / deterministic runs)
  
  URL normalization adds scheme + `/mcp` suffix. Registers `"mcp_tools"` in
  `get_generator`.
  
  ## Tests
  Unit tests for all three sources, URL sanitization, error paths, and the
  generator entry point. `22 passed` (with the formatter suite).
  
  ## Note
  Stacked on #463 (the man-page formatter). Until #463 merges, this PR's diff
  includes that commit; it collapses to just the generator once #463 lands.
