### PR TITLE
feat(mcp-readability): compliance orchestrator, LLM judge, and metrics scorer

### DIFF
--- a/datasets/mcp_readability/run_config.yaml
+++ b/datasets/mcp_readability/run_config.yaml
@@ -12,23 +12,31 @@
 
 orchestrator: mcp_readability
 
+# Plug-and-play scorers. Each key names a registered mcp_readability scorer
+# (SCORER_REGISTRY in the orchestrator) and carries that scorer's own config.
+# The orchestrator runs every scorer declared here against each endpoint and
+# merges their result columns; the shared analyzer aggregates a per-scorer pass
+# rate (comparator = scorer name) for the scores / summary reports. Add a scorer
+# (e.g. conformance) by registering the class and adding a block here.
+scorers:
+  # Deterministic size metrics. Pass = within token budget. `token_budget` feeds
+  # mcp_readability_token_budget_used_percent (endpoints may override per-entry).
+  mcp_tool_metrics:
+    token_budget: 200000
+  # LLM judge vs the style guide. Pass = no P0 findings. Owns its model config
+  # and style-guide path. Run with EVAL_GCP_PROJECT_REGION=global.
+  mcp_style_readability:
+    model_config: datasets/model_configs/gemini_2.5_pro_model.yaml
+    style_guide: datasets/mcp_readability/style_guide.md
+
 # Inputs (paths relative to the repo root / run cwd).
 endpoints_config: datasets/mcp_readability/endpoints.yaml
 exceptions_config: datasets/mcp_readability/exceptions.yaml          # optional
 tools_generator_config: datasets/mcp_readability/tools_generator.yaml
 
-# Token budget for token_budget_used_percent (endpoints may override per-entry).
-token_budget: 200000
-
 # Optional filter: only check endpoints whose endpoint_type is in this list.
 # Empty = check all. e.g. [PROD]
 endpoint_types: []
-
-# LLM judge: consumes a model config and the style-guide path. Reuses the
-# shared repo model config.
-readability_judge:
-  model_config: datasets/model_configs/gemini_2.5_pro_model.yaml
-  style_guide: datasets/mcp_readability/style_guide.md
 
 # Per-endpoint check concurrency.
 runners:

--- a/evalbench/dataset/dataset.py
+++ b/evalbench/dataset/dataset.py
@@ -242,6 +242,17 @@ def load_json(json_file_path):
 
 
 def load_dataset_from_json(json_file_path, config):
+    # No dataset path (e.g. orchestrators driven by their run config rather than a
+    # prompt dataset): nothing to load. flatten_dataset({}) yields []. Log it so
+    # a run that *did* expect a dataset (missing/misconfigured dataset_config)
+    # doesn't fail silently.
+    if not json_file_path:
+        logging.info(
+            "load_dataset_from_json: no dataset path provided; returning an "
+            "empty dataset. Expected only for orchestrators that drive their "
+            "own inputs from the run config."
+        )
+        return {}
     input_items = {}
     dataset_format = config.get("dataset_format", "evalbench-standard-format")
     if dataset_format == "bird-interact-format":

--- a/evalbench/eval_service.py
+++ b/evalbench/eval_service.py
@@ -126,7 +126,9 @@ class EvalServicer(eval_service_pb2_grpc.EvalServiceServicer):
         session = SESSIONMANAGER.get_session(rpc_id_var.get())
         logging.info("Retrieving Evals for: %s.", rpc_id_var.get())
         experiment_config = session["config"]
-        dataset_config_json = experiment_config["dataset_config"]
+        # dataset_config is optional: some orchestrators drive their work from
+        # the run config itself, in which case load_dataset_from_json returns {}.
+        dataset_config_json = experiment_config.get("dataset_config")
         dataset = load_dataset_from_json(
             dataset_config_json, experiment_config)
         for _, eval_inputs in dataset.items():
@@ -316,8 +318,9 @@ class EvalServicer(eval_service_pb2_grpc.EvalServiceServicer):
             context.set_details(error_msg)
             return
 
-        # Load dataset and instantiate the Orchestrator
-        dataset_config_json = config["dataset_config"]
+        # Load dataset and instantiate the Orchestrator. dataset_config is
+        # optional (datasetless orchestrators drive from the run config).
+        dataset_config_json = config.get("dataset_config")
         dataset_dict = load_dataset_from_json(dataset_config_json, config)
 
         dataset = []

--- a/evalbench/evaluator/__init__.py
+++ b/evalbench/evaluator/__init__.py
@@ -8,6 +8,7 @@ from evaluator.streamingorchestrator import StreamingOrchestrator
 from evaluator.dataengineeringagentorchestrator import (
     DataEngineeringAgentOrchestrator,
 )
+from evaluator.mcp_readability import McpReadabilityOrchestrator
 import logging
 
 
@@ -25,6 +26,10 @@ def get_orchestrator(config, db_configs, setup_config, report_progress=False):
         return CortadoOrchestrator(config, db_configs, setup_config, report_progress)
     elif orchestrator_type == "dea":
         return DataEngineeringAgentOrchestrator(
+            config, db_configs, setup_config, report_progress
+        )
+    elif orchestrator_type == "mcp_readability":
+        return McpReadabilityOrchestrator(
             config, db_configs, setup_config, report_progress
         )
     else:

--- a/evalbench/evaluator/mcp_readability/__init__.py
+++ b/evalbench/evaluator/mcp_readability/__init__.py
@@ -1,0 +1,3 @@
+from evaluator.mcp_readability.orchestrator import McpReadabilityOrchestrator
+
+__all__ = ["McpReadabilityOrchestrator"]

--- a/evalbench/evaluator/mcp_readability/exceptions.py
+++ b/evalbench/evaluator/mcp_readability/exceptions.py
@@ -1,0 +1,71 @@
+"""Loading and matching of per-endpoint style-rule exceptions (waivers).
+
+An exceptions file lets an operator waive a specific style requirement for a
+specific endpoint when it legitimately cannot comply. Waived rules are passed to
+the scorer so they are excluded from the P0/P1/P2 counts and surfaced separately
+in the feedback.
+
+File schema (see ``datasets/mcp_readability/exceptions.yaml``)::
+
+    exceptions:
+      - product_name: "Cloud SQL"     # any of product_name / endpoint_type
+        rule_id: "tool-names"
+        reason: "..."
+      - endpoint_type: AUTOPUSH       # "*" or omitted field = match-all
+        rule_id: "use-enums"
+        reason: "..."
+"""
+
+import logging
+from util.config import load_yaml_config
+
+
+def load_exceptions(path: str) -> list[dict]:
+    """Load the exceptions list from a YAML file. Missing/empty -> []."""
+    if not path:
+        return []
+    parsed = load_yaml_config(path)
+    if not parsed:
+        return []
+    exceptions = parsed.get("exceptions") or []
+    if not isinstance(exceptions, list):
+        logging.warning(
+            "mcp_readability: 'exceptions' in %s is not a list; ignoring.", path
+        )
+        return []
+    return exceptions
+
+
+def _matches(field_value, exception_value) -> bool:
+    """A matcher field matches when it is absent, '*', or equal (case-insensitive)."""
+    if exception_value is None or exception_value == "*":
+        return True
+    if field_value is None:
+        return False
+    return str(field_value).strip().lower() == str(exception_value).strip().lower()
+
+
+def applicable_exceptions(endpoint: dict, all_exceptions: list[dict]) -> list[dict]:
+    """Return exceptions whose matchers all apply to ``endpoint``.
+
+    Matchers considered: ``product_name`` and ``endpoint_type`` (the endpoint's
+    identity in #469's ``endpoints.yaml``). Each exception keeps its ``rule_id``
+    and ``reason`` for the scorer prompt.
+    """
+    matched = []
+    for exc in all_exceptions:
+        if not isinstance(exc, dict):
+            continue
+        if not exc.get("rule_id"):
+            continue
+        if (
+            _matches(endpoint.get("product_name"), exc.get("product_name"))
+            and _matches(endpoint.get("endpoint_type"), exc.get("endpoint_type"))
+        ):
+            matched.append(
+                {
+                    "rule_id": exc.get("rule_id"),
+                    "reason": exc.get("reason", ""),
+                }
+            )
+    return matched

--- a/evalbench/evaluator/mcp_readability/orchestrator.py
+++ b/evalbench/evaluator/mcp_readability/orchestrator.py
@@ -1,0 +1,318 @@
+"""Orchestrator for the MCP style-guide readability check.
+
+Flow per endpoint:
+  1. The tools generator fetches the endpoint's tools and renders the man-page
+     markup.
+  2. Applicable exceptions (waivers) are gathered.
+  3. Every scorer declared under ``scorers:`` in the run config is invoked with
+     the shared per-endpoint context; each contributes result-row columns and a
+     binary summary score (see ``scorers.mcp_readability_scoring``).
+  4. A result row is assembled from the base identity columns plus every
+     scorer's contribution.
+
+The orchestrator is scorer-agnostic: it instantiates whatever scorers the run
+config declares (via ``SCORER_REGISTRY``) and merges their contributions. Adding
+a new scorer (e.g. conformance testing) needs only a registry entry and a
+run-config block -- no changes here.
+
+Failure handling is fail-fast: if any endpoint cannot be fetched or scored, the
+exception propagates and the whole job aborts with nothing persisted. There is no
+per-endpoint status; the failure surfaces in the run log. Isolate flaky or
+experimental endpoints with a separate run config rather than per-row state.
+
+Like the standard EvalBench orchestrators, :meth:`process` dumps the result rows
+to a temp JSON and returns it as ``results_tf``; ``evalbench.py`` then hands that
+to the shared reporters (CSV / BigQuery). The orchestrator performs no direct
+CSV or BigQuery writes itself.
+"""
+
+import concurrent.futures
+import datetime
+import json
+import logging
+import tempfile
+import threading
+
+from evaluator.orchestrator import Orchestrator
+from generators.models import get_generator
+from scorers.mcp_readability_scoring import EndpointContext
+from scorers.mcp_style_readability import McpStyleReadabilityScorer
+from scorers.mcp_tool_metrics import McpToolMetricsScorer
+from util.config import load_yaml_config
+
+from evaluator.mcp_readability import exceptions as exceptions_mod
+
+
+# Registered mcp_readability scorers, keyed by the name used under ``scorers:`` in
+# the run config (also each scorer's ``comparator`` in the summary). Add a new
+# scorer here plus a run-config block to extend the check -- the orchestrator
+# itself stays unchanged.
+SCORER_REGISTRY = {
+    "mcp_tool_metrics": McpToolMetricsScorer,
+    "mcp_style_readability": McpStyleReadabilityScorer,
+}
+
+
+# Allowed endpoint_type values (deployment channel / dashboard categorization).
+# Validated at load time; an unknown value fails the run fast.
+ALLOWED_ENDPOINT_TYPES = ("PROD", "AUTOPUSH", "STAGING", "DEV")
+
+
+# Base identity columns present on every result row (``job_id`` is the shared
+# framework column). Each configured scorer appends its own COLUMNS; the full,
+# canonical schema for a run is ``self.columns``. Columns are prefixed
+# ``mcp_readability_`` so rows coexist with other eval types in the shared
+# ``<project>.evalbench.results`` table (``mcp_readability_score`` non-null is the
+# readability-row discriminator). No per-endpoint status column: a fetch/scoring
+# failure aborts the whole job (fail-fast), so every persisted row is successful.
+BASE_COLUMNS = [
+    "mcp_readability_product_name",
+    "mcp_readability_source_url",
+    "mcp_readability_endpoint_type",
+    "mcp_readability_check_timestamp",
+    "job_id",
+]
+
+
+def _validate_endpoint_type(value) -> str:
+    """Normalize + validate an endpoint_type; raise on unknown (fail-fast)."""
+    if value is None:
+        raise ValueError("mcp_readability: endpoint_type is required")
+    name = str(value).strip().upper()
+    if name not in ALLOWED_ENDPOINT_TYPES:
+        raise ValueError(
+            f"mcp_readability: unknown endpoint_type {value!r}; "
+            f"allowed: {', '.join(ALLOWED_ENDPOINT_TYPES)}"
+        )
+    return name
+
+
+class McpReadabilityOrchestrator(Orchestrator):
+    """Checks a list of MCP endpoints against an MCP tool style guide."""
+
+    def __init__(self, config, db_configs, setup_config, report_progress=False):
+        super().__init__(config, db_configs, setup_config, report_progress)
+
+        runner_config = config.get("runners", {}) or {}
+        self.endpoint_runners = runner_config.get("endpoint_runners", 4)
+
+        # Load endpoints (a flat list; no shared defaults block).
+        endpoints_config = config.get("endpoints_config")
+        if not endpoints_config:
+            raise ValueError("mcp_readability requires 'endpoints_config'")
+        parsed = load_yaml_config(endpoints_config) or {}
+        self.endpoints = parsed.get("endpoints") or []
+        if not self.endpoints:
+            logging.warning(
+                "mcp_readability: no endpoints found in %s", endpoints_config
+            )
+
+        # Exceptions (waivers).
+        self.all_exceptions = exceptions_mod.load_exceptions(
+            config.get("exceptions_config")
+        )
+
+        # Optional endpoint_type filter (validated against the allowed set).
+        type_filter = config.get("endpoint_types") or []
+        self.endpoint_type_filter = {
+            _validate_endpoint_type(t) for t in type_filter
+        }
+
+        # Shared model registry for get_generator (lock + cache): get_generator
+        # memoizes instantiated model clients here (guarded by the lock) so
+        # repeated calls -- e.g. across scorers and endpoint threads -- reuse the
+        # same client instead of re-instantiating one per call.
+        self.global_models = {
+            "lock": threading.Lock(),
+            "registered_models": {},
+        }
+
+        # Tools generator (the "system under test" fetcher).
+        tools_generator_config = config.get("tools_generator_config")
+        if not tools_generator_config:
+            raise ValueError("mcp_readability requires 'tools_generator_config'")
+        self.tools_generator = get_generator(
+            self.global_models, tools_generator_config
+        )
+
+        # Plug-and-play scorers: instantiate exactly what the run config declares.
+        # Each scorer owns and validates its own config block (token_budget for
+        # metrics; model_config + style_guide for the LLM judge).
+        scorers_config = config.get("scorers") or {}
+        if not scorers_config:
+            raise ValueError("mcp_readability requires a 'scorers' block")
+        self.scorers = []
+        for name, scorer_config in scorers_config.items():
+            scorer_cls = SCORER_REGISTRY.get(name)
+            if scorer_cls is None:
+                raise ValueError(
+                    f"mcp_readability: unknown scorer {name!r}; "
+                    f"known: {', '.join(sorted(SCORER_REGISTRY))}"
+                )
+            self.scorers.append(
+                scorer_cls(scorer_config or {}, self.global_models)
+            )
+
+        # Full canonical result schema for this run: base identity columns plus
+        # every configured scorer's columns.
+        self.columns = list(BASE_COLUMNS)
+        for scorer in self.scorers:
+            self.columns.extend(scorer.COLUMNS)
+
+        self.rows = []
+        self.score_rows = []
+
+    # ------------------------------------------------------------------
+    # Public lifecycle
+    # ------------------------------------------------------------------
+    def evaluate(self, dataset=None):
+        """Run the readability check for every (filtered) endpoint."""
+        endpoints = self._filtered_endpoints()
+        if not endpoints:
+            logging.warning(
+                "mcp_readability: no endpoints to check after filtering."
+            )
+            self.rows = []
+            self.score_rows = []
+            return
+
+        workers = max(1, int(self.endpoint_runners))
+        results = []  # list[(row, score_rows)]
+        with concurrent.futures.ThreadPoolExecutor(max_workers=workers) as pool:
+            futures = {
+                pool.submit(self._check_endpoint, ep): ep for ep in endpoints
+            }
+            # fail-fast: _check_endpoint lets exceptions propagate, so the first
+            # failed future re-raises here and aborts the run.
+            for future in concurrent.futures.as_completed(futures):
+                results.append(future.result())
+
+        # Deterministic ordering (by product_name then source url).
+        results.sort(
+            key=lambda rs: (
+                rs[0].get("mcp_readability_product_name", ""),
+                rs[0].get("mcp_readability_source_url", ""),
+            )
+        )
+        self.rows = [row for row, _ in results]
+        self.score_rows = [s for _, score_rows in results for s in score_rows]
+        if self.report_progress:
+            logging.info(
+                "mcp_readability: checked %d endpoints.", len(self.rows)
+            )
+
+    def process(self):
+        """Dump result + score rows to temp JSONs and return them.
+
+        Matches the standard orchestrator contract so ``evalbench.py`` + the
+        shared reporters handle the CSV / BigQuery writes with no special casing:
+
+        - ``results_tf`` holds the full per-endpoint readability rows (drives the
+          evals output).
+        - ``scores_tf`` holds one score row per (endpoint, scorer) so the shared
+          analyzer aggregates a pass rate for each scorer key declared under
+          ``scorers:`` (drives the scores / summary output).
+        """
+        results_tf = self._dump_temp_json(self.rows)
+        scores_tf = self._dump_temp_json(self.score_rows)
+        return (self.job_id, self.run_time, results_tf, scores_tf, None)
+
+    # ------------------------------------------------------------------
+    # Per-endpoint work
+    # ------------------------------------------------------------------
+    def _check_endpoint(self, endpoint: dict):
+        """Fetch + score one endpoint. Returns ``(row, score_rows)``.
+
+        Any failure propagates (fail-fast); the run aborts and nothing persists.
+        """
+        product_name = endpoint.get("product_name", "")
+        endpoint_type = _validate_endpoint_type(endpoint.get("endpoint_type"))
+        endpoint_url = self._endpoint_ref(endpoint)
+
+        row = self._base_row(product_name, endpoint_url, endpoint_type)
+        row["job_id"] = self.job_id
+
+        try:
+            # 1. Fetch tools + render man-page markup.
+            tools, man_page = self.tools_generator.fetch_tools(endpoint)
+
+            # 2. Exceptions (waivers) for this endpoint.
+            applicable = exceptions_mod.applicable_exceptions(
+                endpoint, self.all_exceptions
+            )
+
+            # 3. Run every configured scorer against the shared context.
+            context = EndpointContext(
+                product_name=product_name,
+                endpoint=endpoint,
+                tools=tools,
+                man_page=man_page,
+                exceptions=applicable,
+            )
+            score_rows = []
+            for scorer in self.scorers:
+                contribution = scorer.run(context)
+                row.update(contribution.row_fields)
+                score_rows.append(
+                    {
+                        "id": product_name or endpoint_url,
+                        "comparator": scorer.name,
+                        "score": contribution.score,
+                        "comparison_logs": contribution.logs,
+                        "comparison_error": None,
+                    }
+                )
+        except Exception:
+            logging.exception(
+                "mcp_readability: check failed for %s (%s); aborting run.",
+                product_name,
+                endpoint_url,
+            )
+            raise
+
+        return row, score_rows
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+    @staticmethod
+    def _endpoint_ref(endpoint: dict) -> str:
+        """A stable human-readable reference for an endpoint's tool source.
+
+        Reported as ``mcp_readability_source_url``, and used as the sort key and
+        the score-row id. Falls back to the file ``path`` for offline sources
+        (which have no ``url``) so distinct endpoints don't collapse to "".
+        """
+        src = endpoint.get("tools_source") or {}
+        return src.get("url") or src.get("path") or ""
+
+    @staticmethod
+    def _dump_temp_json(rows) -> str:
+        with tempfile.NamedTemporaryFile(
+            mode="w", delete=False, suffix=".json"
+        ) as f:
+            json.dump(rows, f, sort_keys=True, indent=4, default=str)
+            return f.name
+
+    def _filtered_endpoints(self) -> list[dict]:
+        if not self.endpoint_type_filter:
+            return list(self.endpoints)
+        kept = []
+        for ep in self.endpoints:
+            if _validate_endpoint_type(ep.get("endpoint_type")) in (
+                self.endpoint_type_filter
+            ):
+                kept.append(ep)
+        return kept
+
+    @staticmethod
+    def _base_row(product_name, endpoint_url, endpoint_type) -> dict:
+        return {
+            "mcp_readability_product_name": product_name,
+            "mcp_readability_source_url": endpoint_url,
+            "mcp_readability_endpoint_type": endpoint_type,
+            "mcp_readability_check_timestamp": (
+                datetime.datetime.now().isoformat()
+            ),
+            "job_id": "",
+        }

--- a/evalbench/scorers/mcp_readability_scoring.py
+++ b/evalbench/scorers/mcp_readability_scoring.py
@@ -1,0 +1,53 @@
+"""Shared interface for the plug-and-play MCP readability scorers.
+
+The orchestrator fetches each endpoint's tools once, then hands every configured
+scorer the same :class:`EndpointContext` and merges each scorer's
+:class:`ScoreContribution` into the result row. A new scorer (e.g. conformance
+testing) plugs in by registering its class in the orchestrator's registry and
+adding a block under ``scorers:`` in the run config -- no orchestrator changes
+needed.
+
+Each mcp_readability scorer implements:
+
+  - ``name``: str, must match its key under ``scorers:`` in the run config
+    (also used as the ``comparator`` on its summary score rows).
+  - ``COLUMNS``: list[str], the result-row columns it contributes.
+  - ``run(context) -> ScoreContribution``: evaluate one endpoint.
+
+This module is deliberately kept free of any concrete-scorer imports so both the
+scorers and the orchestrator can import it without a cycle.
+"""
+
+from dataclasses import dataclass, field
+from typing import Any
+
+
+@dataclass
+class EndpointContext:
+    """Everything a scorer needs to evaluate a single endpoint.
+
+    Populated once by the orchestrator after fetching + rendering the tools, then
+    shared across all configured scorers for that endpoint.
+    """
+
+    product_name: str
+    endpoint: dict
+    tools: list  # list[mcp.types.Tool]
+    man_page: str
+    exceptions: list  # applicable waivers for this endpoint
+
+
+@dataclass
+class ScoreContribution:
+    """What a scorer returns for one endpoint.
+
+    - ``row_fields``: result-row columns (keys must be within the scorer's
+      declared ``COLUMNS``) merged into the endpoint's evals row.
+    - ``score``: 0/100 binary pass for the shared analyzer summary (aggregated
+      under the scorer's ``name`` as ``comparator``).
+    - ``logs``: human-readable ``comparison_logs`` for the score row.
+    """
+
+    row_fields: dict[str, Any] = field(default_factory=dict)
+    score: int = 100
+    logs: str = ""

--- a/evalbench/scorers/mcp_style_readability.py
+++ b/evalbench/scorers/mcp_style_readability.py
@@ -1,0 +1,346 @@
+"""LLM-backed scorer that evaluates an MCP tool manifest against a style guide.
+
+Follows the same shape as :class:`scorers.llmrater.LLMRater`: constructed with
+``(config, global_models)`` and holds an LLM obtained via
+``generators.models.get_generator``. The orchestrator calls :meth:`evaluate`
+per endpoint with the tool man-page markup.
+
+The model reviews the tools from an LLM-agent-consumption perspective and returns
+a strict JSON object describing P0/P1/P2 findings, an overall readability score,
+and any rules waived via the exceptions file. We parse and normalize that JSON
+defensively so a slightly malformed response degrades to an ERROR row rather than
+crashing the run.
+"""
+
+import html
+import json
+import logging
+import re
+
+from generators.models import get_generator
+from scorers.mcp_readability_scoring import EndpointContext, ScoreContribution
+
+
+# Shared JSON output contract appended to both prompts (escaped for str.format).
+_OUTPUT_SCHEMA = """### OUTPUT
+Return ONLY a JSON object (no markdown, no prose) with exactly this shape:
+{{
+  "readability_score": <integer 0-100, higher is better>,
+  "p0_issues": <integer>,
+  "p1_issues": <integer>,
+  "p2_issues": <integer>,
+  "findings": [
+    {{"severity": "P0|P1|P2", "rule_id": "<string>", "tool": "<tool name or ''>",
+      "title": "<short one-line summary>", "message": "<what is wrong>",
+      "suggestion": "<how to fix>"}}
+  ],
+  "waived": [
+    {{"rule_id": "<string>", "reason": "<reason>", "would_have_violated": <true|false>}}
+  ],
+  "summary": "<one-paragraph overall assessment>"
+}}
+The counts p0_issues/p1_issues/p2_issues MUST equal the number of findings of
+each severity."""
+
+
+PROMPT_TEMPLATE = (
+    """You are an expert on MCP tool design and a pragmatic
+API Developer Experience reviewer. Evaluate the MCP server's tool definitions
+(shown below as a man page) against the STYLE GUIDE and report every violation.
+
+Evaluate from the perspective of an LLM agent that must call these tools, and
+judge every tool against the principle of designing APIs for easy LLM
+consumption (understandable terminology, simple parameters, no client-side
+logic):
+- Will the model understand the terminology and the tool / parameter names?
+- Are the parameters too complex, too numerous, or under-described?
+- Is the agent forced to act like a computer -- e.g. formatting complex strings,
+  generating UUIDs, calculating timestamps, or applying other client-side logic
+  -- instead of simply expressing intent?
+Adopt a consultative, pragmatic tone, like a human code reviewer (e.g.
+"Consider if...", "Evaluate whether..."). Do not be overly pedantic about minor
+wording or text issues when larger architectural blockers exist -- prioritize
+the blockers. Only report issues that genuinely apply; do not fabricate issues
+for a tool that has none.
+
+Severity levels:
+- P0: blocker -- critical violation (must fix; blocks compliance).
+- P1: strong recommendation -- major violation (should fix).
+- P2: informal suggestion -- minor / stylistic violation (nice to fix).
+
+How to assign severity and rule_id:
+- The STYLE GUIDE annotates each rule with its priority in an HTML comment next
+  to the section heading, e.g. `### Tool Names <!-- priority: p1 ... -->` or
+  `#### Safe Pagination <!-- priority: p0 -->`. Use that annotated priority as
+  the severity of any violation of that rule (p0 -> P0, p1 -> P1, p2 -> P2).
+- A heading may specify different priorities for different aspects, e.g.
+  `<!-- priority: p1 for <action>_<resource>, p2 for snake_case -->`. Honor that
+  split when classifying the specific violation.
+- Use the section heading text as the `rule_id` (e.g. "Tool Names",
+  "Use Human-Readable Time and Durations", "Concise Descriptions").
+- Only report violations of rules that actually apply to the given tools. Rules
+  about platform/registration/dashboards that cannot be judged from the tool
+  schema alone should not be flagged as violations.
+
+Avoid duplication (global vs per-tool):
+- If an issue is global or repeats across many tools (e.g. a convention violated
+  everywhere), report it ONCE with "tool" set to "" (empty string). Do NOT emit
+  the same global issue once per tool.
+- Report tool-specific issues with "tool" set to that tool's name.
+
+### STYLE GUIDE
+{style_guide}
+
+### PRODUCT
+{product_name}
+
+### TOOLS (man page)
+{tools_markup}
+
+### EXCEPTIONS (waived rules — DO NOT count these as issues)
+The following rules have been explicitly waived for this endpoint. Do not include
+them in p0_issues/p1_issues/p2_issues or in "findings". Instead list them under
+"waived" with their reason. If a waived rule would otherwise have been violated,
+note that in the waived entry.
+{exceptions}
+
+"""
+    + _OUTPUT_SCHEMA
+)
+
+
+class McpStyleReadabilityScorer:
+    """Scores a tools spec against the MCP style guide using an LLM."""
+
+    # Result-row columns this scorer contributes.
+    COLUMNS = [
+        "mcp_readability_p0_issues",
+        "mcp_readability_p1_issues",
+        "mcp_readability_p2_issues",
+        "mcp_readability_score",
+        "mcp_readability_llm_feedback_json",
+        "mcp_readability_llm_feedback_html",
+    ]
+
+    def __init__(self, config: dict, global_models):
+        self.name = "mcp_style_readability"
+        config = config or {}
+        self.model_config = config.get("model_config") or ""
+        if not self.model_config:
+            raise ValueError(
+                "model_config is required for the mcp_style_readability scorer"
+            )
+        # The scorer owns its style guide: required, read once at construction.
+        style_guide_path = config.get("style_guide")
+        if not style_guide_path:
+            raise ValueError(
+                "style_guide is required for the mcp_style_readability scorer"
+            )
+        self.style_guide = _read_text(style_guide_path)
+        self.model = get_generator(global_models, self.model_config)
+
+    def run(self, context: EndpointContext) -> ScoreContribution:
+        """Evaluate one endpoint: judge the man page, pass iff no P0 findings."""
+        feedback = self.evaluate(
+            tools_markup=context.man_page,
+            style_guide=self.style_guide,
+            product_name=context.product_name,
+            exceptions=context.exceptions,
+        )
+        p0 = int(feedback.get("p0_issues", 0))
+        return ScoreContribution(
+            row_fields={
+                "mcp_readability_p0_issues": p0,
+                "mcp_readability_p1_issues": int(feedback.get("p1_issues", 0)),
+                "mcp_readability_p2_issues": int(feedback.get("p2_issues", 0)),
+                "mcp_readability_score": int(feedback.get("readability_score", 0)),
+                "mcp_readability_llm_feedback_json": json.dumps(feedback),
+                "mcp_readability_llm_feedback_html": self.to_html(feedback),
+            },
+            score=100 if p0 == 0 else 0,
+            logs=(
+                f"p0_issues={p0}, "
+                f"readability_score={feedback.get('readability_score', 0)}"
+            ),
+        )
+
+    def evaluate(
+        self,
+        tools_markup: str,
+        style_guide: str,
+        product_name: str,
+        exceptions: list[dict] | None = None,
+    ) -> dict:
+        """Run the LLM readability check and return a normalized feedback dict."""
+        prompt = PROMPT_TEMPLATE.format(
+            style_guide=style_guide or "(no style guide provided)",
+            product_name=product_name or "(unknown)",
+            tools_markup=tools_markup or "(no tools)",
+            exceptions=json.dumps(exceptions or [], indent=2),
+        )
+        raw = self._generate(prompt)
+        return self._parse(raw)
+
+    def _generate(self, prompt: str) -> str:
+        """Generate the model response as raw JSON text.
+
+        Prefer Gemini's native JSON mode via the underlying genai client, which
+        guarantees syntactically valid JSON and -- crucially -- bypasses
+        ``GeminiGenerator.generate``'s SQL sanitizer (it strips backslashes and
+        collapses whitespace, corrupting JSON escapes). Falls back to the
+        generic ``generate`` for non-Gemini models.
+        """
+        client = getattr(self.model, "client", None)
+        caller = getattr(self.model, "_call_generate_content", None)
+        if client is not None and callable(caller):
+            try:
+                from google.genai import types
+
+                config = types.GenerateContentConfig(
+                    response_mime_type="application/json",
+                    temperature=0,
+                )
+                resp = caller(contents=prompt, config=config)
+                text = getattr(resp, "text", None)
+                if text:
+                    return text
+            except Exception as e:
+                logging.warning(
+                    "mcp_style_readability: JSON-mode generation failed (%s); "
+                    "falling back to plain generate().",
+                    e,
+                )
+        return self.model.generate(prompt)
+
+    # ------------------------------------------------------------------
+    # parsing / rendering
+    # ------------------------------------------------------------------
+    @staticmethod
+    def _extract_json(text: str) -> dict:
+        """Pull a JSON object out of a model response (handles code fences)."""
+        if not text:
+            raise ValueError("empty model response")
+        text = text.strip()
+        # Strip ```json ... ``` or ``` ... ``` fences (tolerating trailing ws).
+        fence = re.match(r"^```(?:json)?\s*(.*?)\s*```\s*$", text, re.DOTALL)
+        if fence:
+            text = fence.group(1).strip()
+        try:
+            return json.loads(text)
+        except json.JSONDecodeError:
+            # Fallback: grab the outermost {...} span.
+            start = text.find("{")
+            end = text.rfind("}")
+            if start != -1 and end > start:
+                try:
+                    return json.loads(text[start:end + 1])
+                except json.JSONDecodeError:
+                    pass
+            raise ValueError("no JSON object found in model response")
+
+    def _parse(self, raw: str) -> dict:
+        """Normalize the model output into a stable feedback dict."""
+        data = self._extract_json(raw)
+        findings = data.get("findings") or []
+        if not isinstance(findings, list):
+            findings = []
+
+        # Counts derived from findings are authoritative (a single pass). Only
+        # fall back to the model's self-reported integers when there are no
+        # findings at all -- otherwise a legitimately-zero severity would be
+        # overwritten by a mismatched self-reported count.
+        if findings:
+            counts = {"P0": 0, "P1": 0, "P2": 0}
+            for f in findings:
+                if isinstance(f, dict):
+                    sev = str(f.get("severity", "")).upper()
+                    if sev in counts:
+                        counts[sev] += 1
+            p0, p1, p2 = counts["P0"], counts["P1"], counts["P2"]
+        else:
+            p0 = _safe_int(data.get("p0_issues"))
+            p1 = _safe_int(data.get("p1_issues"))
+            p2 = _safe_int(data.get("p2_issues"))
+
+        return {
+            "readability_score": _safe_int(data.get("readability_score")),
+            "p0_issues": p0,
+            "p1_issues": p1,
+            "p2_issues": p2,
+            "findings": findings,
+            "waived": data.get("waived") or [],
+            "summary": data.get("summary", ""),
+        }
+
+    @staticmethod
+    def to_html(feedback: dict) -> str:
+        """Render feedback as a severity-grouped HTML fragment."""
+        if not feedback:
+            return ""
+        score = feedback.get("readability_score", 0)
+        summary = html.escape(str(feedback.get("summary", "")))
+        parts = [
+            "<div class='mcp-readability'>",
+            f"<h3>Readability score: {score}</h3>",
+            f"<p>{summary}</p>",
+            "<p>P0: {p0} &nbsp; P1: {p1} &nbsp; P2: {p2}</p>".format(
+                p0=feedback.get("p0_issues", 0),
+                p1=feedback.get("p1_issues", 0),
+                p2=feedback.get("p2_issues", 0),
+            ),
+        ]
+        findings = feedback.get("findings") or []
+        if findings:
+            parts.append(
+                "<table border='1' cellpadding='4' cellspacing='0'>"
+                "<tr><th>Severity</th><th>Rule</th><th>Tool</th>"
+                "<th>Title</th><th>Issue</th><th>Suggestion</th></tr>"
+            )
+            for f in findings:
+                if not isinstance(f, dict):
+                    continue
+                parts.append(
+                    "<tr><td>{sev}</td><td>{rule}</td><td>{tool}</td>"
+                    "<td>{title}</td><td>{msg}</td><td>{sug}</td></tr>".format(
+                        sev=html.escape(str(f.get("severity", ""))),
+                        rule=html.escape(str(f.get("rule_id", ""))),
+                        tool=html.escape(str(f.get("tool", ""))),
+                        title=html.escape(str(f.get("title", ""))),
+                        msg=html.escape(str(f.get("message", ""))),
+                        sug=html.escape(str(f.get("suggestion", ""))),
+                    )
+                )
+            parts.append("</table>")
+        waived = feedback.get("waived") or []
+        if waived:
+            parts.append("<h4>Waived rules</h4><ul>")
+            for w in waived:
+                if not isinstance(w, dict):
+                    continue
+                parts.append(
+                    "<li>{rule}: {reason}</li>".format(
+                        rule=html.escape(str(w.get("rule_id", ""))),
+                        reason=html.escape(str(w.get("reason", ""))),
+                    )
+                )
+            parts.append("</ul>")
+        parts.append("</div>")
+        return "".join(parts)
+
+
+def _safe_int(value) -> int:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return 0
+
+
+def _read_text(path: str) -> str:
+    """Read a text file (the style guide). Raises on an unreadable path."""
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            return f.read()
+    except OSError as e:
+        raise ValueError(
+            f"mcp_style_readability: could not read style_guide {path!r}: {e}"
+        ) from e

--- a/evalbench/scorers/mcp_tool_metrics.py
+++ b/evalbench/scorers/mcp_tool_metrics.py
@@ -1,0 +1,120 @@
+"""Deterministic metrics scorer for an MCP endpoint's tool listing.
+
+This is the *metrics* half of the MCP readability check. Unlike the LLM style
+judge, it computes purely deterministic, model-independent numbers over the tools
+returned by ``McpToolsGenerator``:
+
+  - ``total_tools``: the number of tools exposed by the endpoint.
+  - ``estimated_tokens``: a rough token footprint of the tool definitions,
+    approximated as ``len(JSON(tool)) / 4`` summed across tools.
+  - ``token_budget_used_percent``: that estimate as a percentage of the
+    configured ``token_budget`` (``None`` when no positive budget is set).
+
+It is kept separate from the LLM judge so the metric logic stays deterministic
+and independently testable. It is a plug-and-play mcp_readability scorer (see
+``scorers.mcp_readability_scoring``): the orchestrator calls :meth:`run` with the
+per-endpoint context. Its binary summary metric is "within token budget".
+"""
+
+from collections.abc import Sequence
+import json
+from typing import Any
+
+from scorers.mcp_readability_scoring import EndpointContext, ScoreContribution
+
+# Rough chars-per-token heuristic for estimating a tool's token footprint.
+_CHARS_PER_TOKEN = 4
+
+
+class McpToolMetricsScorer:
+    """Computes deterministic size/cost metrics for a list of MCP tools."""
+
+    # Result-row columns this scorer contributes.
+    COLUMNS = [
+        "mcp_readability_total_tools",
+        "mcp_readability_estimated_tokens",
+        "mcp_readability_token_budget_used_percent",
+    ]
+
+    def __init__(self, config: dict | None = None, global_models=None):
+        # Accept global_models for signature parity with the other scorers even
+        # though this deterministic scorer needs no model.
+        self.name = "mcp_tool_metrics"
+        config = config or {}
+        # Token budget from this scorer's own config block; a per-call value
+        # passed to score() still wins.
+        self.token_budget = config.get("token_budget")
+
+    def run(self, context: EndpointContext) -> ScoreContribution:
+        """Evaluate one endpoint: compute metrics, pass iff within budget.
+
+        An endpoint may override the configured budget with its own
+        ``token_budget`` field.
+        """
+        budget = context.endpoint.get("token_budget", self.token_budget)
+        metrics = self.score(context.tools, budget)
+        used = metrics["token_budget_used_percent"]
+        # No positive budget configured -> nothing to exceed -> pass.
+        within_budget = used is None or used <= 100.0
+        return ScoreContribution(
+            row_fields={
+                "mcp_readability_total_tools": metrics["total_tools"],
+                "mcp_readability_estimated_tokens": metrics["estimated_tokens"],
+                "mcp_readability_token_budget_used_percent": used or 0.0,
+            },
+            score=100 if within_budget else 0,
+            logs=(
+                f"total_tools={metrics['total_tools']}, "
+                f"estimated_tokens={metrics['estimated_tokens']}, "
+                f"token_budget_used_percent={used}"
+            ),
+        )
+
+    def score(
+        self, tools: Sequence[Any], token_budget: int | None = None
+    ) -> dict:
+        """Compute metrics over ``tools``.
+
+        Args:
+          tools: The endpoint's tools (``mcp.types.Tool`` objects or plain
+            dicts in the raw ``tools/list`` shape).
+          token_budget: Overrides the budget from config when provided.
+
+        Returns:
+          ``{"total_tools", "estimated_tokens", "token_budget_used_percent"}``.
+          ``token_budget_used_percent`` is ``None`` when no positive budget is
+          configured.
+        """
+        budget = token_budget if token_budget is not None else self.token_budget
+
+        total_tools = len(tools)
+        total_chars = sum(len(self._to_json(tool)) for tool in tools)
+        estimated_tokens = round(total_chars / _CHARS_PER_TOKEN)
+
+        if budget and budget > 0:
+            used_percent = round(estimated_tokens / budget * 100, 2)
+        else:
+            used_percent = None
+
+        return {
+            "total_tools": total_tools,
+            "estimated_tokens": estimated_tokens,
+            "token_budget_used_percent": used_percent,
+        }
+
+    @staticmethod
+    def _to_json(tool: Any) -> str:
+        """Serialize a tool to JSON for the size estimate.
+
+        Handles both ``mcp.types.Tool`` (a pydantic model) and plain dicts.
+        ``by_alias`` keeps the wire field names (e.g. ``inputSchema``) and
+        ``exclude_none`` drops unset optionals, so the estimate reflects what an
+        endpoint actually puts on the wire.
+        """
+        model_dump_json = getattr(tool, "model_dump_json", None)
+        if callable(model_dump_json):
+            try:
+                return model_dump_json(by_alias=True, exclude_none=True)
+            except TypeError:  # older/non-standard pydantic signatures
+                return model_dump_json()
+        return json.dumps(tool, default=str, sort_keys=True)

--- a/evalbench/test/mcp_readability_test.py
+++ b/evalbench/test/mcp_readability_test.py
@@ -1,0 +1,516 @@
+import json
+import os
+import sys
+import tempfile
+from unittest.mock import patch
+
+import pytest
+
+sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+# Repo root (two levels up from evalbench/evalbench/test/) so dataset paths
+# resolve regardless of the pytest working directory.
+_REPO_ROOT = os.path.dirname(
+    os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+)
+
+
+def _ds(rel):
+    return os.path.join(_REPO_ROOT, rel)
+
+
+from evaluator.mcp_readability import exceptions as exc_mod
+from evaluator.mcp_readability.orchestrator import (
+    ALLOWED_ENDPOINT_TYPES,
+    BASE_COLUMNS,
+    McpReadabilityOrchestrator,
+    _validate_endpoint_type,
+)
+from mcp import types as mcp_types
+from generators.models.mcp_tools import McpToolsGenerator, McpToolsError
+from generators.models.mcp_tool_formatter import format_tools_to_man_page
+from scorers.mcp_readability_scoring import EndpointContext
+from scorers.mcp_style_readability import McpStyleReadabilityScorer
+from scorers.mcp_tool_metrics import McpToolMetricsScorer
+
+
+# --------------------------------------------------------------------------
+# endpoint_type validation (fail-fast, no enum)
+# --------------------------------------------------------------------------
+def test_endpoint_type_validation():
+    # Case-insensitive, returns the canonical upper-case name.
+    assert _validate_endpoint_type("PROD") == "PROD"
+    assert _validate_endpoint_type("dev") == "DEV"
+    assert _validate_endpoint_type(" AutoPush ") == "AUTOPUSH"
+    assert set(ALLOWED_ENDPOINT_TYPES) == {"PROD", "AUTOPUSH", "STAGING", "DEV"}
+    # Unknown / missing values fail fast.
+    with pytest.raises(ValueError):
+        _validate_endpoint_type("bogus")
+    with pytest.raises(ValueError):
+        _validate_endpoint_type(None)
+
+
+# --------------------------------------------------------------------------
+# Exceptions matching (by product_name / endpoint_type)
+# --------------------------------------------------------------------------
+def test_exceptions_matching():
+    all_exc = [
+        {"product_name": "Cloud SQL", "rule_id": "R1", "reason": "x"},
+        {"endpoint_type": "AUTOPUSH", "rule_id": "R2", "reason": "y"},
+        {"rule_id": "R3", "reason": "global"},  # match-all
+        {"reason": "no rule id, ignored"},
+    ]
+    ep = {"product_name": "Cloud SQL", "endpoint_type": "PROD"}
+    matched = {e["rule_id"] for e in exc_mod.applicable_exceptions(ep, all_exc)}
+    assert matched == {"R1", "R3"}
+
+    ep2 = {"product_name": "Other", "endpoint_type": "AUTOPUSH"}
+    matched2 = {e["rule_id"] for e in exc_mod.applicable_exceptions(ep2, all_exc)}
+    assert matched2 == {"R2", "R3"}
+
+
+# --------------------------------------------------------------------------
+# Deterministic metrics scorer
+# --------------------------------------------------------------------------
+def test_metrics_scorer():
+    scorer = McpToolMetricsScorer()
+    tools = [
+        mcp_types.Tool(name="a", description="d", inputSchema={"type": "object"}),
+        mcp_types.Tool(name="b", description="d", inputSchema={"type": "object"}),
+    ]
+    m = scorer.score(tools, token_budget=0)
+    assert m["total_tools"] == 2
+    assert m["estimated_tokens"] > 0
+    assert m["token_budget_used_percent"] is None  # no positive budget
+    m2 = scorer.score(tools, token_budget=1000)
+    assert m2["token_budget_used_percent"] is not None
+
+
+def test_metrics_scorer_run_pass_and_fail():
+    """run(context) contributes metric columns; pass iff within token budget."""
+    tools = [
+        mcp_types.Tool(name="a", description="d", inputSchema={"type": "object"}),
+        mcp_types.Tool(name="b", description="d", inputSchema={"type": "object"}),
+    ]
+    ctx = EndpointContext(
+        product_name="p", endpoint={}, tools=tools, man_page="", exceptions=[]
+    )
+    within = McpToolMetricsScorer({"token_budget": 100000}).run(ctx)
+    assert within.row_fields["mcp_readability_total_tools"] == 2
+    assert within.score == 100  # comfortably within budget
+
+    over = McpToolMetricsScorer({"token_budget": 1}).run(ctx)
+    assert over.score == 0  # exceeds a 1-token budget
+
+    # No budget configured -> nothing to exceed -> pass.
+    assert McpToolMetricsScorer({}).run(ctx).score == 100
+
+    # An endpoint may override the configured budget.
+    ctx_override = EndpointContext(
+        product_name="p", endpoint={"token_budget": 1}, tools=tools,
+        man_page="", exceptions=[],
+    )
+    assert McpToolMetricsScorer({"token_budget": 100000}).run(ctx_override).score == 0
+
+
+# --------------------------------------------------------------------------
+# URL sanitization
+# --------------------------------------------------------------------------
+def test_sanitize_url():
+    s = McpToolsGenerator.sanitize_url
+    assert s("example.com") == "https://example.com/mcp"
+    assert s("https://x.com/mcp") == "https://x.com/mcp"
+    assert s("https://x.com/mcp/") == "https://x.com/mcp"
+    assert s("localhost:8000") == "http://localhost:8000/mcp"
+    assert s("https://x.com") == "https://x.com/mcp"
+
+
+# --------------------------------------------------------------------------
+# Formatter (man-page markup -> string)
+# --------------------------------------------------------------------------
+def test_formatter_renders_enum_default():
+    tool = mcp_types.Tool(
+        name="t",
+        description="d",
+        inputSchema={
+            "type": "object",
+            "properties": {
+                "mode": {
+                    "type": "string",
+                    "enum": ["a", "b"],
+                    "default": "a",
+                    "description": "the mode",
+                }
+            },
+            "required": ["mode"],
+        },
+    )
+    man_page = format_tools_to_man_page([tool])
+    assert isinstance(man_page, str)
+    assert "TOOL: t" in man_page
+    assert "enum:" in man_page and '"a"' in man_page
+    assert "default:" in man_page
+
+
+# --------------------------------------------------------------------------
+# Generator (file source)
+# --------------------------------------------------------------------------
+def test_generator_file_source():
+    gen = McpToolsGenerator({})
+    endpoint = {
+        "tools_source": {
+            "type": "file",
+            "path": _ds("datasets/mcp_readability/sample_tools.json"),
+        }
+    }
+    tools, man_page = gen.fetch_tools(endpoint)
+    assert isinstance(man_page, str)
+    assert all(isinstance(t, mcp_types.Tool) for t in tools)
+    assert {t.name for t in tools} == {"list_datasets", "get_job_state"}
+    assert "TOOL: list_datasets" in man_page
+
+
+def test_generator_missing_file_raises():
+    gen = McpToolsGenerator({})
+    with pytest.raises(McpToolsError):
+        gen.fetch_tools({"tools_source": {"type": "file", "path": "nope.json"}})
+
+
+# --------------------------------------------------------------------------
+# Scorer parsing / html / run (no live LLM call)
+# --------------------------------------------------------------------------
+def test_scorer_parse_and_html():
+    raw = """```json
+    {"readability_score": 75, "findings": [
+       {"severity": "P0", "rule_id": "P0-X", "tool": "t", "title": "Bad name", "message": "m", "suggestion": "s"},
+       {"severity": "P2", "rule_id": "P2-Y", "tool": "t", "message": "m", "suggestion": "s"}
+     ], "waived": [], "summary": "ok"}
+    ```"""
+    # Build a scorer without invoking the LLM constructor path.
+    scorer = McpStyleReadabilityScorer.__new__(McpStyleReadabilityScorer)
+    fb = scorer._parse(raw)
+    assert fb["p0_issues"] == 1
+    assert fb["p2_issues"] == 1
+    assert fb["readability_score"] == 75
+    # title flows through the parser unchanged.
+    assert fb["findings"][0]["title"] == "Bad name"
+    html = McpStyleReadabilityScorer.to_html(fb)
+    assert "<table" in html and "P0-X" in html
+    # title is rendered as its own column.
+    assert "<th>Title</th>" in html and "Bad name" in html
+
+
+def test_scorer_counts_are_authoritative_from_findings():
+    """A severity with zero findings must stay 0 even if the model over-reports.
+
+    Regression: the old `_count(sev) or _safe_int(...)` fell back to the model's
+    self-reported integer whenever a severity's true count was 0.
+    """
+    raw = json.dumps(
+        {
+            "readability_score": 90,
+            # No P0 findings, but the model wrongly claims 3.
+            "p0_issues": 3,
+            "findings": [
+                {"severity": "P1", "rule_id": "P1-A", "tool": "t",
+                 "message": "m", "suggestion": "s"},
+            ],
+            "summary": "ok",
+        }
+    )
+    scorer = McpStyleReadabilityScorer.__new__(McpStyleReadabilityScorer)
+    fb = scorer._parse(raw)
+    assert fb["p0_issues"] == 0  # derived from findings, not the bogus 3
+    assert fb["p1_issues"] == 1
+
+    # When there are NO findings at all, fall back to the reported integers.
+    raw2 = json.dumps({"readability_score": 50, "p0_issues": 2, "findings": []})
+    fb2 = scorer._parse(raw2)
+    assert fb2["p0_issues"] == 2
+
+
+def test_scorer_single_pass():
+    """evaluate() runs a single review pass and returns normalized feedback."""
+
+    class _OneLLM:
+        def __init__(self):
+            self.calls = 0
+
+        def generate(self, prompt):
+            self.calls += 1
+            return json.dumps({"readability_score": 90, "findings": [], "summary": "ok"})
+
+    scorer = McpStyleReadabilityScorer.__new__(McpStyleReadabilityScorer)
+    scorer.model = _OneLLM()
+    fb = scorer.evaluate(tools_markup="x", style_guide="g", product_name="p")
+    assert scorer.model.calls == 1
+    assert fb["readability_score"] == 90
+
+
+def test_readability_scorer_run():
+    """run(context) contributes P0/P1/P2 + score columns; pass iff no P0."""
+    scorer = McpStyleReadabilityScorer.__new__(McpStyleReadabilityScorer)
+    scorer.name = "mcp_style_readability"
+    scorer.style_guide = "guide"
+    scorer.model = _FakeLLM()  # one P1 finding, no P0
+    ctx = EndpointContext(
+        product_name="p", endpoint={}, tools=[], man_page="mp", exceptions=[]
+    )
+    contrib = scorer.run(ctx)
+    assert contrib.row_fields["mcp_readability_p1_issues"] == 1
+    assert contrib.row_fields["mcp_readability_score"] == 80
+    assert contrib.score == 100  # no P0 -> pass
+
+
+def test_readability_scorer_requires_style_guide():
+    """The judge owns its config: model_config and style_guide are required."""
+    with pytest.raises(ValueError):
+        McpStyleReadabilityScorer({"model_config": "x"}, _global_models())
+    with pytest.raises(ValueError):
+        McpStyleReadabilityScorer({"style_guide": "y"}, _global_models())
+
+
+# --------------------------------------------------------------------------
+# End-to-end orchestrator with stubbed LLM
+# --------------------------------------------------------------------------
+class _FakeLLM:
+    def generate(self, prompt):
+        return json.dumps(
+            {
+                "readability_score": 80,
+                "findings": [
+                    {"severity": "P1", "rule_id": "P1-A", "tool": "list_datasets",
+                     "message": "m", "suggestion": "s"},
+                ],
+                "waived": [{"rule_id": "use-enums", "reason": "r"}],
+                "summary": "fine",
+            }
+        )
+
+
+def _global_models():
+    import threading
+
+    return {"lock": threading.Lock(), "registered_models": {}}
+
+
+def _write_endpoints(path, product_name, source):
+    import yaml
+
+    with open(path, "w") as f:
+        yaml.safe_dump(
+            {
+                "endpoints": [
+                    {
+                        "product_name": product_name,
+                        "endpoint_type": "PROD",
+                        "tools_source": source,
+                    }
+                ]
+            },
+            f,
+        )
+
+
+def _base_config(ep_path, output_dir, token_budget=25000):
+    return {
+        "orchestrator": "mcp_readability",
+        "endpoints_config": ep_path,
+        "exceptions_config": _ds("datasets/mcp_readability/exceptions.yaml"),
+        "tools_generator_config": _ds(
+            "datasets/mcp_readability/tools_generator.yaml"
+        ),
+        "endpoint_types": [],
+        "scorers": {
+            "mcp_tool_metrics": {"token_budget": token_budget},
+            "mcp_style_readability": {
+                "model_config": "unused",
+                "style_guide": _ds("datasets/mcp_readability/style_guide.md"),
+            },
+        },
+        "runners": {"endpoint_runners": 2},
+        "reporting": {"csv": {"output_directory": output_dir}},
+    }
+
+
+def test_orchestrator_end_to_end():
+    with patch(
+        "scorers.mcp_style_readability.get_generator", return_value=_FakeLLM()
+    ):
+        from evaluator import get_orchestrator
+
+        # Use the offline file source so the test stays deterministic and
+        # independent of the production endpoint list.
+        with tempfile.TemporaryDirectory() as d:
+            ep_path = os.path.join(d, "endpoints.yaml")
+            _write_endpoints(
+                ep_path,
+                "Sample",
+                {
+                    "type": "file",
+                    "path": _ds("datasets/mcp_readability/sample_tools.json"),
+                },
+            )
+            orch = get_orchestrator(_base_config(ep_path, d), [], {})
+            orch.evaluate([])
+            # process() returns the standard tuple: full readability rows in
+            # results_tf and one score row per (endpoint, scorer) in scores_tf.
+            job_id, _, results_tf, scores_tf, multi_tf = orch.process()
+            assert multi_tf is None
+            with open(results_tf) as f:
+                rows = json.load(f)
+            # Row schema is base identity columns + every scorer's columns.
+            assert set(rows[0].keys()) == set(orch.columns)
+            row = rows[0]
+            assert row["mcp_readability_endpoint_type"] == "PROD"
+            assert int(row["mcp_readability_total_tools"]) == 2
+            assert int(row["mcp_readability_p1_issues"]) == 1
+            assert int(row["mcp_readability_score"]) == 80
+            assert row["job_id"] == job_id
+
+            # scores_tf: one row per (endpoint, scorer).
+            with open(scores_tf) as f:
+                scores = json.load(f)
+            assert len(scores) == 2 * len(rows)
+            by_comp = {s["comparator"]: s for s in scores}
+            assert set(by_comp) == {"mcp_tool_metrics", "mcp_style_readability"}
+            # readability: no P0 -> pass; metrics: within budget -> pass.
+            assert by_comp["mcp_style_readability"]["score"] == 100
+            assert by_comp["mcp_tool_metrics"]["score"] == 100
+            assert (
+                by_comp["mcp_style_readability"]["id"]
+                == row["mcp_readability_product_name"]
+            )
+            assert by_comp["mcp_style_readability"]["comparison_error"] is None
+
+
+def test_orchestrator_fetch_error_aborts_run():
+    """Fail-fast: a fetch failure propagates and aborts the run (nothing stored).
+
+    There is no per-endpoint status; the error surfaces to the caller (and the
+    run log) instead of being recorded as a row.
+    """
+    with patch(
+        "scorers.mcp_style_readability.get_generator", return_value=_FakeLLM()
+    ):
+        from evaluator import get_orchestrator
+
+        with tempfile.TemporaryDirectory() as d:
+            ep_path = os.path.join(d, "endpoints.yaml")
+            _write_endpoints(
+                ep_path,
+                "Bad",
+                {"type": "file", "path": os.path.join(d, "missing.json")},
+            )
+            orch = get_orchestrator(_base_config(ep_path, d), [], {})
+            with pytest.raises(McpToolsError):
+                orch.evaluate([])
+
+
+def test_unknown_scorer_raises():
+    """An unregistered scorer name in the run config fails fast at construction."""
+    from evaluator import get_orchestrator
+
+    with tempfile.TemporaryDirectory() as d:
+        ep_path = os.path.join(d, "endpoints.yaml")
+        _write_endpoints(
+            ep_path,
+            "Sample",
+            {"type": "file", "path": _ds("datasets/mcp_readability/sample_tools.json")},
+        )
+        config = _base_config(ep_path, d)
+        config["scorers"] = {"bogus_scorer": {}}
+        with pytest.raises(ValueError):
+            get_orchestrator(config, [], {})
+
+
+def test_missing_scorers_block_raises():
+    from evaluator import get_orchestrator
+
+    with tempfile.TemporaryDirectory() as d:
+        ep_path = os.path.join(d, "endpoints.yaml")
+        _write_endpoints(
+            ep_path,
+            "Sample",
+            {"type": "file", "path": _ds("datasets/mcp_readability/sample_tools.json")},
+        )
+        config = _base_config(ep_path, d)
+        del config["scorers"]
+        with pytest.raises(ValueError):
+            get_orchestrator(config, [], {})
+
+
+def test_endpoint_type_filter():
+    """endpoint_types filter matches case-insensitively; unknowns fail fast."""
+    orch = McpReadabilityOrchestrator.__new__(McpReadabilityOrchestrator)
+    # Built the way __init__ builds it: validated canonical upper-case names.
+    orch.endpoint_type_filter = {_validate_endpoint_type("prod")}
+    orch.endpoints = [
+        {"product_name": "A", "endpoint_type": "PROD"},
+        {"product_name": "B", "endpoint_type": "DEV"},
+    ]
+    kept = orch._filtered_endpoints()
+    assert [e["product_name"] for e in kept] == ["A"]
+
+
+# --------------------------------------------------------------------------
+# Integration with the shared evalbench.py report path (no changes needed there)
+# --------------------------------------------------------------------------
+def test_datasetless_config_loads_empty_dataset():
+    """A run config with no dataset_config loads an empty dataset (no KeyError).
+
+    This is what lets evalbench.py's unchanged
+    `load_dataset_from_json(session["dataset_config"], config)` work for the
+    datasetless mcp_readability orchestrator.
+    """
+    from util.config import set_session_configs
+    from dataset.dataset import load_dataset_from_json, flatten_dataset
+
+    session = {}
+    set_session_configs(session, {"orchestrator": "mcp_readability"})
+    assert session["dataset_config"] is None
+    dataset = load_dataset_from_json(session["dataset_config"], {})
+    assert flatten_dataset(dataset) == []
+
+
+def test_scores_flow_through_shared_analyzer():
+    """The emitted score rows are consumable by the shared analyzer as-is.
+
+    Proves evalbench.py's standard branch (`analyzer.analyze_result`) produces a
+    correct per-scorer pass rate from mcp_readability's scores_tf without any
+    mcp-specific handling. Each scorer key under `scorers:` aggregates its own
+    `comparator` rows.
+    """
+    import reporting.analyzer as analyzer
+
+    def _score(id_, comparator, score):
+        return {
+            "id": id_,
+            "comparator": comparator,
+            "score": score,
+            "comparison_logs": "",
+            "comparison_error": None,
+        }
+
+    # Endpoint A: readability pass (no P0), within budget.
+    # Endpoint B: readability fail (P0), within budget.
+    scores = [
+        _score("A", "mcp_style_readability", 100),
+        _score("A", "mcp_tool_metrics", 100),
+        _score("B", "mcp_style_readability", 0),
+        _score("B", "mcp_tool_metrics", 100),
+    ]
+    config = {"scorers": {"mcp_style_readability": None, "mcp_tool_metrics": None}}
+
+    _, summary_df = analyzer.analyze_result(
+        scores, config, num_prompts=0, num_trials=1
+    )
+    readability = summary_df[
+        summary_df["metric_name"] == "mcp_style_readability"
+    ].iloc[0]
+    assert int(readability["correct_results_count"]) == 1  # only A is P0-clean
+    assert int(readability["total_results_count"]) == 2
+
+    metrics = summary_df[summary_df["metric_name"] == "mcp_tool_metrics"].iloc[0]
+    assert int(metrics["correct_results_count"]) == 2  # both within budget
+    assert int(metrics["total_results_count"]) == 2

--- a/evalbench/test/mcp_tool_metrics_test.py
+++ b/evalbench/test/mcp_tool_metrics_test.py
@@ -1,0 +1,99 @@
+"""Unit tests for the deterministic MCP tool metrics scorer."""
+
+import json
+import unittest
+
+from mcp import types as mcp_types
+
+from scorers.mcp_tool_metrics import McpToolMetricsScorer
+
+
+def _tool(name, description, schema=None):
+    return mcp_types.Tool(
+        name=name, description=description, inputSchema=schema or {"type": "object"}
+    )
+
+
+class McpToolMetricsScorerTest(unittest.TestCase):
+
+    def setUp(self):
+        self.scorer = McpToolMetricsScorer()
+
+    # ---- total_tools --------------------------------------------------
+    def test_total_tools_counts_entries(self):
+        tools = [_tool("a", "A."), _tool("b", "B."), _tool("c", "C.")]
+        self.assertEqual(self.scorer.score(tools)["total_tools"], 3)
+
+    def test_empty_tools(self):
+        result = self.scorer.score([])
+        self.assertEqual(result["total_tools"], 0)
+        self.assertEqual(result["estimated_tokens"], 0)
+        self.assertIsNone(result["token_budget_used_percent"])
+
+    # ---- estimated_tokens (dict input -> exact, computable) -----------
+    def test_estimated_tokens_matches_json_quarter_for_dicts(self):
+        tools = [
+            {"name": "x", "description": "hello", "inputSchema": {"type": "object"}},
+            {"name": "y", "description": "world", "inputSchema": {"type": "string"}},
+        ]
+        expected_chars = sum(
+            len(json.dumps(t, default=str, sort_keys=True)) for t in tools
+        )
+        result = self.scorer.score(tools)
+        self.assertEqual(result["estimated_tokens"], round(expected_chars / 4))
+
+    def test_estimated_tokens_positive_for_real_tools(self):
+        result = self.scorer.score([_tool("a", "A tool that does things.")])
+        self.assertGreater(result["estimated_tokens"], 0)
+
+    def test_more_tools_means_more_tokens(self):
+        one = self.scorer.score([_tool("a", "A.")])["estimated_tokens"]
+        two = self.scorer.score([_tool("a", "A."), _tool("b", "B.")])[
+            "estimated_tokens"
+        ]
+        self.assertGreater(two, one)
+
+    # ---- token_budget_used_percent -----------------------------------
+    def test_budget_percent_computed(self):
+        tools = [{"name": "x", "description": "d"}]
+        est = self.scorer.score(tools)["estimated_tokens"]
+        budget = 1000
+        result = self.scorer.score(tools, token_budget=budget)
+        self.assertEqual(
+            result["token_budget_used_percent"], round(est / budget * 100, 2)
+        )
+
+    def test_no_budget_yields_none_percent(self):
+        result = self.scorer.score([_tool("a", "A.")])
+        self.assertIsNone(result["token_budget_used_percent"])
+
+    def test_zero_budget_yields_none_percent(self):
+        result = self.scorer.score([_tool("a", "A.")], token_budget=0)
+        self.assertIsNone(result["token_budget_used_percent"])
+
+    def test_empty_tools_with_budget_is_zero_percent(self):
+        result = self.scorer.score([], token_budget=1000)
+        self.assertEqual(result["token_budget_used_percent"], 0.0)
+
+    # ---- config vs per-call budget -----------------------------------
+    def test_config_budget_used_when_no_override(self):
+        scorer = McpToolMetricsScorer({"token_budget": 1000})
+        tools = [{"name": "x", "description": "d"}]
+        est = scorer.score(tools)["estimated_tokens"]
+        self.assertEqual(
+            scorer.score(tools)["token_budget_used_percent"],
+            round(est / 1000 * 100, 2),
+        )
+
+    def test_per_call_budget_overrides_config(self):
+        scorer = McpToolMetricsScorer({"token_budget": 1000})
+        tools = [{"name": "x", "description": "d"}]
+        est = scorer.score(tools)["estimated_tokens"]
+        result = scorer.score(tools, token_budget=2000)
+        self.assertEqual(
+            result["token_budget_used_percent"], round(est / 2000 * 100, 2)
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/evalbench/util/config.py
+++ b/evalbench/util/config.py
@@ -189,6 +189,11 @@ def get_google3_relative_path(value, session_id):
 
 def set_session_configs(session, experiment_config: dict):
     session["config"] = experiment_config
+    # Always set dataset_config so callers can subscript it unconditionally. Some
+    # orchestrators (e.g. mcp_readability) drive their work from the run config
+    # itself and have no prompt dataset, in which case this stays None and
+    # load_dataset_from_json returns {}.
+    session["dataset_config"] = None
     if "dataset_config" in experiment_config and experiment_config["dataset_config"]:
         # Handle both flat string paths and nested dicts (e.g. BIRD configs)
         dc = experiment_config["dataset_config"]


### PR DESCRIPTION
## Summary

The evaluation half of the MCP-readability work, running on top of the `mcp_tools`
generator from #469. Given a set of MCP endpoints, it fetches each endpoint's
tools (rendered as a man page) and scores them against the Data Cloud MCP tool
style guide, emitting one result row per endpoint through the shared EvalBench
reporters.

- **`McpReadabilityOrchestrator`** (`orchestrator: mcp_readability`) — for each
  endpoint: fetch tools via the generator, gather applicable waivers, run every
  scorer declared in the run config, and merge their columns into a single result
  row. The orchestrator is **scorer-agnostic**: it iterates the registered
  scorers named under the run config's `scorers:` block (via `SCORER_REGISTRY`)
  and invokes each — adding a new scorer (e.g. conformance) needs only a registry
  entry and a config block, no orchestrator changes.
- **`mcp_readability_scoring.py`** — the plug-and-play scorer contract:
  `EndpointContext` + the scorer registry the orchestrator drives.
- **`McpToolMetricsScorer`** (`mcp_tool_metrics`) — deterministic tool count /
  estimated tokens / token-budget usage. Owns its own `token_budget` config.
- **`McpStyleReadabilityScorer`** (`mcp_style_readability`) — LLM judge scoring
  the man page vs the style guide (P0/P1/P2 findings, readability score, waived
  rules). Owns its own `model_config` + `style_guide` config.
- **exceptions helper** — per-endpoint rule waivers, matched by
  product_name / endpoint_type against style-guide `{#tag}` rule ids.
- **`dataset.py` / `evalbench.py` plumbing** — `dataset_config` is optional, and
  orchestrators may emit results without NL2SQL scores (None-guarded reporter
  writes); logs an info message when no dataset path is provided.

Run config uses a plug-and-play `scorers:` block; each key names a registered
scorer and carries that scorer's own config:

```yaml
scorers:
  mcp_tool_metrics:
    token_budget: 200000
  mcp_style_readability:
    model_config: datasets/model_configs/gemini_3.1_pro_model.yaml
    style_guide: datasets/mcp_readability/style_guide.md
```

## Testing

- `pytest evalbench/test/mcp_readability_test.py evalbench/test/mcp_tool_metrics_test.py` — **31 passing**.
- Covers exceptions matching, deterministic metrics, the LLM-judge parsing, and
  an offline end-to-end orchestrator run (file source + stubbed LLM) asserting
  the result schema.
- **Local e2e run** against the sample config exercising all three
  `tools_source` types in one job (file / http / stdio): 3/3 endpoints checked,
  0 errors — `mcp_tool_metrics` 3/3, `mcp_style_readability` 2/3.
