### PR TITLE
Feat/mcp readability metrics scorer

### DIFF
--- a/evalbench/generators/models/__init__.py
+++ b/evalbench/generators/models/__init__.py
@@ -12,6 +12,7 @@ from .claude_code import ClaudeCodeGenerator
 from .codex_cli import CodexCliGenerator
 from .gcp_data_engineering_agent import DataEngineeringAgentGenerator
 from .agy_cli import AgyCliGenerator
+from .mcp_tools import McpToolsGenerator
 from util.config import load_yaml_config
 
 
@@ -36,6 +37,7 @@ def get_generator(global_models, model_config_path: str, db: DB = None):
             "codex_cli": lambda: CodexCliGenerator(config),
             "data_engineering_agent": lambda: DataEngineeringAgentGenerator(config),
             "agy_cli": lambda: AgyCliGenerator(config),
+            "mcp_tools": lambda: McpToolsGenerator(config),
         }
         generator = config["generator"]
         if generator not in generators:

--- a/evalbench/generators/models/mcp_tool_formatter.py
+++ b/evalbench/generators/models/mcp_tool_formatter.py
@@ -1,0 +1,267 @@
+"""Render MCP tools into a human-readable "man page".
+
+This is the *rendering* half of the MCP readability check. It takes a sequence of
+MCP tools (as returned by ``tools/list``) and produces a single man-page style
+string that the readability scorer feeds to an LLM judge.
+
+The renderer:
+  - resolves JSON-Schema ``$ref`` / ``$defs`` references,
+  - flattens nested parameters into dotted paths,
+  - marks each parameter ``REQUIRED`` / ``OPTIONAL``,
+  - renders structured ``enum`` and ``default`` values so style rules that key
+    off them (e.g. "Use Enums") are judgeable from the markup,
+  - guards against infinite recursion in self-referential schemas.
+
+Scope note: this module *only* renders the man page. Deterministic metrics such
+as tool count, estimated tokens, and token-budget usage are computed by a
+separate scorer, not here -- the generator's job is to produce the artifact, and
+the scorers compute metrics over it.
+"""
+
+from collections.abc import Mapping, Sequence, Set
+import json
+import textwrap
+from typing import Any
+
+from mcp import types as mcp_types
+
+
+def _wrap_text(text: str, indent: str) -> list[str]:
+    """Wraps text preserving empty lines and applying indentation."""
+    wrapped = []
+    for line in (text or "").splitlines():
+        line = line.strip()
+        if not line:
+            if wrapped:  # Don't add leading empty lines.
+                wrapped.append("")
+        else:
+            wrapped.extend(
+                textwrap.wrap(
+                    line, width=80, initial_indent=indent, subsequent_indent=indent
+                )
+            )
+    while wrapped and not wrapped[-1]:
+        wrapped.pop()
+    return wrapped
+
+
+def _value_indent(level: int) -> str:
+    """Indent used for sub-lines (description/enum/default) at a given level.
+
+    The base sub-line sits 6 spaces in, and each nesting level adds 3 more.
+    """
+    return " " * (6 + 3 * level)
+
+
+def _format_enum_default(schema: Mapping[str, Any], level: int) -> list[str]:
+    """Render ``enum`` / ``default`` values for a property, if present."""
+    lines: list[str] = []
+    indent = _value_indent(level)
+    if "enum" in schema and isinstance(schema["enum"], (list, tuple)):
+        values = ", ".join(json.dumps(v, default=str) for v in schema["enum"])
+        lines.extend(_wrap_text(f"enum: [{values}]", indent))
+    if "default" in schema:
+        lines.extend(
+            _wrap_text(f"default: {json.dumps(schema['default'], default=str)}", indent)
+        )
+    return lines
+
+
+def _resolve_ref(
+    schema: Mapping[str, Any], defs: Mapping[str, Any]
+) -> tuple[Mapping[str, Any], str | None]:
+    """Resolves JSON schema references.
+
+    Args:
+      schema: The current JSON schema dictionary.
+      defs: A dictionary of schema definitions where '$ref' can be resolved.
+
+    Returns:
+      A tuple (resolved_schema, ref_name), where `resolved_schema` is the
+      resolved schema dictionary (or the original schema if no '$ref' is present
+      or resolvable), and `ref_name` is the name of the resolved reference (e.g.,
+      the part after '#/$defs/'), or None if no reference was resolved.
+    """
+    if "$ref" in schema:
+        ref_path = schema["$ref"]
+        if ref_path.startswith("#/$defs/"):
+            ref_name = ref_path.split("/")[-1]
+            if ref_name in defs:
+                return defs[ref_name], ref_name
+    return schema, None
+
+
+def _format_type(schema: Mapping[str, Any]) -> str:
+    """Formats a JSON schema type representation."""
+    schema_type = schema.get("type", "any")
+    if isinstance(schema_type, list):
+        return " | ".join(str(t) for t in schema_type)
+    return str(schema_type)
+
+
+def _format_header(
+    prop_name: str,
+    prop_type: str,
+    req_str: str,
+    desc: str,
+    full_path: str,
+    level: int,
+) -> list[str]:
+    """Formats a property's header line and description based on nesting level."""
+    lines = []
+    if level == 0:
+        lines.append(f"  {prop_name} ({prop_type}) [{req_str}]")
+    elif level == 1:
+        lines.append(f"      -> {full_path} ({prop_type}) [{req_str}]")
+    else:
+        lines.append(f"{' ' * (4 + 3 * level)}* {prop_name} ({prop_type})")
+    if desc:
+        lines.extend(_wrap_text(desc, _value_indent(level)))
+    return lines
+
+
+def _format_recursive(level: int) -> list[str]:
+    """Formats a recursive reference notice for array items at the given level."""
+    return _wrap_text("[Recursive Reference]", _value_indent(level))
+
+
+def _format_obj(
+    schema: Mapping[str, Any],
+    defs: Mapping[str, Any],
+    full_path: str,
+    level: int,
+    visited: Set[str],
+) -> list[str]:
+    """Formats an object property by recursively traversing its children."""
+    lines = _format_props(
+        schema,
+        defs=defs,
+        path_prefix=full_path,
+        level=level + 1,
+        visited=visited,
+    )
+    if lines and lines[-1]:
+        lines.append("")
+    return lines
+
+
+def _format_array(
+    schema: Mapping[str, Any],
+    defs: Mapping[str, Any],
+    full_path: str,
+    level: int,
+    visited: Set[str],
+) -> list[str]:
+    """Formats an array property by traversing its items schema."""
+    # Resolve the items schema to check if it points to a reference definition.
+    schema, ref = _resolve_ref(schema["items"], defs)
+    is_recursive = False
+    if ref:
+        # Check if this reference name has already been encountered higher up in
+        # the current traversal path to prevent infinite recursion.
+        if ref in visited:
+            is_recursive = True
+        else:
+            visited = visited | {ref}
+
+    if not is_recursive and schema.get("type") == "object":
+        return _format_props(
+            schema,
+            defs=defs,
+            path_prefix=full_path + "[]",
+            level=level + 1,
+            visited=visited,
+        )
+    if is_recursive:
+        return _format_recursive(level)
+    return []
+
+
+def _format_props(
+    schema: Mapping[str, Any],
+    *,
+    defs: Mapping[str, Any] | None = None,
+    path_prefix: str = "",
+    level: int = 0,
+    visited: Set[str] | None = None,
+) -> list[str]:
+    """Recursively formats JSON schema properties into man-page parameter lines."""
+    lines = []
+    if defs is None:
+        defs = schema.get("$defs", {}) or schema.get("definitions", {})
+    visited = visited if visited is not None else set()
+
+    schema, _ = _resolve_ref(schema, defs)
+    properties = schema.get("properties", {})
+    required_fields = set(schema.get("required", []))
+
+    for prop_name, prop_schema in properties.items():
+        prop_schema, ref_name = _resolve_ref(prop_schema, defs)
+        is_recursive = ref_name in visited if ref_name else False
+        prop_visited = (
+            visited | {ref_name} if ref_name and not is_recursive else visited
+        )
+
+        is_required = prop_name in required_fields
+        req_str = "REQUIRED" if is_required else "OPTIONAL"
+        prop_type = _format_type(prop_schema)
+
+        desc = prop_schema.get("description", "").strip()
+        if is_recursive:
+            desc = f"[Recursive Reference] {desc}".strip()
+
+        full_path = f"{path_prefix}.{prop_name}" if path_prefix else prop_name
+
+        lines.extend(
+            _format_header(prop_name, prop_type, req_str, desc, full_path, level)
+        )
+        lines.extend(_format_enum_default(prop_schema, level))
+
+        if not is_recursive:
+            if prop_type == "object" and "properties" in prop_schema:
+                lines.extend(
+                    _format_obj(prop_schema, defs, full_path, level, prop_visited)
+                )
+            elif prop_type == "array" and "items" in prop_schema:
+                lines.extend(
+                    _format_array(prop_schema, defs, full_path, level, prop_visited)
+                )
+
+        if level == 0:
+            if lines and lines[-1]:
+                lines.append("")
+
+    return lines
+
+
+def format_tools_to_man_page(tools: Sequence[mcp_types.Tool]) -> str:
+    """Formats a sequence of MCP tools into a man-page style string.
+
+    Args:
+      tools: Sequence of ``mcp.types.Tool`` objects.
+
+    Returns:
+      The formatted man-page markup. Returns ``"No tools available."`` for an
+      empty sequence.
+    """
+    if not tools:
+        return "No tools available."
+
+    lines = []
+    for tool in tools:
+        lines.append("=" * 80)
+        lines.append(f"TOOL: {tool.name}")
+        lines.append("=" * 80)
+        lines.append("DESCRIPTION:")
+
+        desc = tool.description or "No description provided."
+        lines.extend(_wrap_text(desc, "  "))
+
+        lines.append("\nPARAMETERS:")
+        if tool.inputSchema and tool.inputSchema.get("properties"):
+            schema_lines = _format_props(tool.inputSchema)
+            lines.extend(schema_lines)
+        else:
+            lines.append("  None\n")
+
+    return "\n".join(lines).strip()

--- a/evalbench/generators/models/mcp_tools.py
+++ b/evalbench/generators/models/mcp_tools.py
@@ -1,0 +1,230 @@
+"""Generator that fetches an MCP endpoint's tools and renders man-page markup.
+
+This plays the EvalBench *generator* role for the MCP readability check: instead
+of asking a model to produce an artifact, it fetches the tool listing from the
+"system under test" (an MCP endpoint) and renders the man-page markup that the
+readability *scorer* then evaluates against the style guide.
+
+The source is pluggable per endpoint via ``tools_source.type``. The type names
+the *transport*, not the protocol -- ``http`` and ``stdio`` both speak MCP:
+  - ``http``: live MCP ``tools/list`` over Streamable HTTP using the official
+    ``mcp`` Python SDK. The fetch URL is ``tools_source.url`` (falling back to
+    the endpoint's ``endpoint_url``). No authentication is configured -- the
+    public endpoints are reached unauthenticated; auth can be added back later
+    if a future endpoint requires it.
+  - ``stdio``: launch a local MCP server via a command and speak MCP over its
+    stdio pipes (official ``mcp`` SDK). The process is started before fetching,
+    ``tools/list`` is called, then it is shut down. For local / command-launched
+    servers such as MCP Toolbox.
+  - ``file``: read a local spec in the raw ``tools/list`` format
+    (``{"tools": [...]}``); dependency-free, for offline / deterministic runs.
+"""
+
+import functools
+import json
+import logging
+import os
+
+import anyio
+
+from mcp import types as mcp_types
+from mcp import StdioServerParameters
+from mcp.client.session import ClientSession
+from mcp.client.stdio import stdio_client
+from mcp.client.streamable_http import streamablehttp_client
+
+from .generator import QueryGenerator
+from .mcp_tool_formatter import format_tools_to_man_page
+
+
+class McpToolsError(Exception):
+    """Raised when a tools spec cannot be fetched or parsed."""
+
+
+class McpToolsGenerator(QueryGenerator):
+    """Fetches an MCP endpoint's tools and renders them as man-page markup."""
+
+    def __init__(self, querygenerator_config):
+        super().__init__(querygenerator_config)
+        self.name = "mcp_tools"
+        cfg = querygenerator_config or {}
+        self.timeout = cfg.get("timeout", 30)
+
+    # The abstract base requires generate_internal; the orchestrator calls
+    # fetch_tools directly, but we keep this so the class is a valid generator.
+    def generate_internal(self, prompt):
+        if isinstance(prompt, dict):
+            _, man_page = self.fetch_tools(prompt)
+            return man_page
+        return ""
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+    def fetch_tools(self, endpoint: dict) -> tuple[list[mcp_types.Tool], str]:
+        """Fetch tools for ``endpoint`` and render man-page markup.
+
+        Returns ``(tools, man_page)`` where ``tools`` is a list of
+        ``mcp.types.Tool`` (used by the metrics scorer) and ``man_page`` is the
+        rendered markup string (fed to the readability scorer).
+        """
+        source = self._resolve_source(endpoint)
+        source_type = (source.get("type") or "http").lower()
+
+        if source_type == "file":
+            tools = self._from_file(source)
+        elif source_type == "http":
+            tools = self._from_http(source, endpoint)
+        elif source_type == "stdio":
+            tools = self._from_stdio(source)
+        else:
+            raise McpToolsError(f"Unknown tools_source.type '{source_type}'")
+
+        return tools, format_tools_to_man_page(tools)
+
+    # ------------------------------------------------------------------
+    # Source resolution
+    # ------------------------------------------------------------------
+    @staticmethod
+    def _resolve_source(endpoint: dict) -> dict:
+        """The endpoint's ``tools_source`` (or ``{}`` to default to ``http``)."""
+        return dict(endpoint.get("tools_source") or {})
+
+    @staticmethod
+    def sanitize_url(url: str) -> str:
+        """Ensure the URL has a scheme and ends with ``/mcp``.
+
+        ``/mcp`` is the conventional path where the MCP protocol is exposed.
+        """
+        stripped_url = (url or "").strip()
+        if stripped_url.startswith(("http://", "https://")):
+            url_with_scheme = stripped_url
+        elif "localhost" in stripped_url:
+            url_with_scheme = f"http://{stripped_url}"
+        else:
+            url_with_scheme = f"https://{stripped_url}"
+
+        rstripped_url = url_with_scheme.rstrip("/")
+        if not rstripped_url.endswith("/mcp"):
+            return f"{rstripped_url}/mcp"
+        return rstripped_url
+
+    # ------------------------------------------------------------------
+    # http source (official SDK over Streamable HTTP, no auth)
+    # ------------------------------------------------------------------
+    def _from_http(self, source: dict, endpoint: dict) -> list[mcp_types.Tool]:
+        raw_url = source.get("url") or endpoint.get("endpoint_url")
+        if not raw_url:
+            raise McpToolsError(
+                "tools_source.type 'http' requires a 'url' (or endpoint_url)"
+            )
+        url = self.sanitize_url(raw_url)
+        try:
+            return anyio.run(functools.partial(self._async_fetch_tools, url))
+        except McpToolsError:
+            raise
+        except Exception as e:
+            raise McpToolsError(f"Failed to fetch tools from {url}: {e}") from e
+
+    async def _async_fetch_tools(self, url: str) -> list[mcp_types.Tool]:
+        """Connect to the MCP server over Streamable HTTP and list its tools."""
+        async with streamablehttp_client(url, timeout=self.timeout) as streams:
+            reader, writer, _ = streams
+            async with ClientSession(reader, writer) as session:
+                await session.initialize()
+                tools_response = await session.list_tools()
+        return list(tools_response.tools)
+
+    # ------------------------------------------------------------------
+    # stdio source (official SDK over a launched local process)
+    # ------------------------------------------------------------------
+    def _from_stdio(self, source: dict) -> list[mcp_types.Tool]:
+        command = source.get("command")
+        if not command:
+            raise McpToolsError("tools_source.type 'stdio' requires a 'command'")
+        args = list(source.get("args") or [])
+        # Merge the current environment with any per-source overrides so the
+        # launched server inherits PATH etc. but can be given extra config.
+        env = source.get("env")
+        if env is not None:
+            merged_env = dict(os.environ)
+            merged_env.update({str(k): str(v) for k, v in env.items()})
+            env = merged_env
+        cwd = source.get("cwd")
+        server_params = StdioServerParameters(
+            command=command, args=args, env=env, cwd=cwd
+        )
+        try:
+            return anyio.run(
+                functools.partial(self._async_fetch_tools_stdio, server_params)
+            )
+        except McpToolsError:
+            raise
+        except Exception as e:
+            raise McpToolsError(
+                f"Failed to fetch tools from stdio server '{command}': {e}"
+            ) from e
+
+    async def _async_fetch_tools_stdio(
+        self, server_params: StdioServerParameters
+    ) -> list[mcp_types.Tool]:
+        """Launch the local MCP server and list its tools over stdio."""
+        async with stdio_client(server_params) as (reader, writer):
+            async with ClientSession(reader, writer) as session:
+                await session.initialize()
+                tools_response = await session.list_tools()
+        return list(tools_response.tools)
+
+    # ------------------------------------------------------------------
+    # file source
+    # ------------------------------------------------------------------
+    def _from_file(self, source: dict) -> list[mcp_types.Tool]:
+        path = source.get("path")
+        if not path:
+            raise McpToolsError("tools_source.type 'file' requires a 'path'")
+        if not os.path.exists(path):
+            raise McpToolsError(f"Tools file not found: {path}")
+        try:
+            with open(path, "r") as f:
+                parsed = json.loads(f.read())  # raw tools/list JSON dump
+        except Exception as e:
+            raise McpToolsError(f"Could not parse tools file {path}: {e}") from e
+        if not parsed:
+            raise McpToolsError(f"Empty or unreadable tools file: {path}")
+        return self._to_tools(parsed)
+
+    @staticmethod
+    def _to_tools(raw) -> list[mcp_types.Tool]:
+        """Build ``mcp.types.Tool`` objects from a raw ``tools/list`` spec.
+
+        The spec must match the raw ``tools/list`` output: an object with a
+        top-level ``tools`` array, each entry a tool with ``name``,
+        ``description``, and ``inputSchema`` (JSON Schema).
+        """
+        if not isinstance(raw, dict) or not isinstance(raw.get("tools"), list):
+            raise McpToolsError(
+                "tools file must be the raw tools/list output: a JSON object "
+                "with a top-level 'tools' array"
+            )
+        tools = raw["tools"]
+        if not tools:
+            raise McpToolsError("tools/list spec contains no tools")
+
+        built: list[mcp_types.Tool] = []
+        for t in tools:
+            if not isinstance(t, dict):
+                raise McpToolsError(f"Invalid tool entry (not an object): {t!r}")
+            schema = t.get("inputSchema") or {}
+            if not isinstance(schema, dict):
+                schema = {}
+            try:
+                built.append(
+                    mcp_types.Tool(
+                        name=t.get("name", ""),
+                        description=t.get("description") or "",
+                        inputSchema=schema,
+                    )
+                )
+            except Exception as e:
+                raise McpToolsError(f"Invalid tool entry {t!r}: {e}") from e
+        return built

--- a/evalbench/scorers/mcp_tool_metrics.py
+++ b/evalbench/scorers/mcp_tool_metrics.py
@@ -1,0 +1,82 @@
+"""Deterministic metrics scorer for an MCP endpoint's tool listing.
+
+This is the *metrics* half of the MCP readability check. Unlike the LLM style
+judge, it computes purely deterministic, model-independent numbers over the tools
+returned by ``McpToolsGenerator``:
+
+  - ``total_tools``: the number of tools exposed by the endpoint.
+  - ``estimated_tokens``: a rough token footprint of the tool definitions,
+    approximated as ``len(JSON(tool)) / 4`` summed across tools.
+  - ``token_budget_used_percent``: that estimate as a percentage of the
+    configured ``token_budget`` (``None`` when no positive budget is set).
+
+It is kept separate from the LLM judge so the metric logic stays deterministic
+and independently testable. The ``McpReadabilityOrchestrator`` calls ``score``
+with the tools it gets back from the generator.
+"""
+
+from collections.abc import Sequence
+import json
+from typing import Any
+
+# Rough chars-per-token heuristic for estimating a tool's token footprint.
+_CHARS_PER_TOKEN = 4
+
+
+class McpToolMetricsScorer:
+    """Computes deterministic size/cost metrics for a list of MCP tools."""
+
+    def __init__(self, config: dict | None = None):
+        self.name = "mcp_tool_metrics"
+        config = config or {}
+        # A default token budget; a per-call value passed to score() wins.
+        self.token_budget = config.get("token_budget")
+
+    def score(
+        self, tools: Sequence[Any], token_budget: int | None = None
+    ) -> dict:
+        """Compute metrics over ``tools``.
+
+        Args:
+          tools: The endpoint's tools (``mcp.types.Tool`` objects or plain
+            dicts in the raw ``tools/list`` shape).
+          token_budget: Overrides the budget from config when provided.
+
+        Returns:
+          ``{"total_tools", "estimated_tokens", "token_budget_used_percent"}``.
+          ``token_budget_used_percent`` is ``None`` when no positive budget is
+          configured.
+        """
+        budget = token_budget if token_budget is not None else self.token_budget
+
+        total_tools = len(tools)
+        total_chars = sum(len(self._to_json(tool)) for tool in tools)
+        estimated_tokens = round(total_chars / _CHARS_PER_TOKEN)
+
+        if budget and budget > 0:
+            used_percent = round(estimated_tokens / budget * 100, 2)
+        else:
+            used_percent = None
+
+        return {
+            "total_tools": total_tools,
+            "estimated_tokens": estimated_tokens,
+            "token_budget_used_percent": used_percent,
+        }
+
+    @staticmethod
+    def _to_json(tool: Any) -> str:
+        """Serialize a tool to JSON for the size estimate.
+
+        Handles both ``mcp.types.Tool`` (a pydantic model) and plain dicts.
+        ``by_alias`` keeps the wire field names (e.g. ``inputSchema``) and
+        ``exclude_none`` drops unset optionals, so the estimate reflects what an
+        endpoint actually puts on the wire.
+        """
+        model_dump_json = getattr(tool, "model_dump_json", None)
+        if callable(model_dump_json):
+            try:
+                return model_dump_json(by_alias=True, exclude_none=True)
+            except TypeError:  # older/non-standard pydantic signatures
+                return model_dump_json()
+        return json.dumps(tool, default=str, sort_keys=True)

--- a/evalbench/test/mcp_tool_formatter_test.py
+++ b/evalbench/test/mcp_tool_formatter_test.py
@@ -1,0 +1,151 @@
+"""Unit tests for the MCP man-page formatter.
+
+These exercise the rendering logic in isolation -- no network, no LLM, no auth --
+covering simple/nested/array params, $ref/$defs resolution, enum/default
+rendering, the required/optional marker, and the recursion guard.
+"""
+
+import unittest
+
+from mcp import types as mcp_types
+
+from generators.models.mcp_tool_formatter import format_tools_to_man_page
+
+
+def _tool(name, description, schema):
+    return mcp_types.Tool(name=name, description=description, inputSchema=schema)
+
+
+class FormatToolsToManPageTest(unittest.TestCase):
+
+    def test_empty_tools(self):
+        self.assertEqual(format_tools_to_man_page([]), "No tools available.")
+
+    def test_tool_with_no_parameters(self):
+        out = format_tools_to_man_page(
+            [_tool("ping", "Health check.", {"type": "object"})]
+        )
+        self.assertIn("TOOL: ping", out)
+        self.assertIn("Health check.", out)
+        self.assertIn("PARAMETERS:", out)
+        self.assertIn("None", out)
+
+    def test_simple_required_and_optional(self):
+        schema = {
+            "type": "object",
+            "properties": {
+                "query": {"type": "string", "description": "The search query."},
+                "limit": {"type": "integer", "description": "Max results."},
+            },
+            "required": ["query"],
+        }
+        out = format_tools_to_man_page([_tool("search", "Search docs.", schema)])
+        self.assertIn("query (string) [REQUIRED]", out)
+        self.assertIn("The search query.", out)
+        self.assertIn("limit (integer) [OPTIONAL]", out)
+
+    def test_enum_and_default_rendering(self):
+        schema = {
+            "type": "object",
+            "properties": {
+                "mode": {
+                    "type": "string",
+                    "enum": ["fast", "slow"],
+                    "default": "fast",
+                    "description": "Execution mode.",
+                }
+            },
+        }
+        out = format_tools_to_man_page([_tool("run", "Run it.", schema)])
+        self.assertIn('enum: ["fast", "slow"]', out)
+        self.assertIn('default: "fast"', out)
+
+    def test_nested_object_uses_dotted_path(self):
+        schema = {
+            "type": "object",
+            "properties": {
+                "filter": {
+                    "type": "object",
+                    "description": "Filter spec.",
+                    "properties": {
+                        "field": {"type": "string", "description": "Field name."}
+                    },
+                    "required": ["field"],
+                }
+            },
+        }
+        out = format_tools_to_man_page([_tool("list", "List rows.", schema)])
+        self.assertIn("filter (object)", out)
+        self.assertIn("filter.field (string) [REQUIRED]", out)
+
+    def test_ref_defs_resolution(self):
+        schema = {
+            "type": "object",
+            "$defs": {
+                "Address": {
+                    "type": "object",
+                    "properties": {
+                        "city": {"type": "string", "description": "City name."}
+                    },
+                }
+            },
+            "properties": {"home": {"$ref": "#/$defs/Address"}},
+        }
+        out = format_tools_to_man_page([_tool("save", "Save user.", schema)])
+        self.assertIn("home (object)", out)
+        self.assertIn("home.city (string)", out)
+
+    def test_array_of_objects(self):
+        schema = {
+            "type": "object",
+            "properties": {
+                "rows": {
+                    "type": "array",
+                    "description": "Rows to insert.",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "id": {"type": "string", "description": "Row id."}
+                        },
+                    },
+                }
+            },
+        }
+        out = format_tools_to_man_page([_tool("insert", "Insert.", schema)])
+        self.assertIn("rows (array)", out)
+        self.assertIn("rows[].id (string)", out)
+
+    def test_recursive_schema_does_not_loop(self):
+        schema = {
+            "type": "object",
+            "$defs": {
+                "Node": {
+                    "type": "object",
+                    "properties": {
+                        "value": {"type": "string", "description": "Value."},
+                        "children": {
+                            "type": "array",
+                            "items": {"$ref": "#/$defs/Node"},
+                        },
+                    },
+                }
+            },
+            "properties": {"root": {"$ref": "#/$defs/Node"}},
+        }
+        out = format_tools_to_man_page([_tool("tree", "Build tree.", schema)])
+        self.assertIn("root (object)", out)
+        self.assertIn("[Recursive Reference]", out)
+
+    def test_multiple_tools_all_rendered(self):
+        out = format_tools_to_man_page(
+            [
+                _tool("a", "Tool A.", {"type": "object"}),
+                _tool("b", "Tool B.", {"type": "object"}),
+            ]
+        )
+        self.assertIn("TOOL: a", out)
+        self.assertIn("TOOL: b", out)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/evalbench/test/mcp_tool_metrics_test.py
+++ b/evalbench/test/mcp_tool_metrics_test.py
@@ -1,0 +1,99 @@
+"""Unit tests for the deterministic MCP tool metrics scorer."""
+
+import json
+import unittest
+
+from mcp import types as mcp_types
+
+from scorers.mcp_tool_metrics import McpToolMetricsScorer
+
+
+def _tool(name, description, schema=None):
+    return mcp_types.Tool(
+        name=name, description=description, inputSchema=schema or {"type": "object"}
+    )
+
+
+class McpToolMetricsScorerTest(unittest.TestCase):
+
+    def setUp(self):
+        self.scorer = McpToolMetricsScorer()
+
+    # ---- total_tools --------------------------------------------------
+    def test_total_tools_counts_entries(self):
+        tools = [_tool("a", "A."), _tool("b", "B."), _tool("c", "C.")]
+        self.assertEqual(self.scorer.score(tools)["total_tools"], 3)
+
+    def test_empty_tools(self):
+        result = self.scorer.score([])
+        self.assertEqual(result["total_tools"], 0)
+        self.assertEqual(result["estimated_tokens"], 0)
+        self.assertIsNone(result["token_budget_used_percent"])
+
+    # ---- estimated_tokens (dict input -> exact, computable) -----------
+    def test_estimated_tokens_matches_json_quarter_for_dicts(self):
+        tools = [
+            {"name": "x", "description": "hello", "inputSchema": {"type": "object"}},
+            {"name": "y", "description": "world", "inputSchema": {"type": "string"}},
+        ]
+        expected_chars = sum(
+            len(json.dumps(t, default=str, sort_keys=True)) for t in tools
+        )
+        result = self.scorer.score(tools)
+        self.assertEqual(result["estimated_tokens"], round(expected_chars / 4))
+
+    def test_estimated_tokens_positive_for_real_tools(self):
+        result = self.scorer.score([_tool("a", "A tool that does things.")])
+        self.assertGreater(result["estimated_tokens"], 0)
+
+    def test_more_tools_means_more_tokens(self):
+        one = self.scorer.score([_tool("a", "A.")])["estimated_tokens"]
+        two = self.scorer.score([_tool("a", "A."), _tool("b", "B.")])[
+            "estimated_tokens"
+        ]
+        self.assertGreater(two, one)
+
+    # ---- token_budget_used_percent -----------------------------------
+    def test_budget_percent_computed(self):
+        tools = [{"name": "x", "description": "d"}]
+        est = self.scorer.score(tools)["estimated_tokens"]
+        budget = 1000
+        result = self.scorer.score(tools, token_budget=budget)
+        self.assertEqual(
+            result["token_budget_used_percent"], round(est / budget * 100, 2)
+        )
+
+    def test_no_budget_yields_none_percent(self):
+        result = self.scorer.score([_tool("a", "A.")])
+        self.assertIsNone(result["token_budget_used_percent"])
+
+    def test_zero_budget_yields_none_percent(self):
+        result = self.scorer.score([_tool("a", "A.")], token_budget=0)
+        self.assertIsNone(result["token_budget_used_percent"])
+
+    def test_empty_tools_with_budget_is_zero_percent(self):
+        result = self.scorer.score([], token_budget=1000)
+        self.assertEqual(result["token_budget_used_percent"], 0.0)
+
+    # ---- config vs per-call budget -----------------------------------
+    def test_config_budget_used_when_no_override(self):
+        scorer = McpToolMetricsScorer({"token_budget": 1000})
+        tools = [{"name": "x", "description": "d"}]
+        est = scorer.score(tools)["estimated_tokens"]
+        self.assertEqual(
+            scorer.score(tools)["token_budget_used_percent"],
+            round(est / 1000 * 100, 2),
+        )
+
+    def test_per_call_budget_overrides_config(self):
+        scorer = McpToolMetricsScorer({"token_budget": 1000})
+        tools = [{"name": "x", "description": "d"}]
+        est = scorer.score(tools)["estimated_tokens"]
+        result = scorer.score(tools, token_budget=2000)
+        self.assertEqual(
+            result["token_budget_used_percent"], round(est / 2000 * 100, 2)
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/evalbench/test/mcp_tools_test.py
+++ b/evalbench/test/mcp_tools_test.py
@@ -1,0 +1,146 @@
+"""Unit tests for the MCP tools generator (file source + URL/error handling).
+
+The ``file`` source is exercised end-to-end (offline, deterministic). The
+``http`` path is covered via a mocked async fetch so no network is required.
+``stdio`` launches a real subprocess so it is left to integration testing.
+"""
+
+import json
+import os
+import tempfile
+import unittest
+from unittest.mock import patch
+
+from mcp import types as mcp_types
+
+from generators.models.mcp_tools import McpToolsError, McpToolsGenerator
+
+
+_TOOLS_SPEC = {
+    "tools": [
+        {
+            "name": "list_datasets",
+            "description": "List all BigQuery datasets in the given project.",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "project_id": {
+                        "type": "string",
+                        "description": "The Google Cloud project ID.",
+                    }
+                },
+                "required": ["project_id"],
+            },
+        }
+    ]
+}
+
+
+class McpToolsGeneratorTest(unittest.TestCase):
+
+    def setUp(self):
+        self.gen = McpToolsGenerator({})
+
+    def _write_spec(self, obj) -> str:
+        fd, path = tempfile.mkstemp(suffix=".json")
+        with os.fdopen(fd, "w") as f:
+            json.dump(obj, f)
+        self.addCleanup(os.remove, path)
+        return path
+
+    # ---- file source --------------------------------------------------
+    def test_file_source_returns_tools_and_man_page(self):
+        path = self._write_spec(_TOOLS_SPEC)
+        endpoint = {"tools_source": {"type": "file", "path": path}}
+        tools, man_page = self.gen.fetch_tools(endpoint)
+        self.assertEqual(len(tools), 1)
+        self.assertIsInstance(tools[0], mcp_types.Tool)
+        self.assertEqual(tools[0].name, "list_datasets")
+        self.assertIn("TOOL: list_datasets", man_page)
+        self.assertIn("project_id (string) [REQUIRED]", man_page)
+
+    def test_file_missing_path_raises(self):
+        endpoint = {"tools_source": {"type": "file"}}
+        with self.assertRaises(McpToolsError):
+            self.gen.fetch_tools(endpoint)
+
+    def test_file_not_found_raises(self):
+        endpoint = {"tools_source": {"type": "file", "path": "/no/such/file.json"}}
+        with self.assertRaises(McpToolsError):
+            self.gen.fetch_tools(endpoint)
+
+    def test_file_wrong_shape_raises(self):
+        path = self._write_spec({"not_tools": []})
+        endpoint = {"tools_source": {"type": "file", "path": path}}
+        with self.assertRaises(McpToolsError):
+            self.gen.fetch_tools(endpoint)
+
+    def test_file_empty_tools_raises(self):
+        path = self._write_spec({"tools": []})
+        endpoint = {"tools_source": {"type": "file", "path": path}}
+        with self.assertRaises(McpToolsError):
+            self.gen.fetch_tools(endpoint)
+
+    # ---- source resolution / unknown type -----------------------------
+    def test_unknown_source_type_raises(self):
+        endpoint = {"tools_source": {"type": "carrier-pigeon"}}
+        with self.assertRaises(McpToolsError):
+            self.gen.fetch_tools(endpoint)
+
+    # ---- url sanitization --------------------------------------------
+    def test_sanitize_url_adds_scheme_and_mcp_suffix(self):
+        self.assertEqual(
+            self.gen.sanitize_url("example.googleapis.com"),
+            "https://example.googleapis.com/mcp",
+        )
+
+    def test_sanitize_url_localhost_uses_http(self):
+        self.assertEqual(
+            self.gen.sanitize_url("localhost:8080"),
+            "http://localhost:8080/mcp",
+        )
+
+    def test_sanitize_url_preserves_existing_mcp_suffix(self):
+        self.assertEqual(
+            self.gen.sanitize_url("https://x.dev/mcp/"),
+            "https://x.dev/mcp",
+        )
+
+    # ---- http source (mocked, no network) -----------------------------
+    def test_http_source_defaults_url_to_endpoint_url(self):
+        captured = {}
+
+        def fake_from_http(source, endpoint):
+            captured["url"] = source.get("url") or endpoint.get("endpoint_url")
+            return [
+                mcp_types.Tool(name="t", description="d", inputSchema={})
+            ]
+
+        endpoint = {
+            "endpoint_url": "https://svc.googleapis.com/mcp",
+            "tools_source": {"type": "http"},
+        }
+        with patch.object(self.gen, "_from_http", side_effect=fake_from_http):
+            tools, man_page = self.gen.fetch_tools(endpoint)
+        self.assertEqual(captured["url"], "https://svc.googleapis.com/mcp")
+        self.assertEqual(len(tools), 1)
+        self.assertIn("TOOL: t", man_page)
+
+    def test_http_missing_url_raises(self):
+        endpoint = {"tools_source": {"type": "http"}}
+        with self.assertRaises(McpToolsError):
+            self.gen.fetch_tools(endpoint)
+
+    # ---- generate_internal passthrough --------------------------------
+    def test_generate_internal_returns_man_page(self):
+        path = self._write_spec(_TOOLS_SPEC)
+        endpoint = {"tools_source": {"type": "file", "path": path}}
+        out = self.gen.generate_internal(endpoint)
+        self.assertIn("TOOL: list_datasets", out)
+
+    def test_generate_internal_non_dict_returns_empty(self):
+        self.assertEqual(self.gen.generate_internal("hello"), "")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Adds `McpToolMetricsScorer`, the deterministic (LLM-free) half of the MCP
  readability check. It computes model-independent size/cost metrics over the
  tools returned by `McpToolsGenerator`:
  
  - **`total_tools`** — number of tools the endpoint exposes
  - **`estimated_tokens`** — rough token footprint, `len(JSON(tool)) / 4` summed
    across tools
  - **`token_budget_used_percent`** — the estimate as a percentage of the
    configured `token_budget` (`None` when no positive budget is set; `0.0` for an
    empty toolset with a budget)
  
  ## Design notes
  - Kept separate from the LLM style judge so the metric logic stays deterministic
    and independently testable.
  - Serializes via `model_dump_json(by_alias=True, exclude_none=True)` so the
    estimate reflects actual wire field names (`inputSchema`) and omits unset
    optionals. Accepts both `mcp.types.Tool` objects and raw `tools/list` dicts.
  
  ## Tests
  `test/mcp_tool_metrics_test.py` — counts, the token estimate (exact for dict
  input), budget math, the no-/zero-budget cases, and config-vs-per-call budget
  precedence. Full MCP suite: `33 passed`.
  
  ## Stacking
  Stacked on the generator PR (`McpToolsGenerator`), which is stacked on #463 (the
  man-page formatter). Until those land, this PR's diff includes their commits;
  review/merge bottom-up: #463 → generator → metrics.
