### PR TITLE
Move teardown script into finally block

### DIFF
--- a/evalbench/evalbench.py
+++ b/evalbench/evalbench.py
@@ -48,6 +48,8 @@ flags.declare_key_flag('experiment_config')
 
 
 def eval(experiment_config: str):
+    config = None
+    session_dir = None
     try:
         logging.info("EvalBench v1.0.0")
         logging.getLogger("google_genai.models").setLevel(logging.WARNING)
@@ -157,17 +159,6 @@ def eval(experiment_config: str):
 
         print(f"Finished Job ID {job_id}")
 
-        tear_down_script = config.get("tear_down_script")
-        if tear_down_script:
-            if os.path.exists(tear_down_script):
-                logging.info("Executing tear_down_script '%s'", tear_down_script)
-                run_script(tear_down_script, session_dir, "teardown")
-            else:
-                logging.error(
-                    "Cannot run tear_down_script, file not found at '%s'",
-                    tear_down_script,
-                )
-
         return True
     except Exception as e:
         display_config = experiment_config
@@ -176,6 +167,18 @@ def eval(experiment_config: str):
             display_config = display_config[g3_idx:]
         logging.exception(f"Evaluation failed for config '{display_config}': {e}")
         return False
+    finally:
+        if config and session_dir:
+            tear_down_script = config.get("tear_down_script")
+            if tear_down_script:
+                if os.path.exists(tear_down_script):
+                    logging.info("Executing tear_down_script '%s'", tear_down_script)
+                    run_script(tear_down_script, session_dir, "teardown")
+                else:
+                    logging.error(
+                        "Cannot run tear_down_script, file not found at '%s'",
+                        tear_down_script,
+                    )
 
 
 def run_suite(suite_config_path: str) -> bool:

--- a/evalbench/test/evalbench_test.py
+++ b/evalbench/test/evalbench_test.py
@@ -79,6 +79,63 @@ class TestEvalbench(unittest.TestCase):
 
         self.assertFalse(success)
 
+    @patch('evalbench.evalbench.run_script')
+    @patch('os.path.exists')
+    @patch('evalbench.evalbench.get_orchestrator')
+    @patch('evalbench.evalbench.load_yaml_config')
+    @patch('evalbench.evalbench.load_dataset_from_json')
+    @patch('evalbench.evalbench.set_session_configs')
+    @patch('evalbench.evalbench.load_session_configs')
+    @patch('evalbench.evalbench.get_reporters')
+    def test_eval_teardown_on_success(self, mock_get_reporters, mock_load_session, mock_set_session, mock_load_dataset, mock_load_yaml, mock_get_orch, mock_exists, mock_run_script):
+        mock_load_yaml.return_value = {"dummy": "config"}
+
+        def mock_set_session_fn(session, parsed_config):
+            session["dataset_config"] = "fake_ds.json"
+        mock_set_session.side_effect = mock_set_session_fn
+
+        mock_load_session.return_value = ({"tear_down_script": "teardown.sh"}, [{}], {}, {})
+
+        mock_evaluator = MagicMock()
+        mock_evaluator.job_id = "job123"
+        mock_evaluator.process.return_value = ("job123", "10s", None, None, None)
+        mock_get_orch.return_value = mock_evaluator
+
+        mock_exists.return_value = True
+
+        success = evalbench_eval("fake_config.yaml")
+
+        self.assertTrue(success)
+        mock_run_script.assert_called_once_with("teardown.sh", os.path.abspath("results/job123"), "teardown")
+
+    @patch('evalbench.evalbench.run_script')
+    @patch('os.path.exists')
+    @patch('evalbench.evalbench.get_orchestrator')
+    @patch('evalbench.evalbench.load_yaml_config')
+    @patch('evalbench.evalbench.load_dataset_from_json')
+    @patch('evalbench.evalbench.set_session_configs')
+    @patch('evalbench.evalbench.load_session_configs')
+    def test_eval_teardown_on_error(self, mock_load_session, mock_set_session, mock_load_dataset, mock_load_yaml, mock_get_orch, mock_exists, mock_run_script):
+        mock_load_yaml.return_value = {"dummy": "config"}
+
+        def mock_set_session_fn(session, parsed_config):
+            session["dataset_config"] = "fake_ds.json"
+        mock_set_session.side_effect = mock_set_session_fn
+
+        mock_load_session.return_value = ({"tear_down_script": "teardown.sh"}, [{}], {}, {})
+
+        mock_evaluator = MagicMock()
+        mock_evaluator.job_id = "job123"
+        mock_evaluator.evaluate.side_effect = Exception("Evaluation failed!")
+        mock_get_orch.return_value = mock_evaluator
+
+        mock_exists.return_value = True
+
+        success = evalbench_eval("fake_config.yaml")
+
+        self.assertFalse(success)
+        mock_run_script.assert_called_once_with("teardown.sh", os.path.abspath("results/job123"), "teardown")
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This CL moves the teardown script parsing and execution into a new finally block, ensuring that the teardown runs even if an exception is thrown. UTs are added to verify functionality.