### PR TITLE
Make plugin installation synchronous to avoid timing issues during eval

### DIFF
--- a/evalbench/generators/models/claude_code.py
+++ b/evalbench/generators/models/claude_code.py
@@ -260,6 +260,7 @@ class ClaudeCodeGenerator(AgentCliGenerator):
                     marketplace_dir,
                     plugin_name=mcp_config.get("plugin"),
                     plugin_config=mcp_config.get("config"),
+                    env=setup_env,
                 )
 
     def _translate_mcp_config(self, server_name: str, config: dict) -> dict:
@@ -359,7 +360,7 @@ class ClaudeCodeGenerator(AgentCliGenerator):
             marketplace_dir = self._clone_marketplace_repo(
                 url, marketplaces_dir, setup_env)
             if marketplace_dir:
-                self._register_marketplace_plugin(marketplace_dir)
+                self._register_marketplace_plugin(marketplace_dir, env=setup_env)
 
     def _setup_skills_from_dir(self, skills_dir_path: str):
         """Registers a local plugin marketplace directory in settings.json."""
@@ -400,7 +401,7 @@ class ClaudeCodeGenerator(AgentCliGenerator):
 
     def _register_marketplace_plugin(
         self, marketplace_dir: str, plugin_name: str | None = None,
-        plugin_config: dict | None = None,
+        plugin_config: dict | None = None, env: dict | None = None,
     ):
         """Reads marketplace.json and updates settings.json so Claude Code
         auto-loads a marketplace plugin at startup.
@@ -478,6 +479,37 @@ class ClaudeCodeGenerator(AgentCliGenerator):
             f"Registered plugin '{plugin_id}' "
             f"(directory source: {marketplace_dir})"
             + (f" with userConfig {list(plugin_config)}" if plugin_config else ""))
+
+        self._install_plugin(plugin_id, env)
+
+    def _install_plugin(self, plugin_id: str, env: dict | None = None):
+        """Forces synchronous installation of a registered plugin."""
+        if not env:
+            env = os.environ.copy()
+            env.update(self.env)
+
+        cli = self.claude_code_version
+        if cli.startswith("@") or "/" in cli:
+            cli_base_cmd = ["npm", "exec", "--yes", cli, "--"]
+        else:
+            cli_base_cmd = [cli]
+
+        # Run a dummy command to force initialization of projects/sessions
+        # and plugin manager state. Ignore the failure (it will fail with
+        # auth error if credentials are not ready, which is expected).
+        init_command = cli_base_cmd + ["-p", "initialize_session"]
+        logging.info(f"Initializing Claude Code state: {' '.join(init_command)}")
+        self._execute_cli_command(init_command, env=env)
+
+        # Now run the actual install command
+        install_command = cli_base_cmd + ["plugins", "install", plugin_id]
+        logging.info(f"Synchronously installing plugin: {' '.join(install_command)}")
+
+        result = self._execute_cli_command(install_command, env=env)
+        if result.returncode != 0:
+            logging.error(f"Failed to install plugin '{plugin_id}': {result.stderr}")
+        else:
+            logging.info(f"Successfully installed plugin '{plugin_id}'")
 
     def generate_internal(self, cli_cmd):
         if not isinstance(cli_cmd, CLICommand):

--- a/evalbench/test/claude_code_test.py
+++ b/evalbench/test/claude_code_test.py
@@ -1,0 +1,90 @@
+import os
+import sys
+from unittest.mock import MagicMock, patch, ANY
+
+# Add parent directory to path so we can import generators
+sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from generators.models.claude_code import ClaudeCodeGenerator
+
+
+@patch('generators.models.claude_code.os.makedirs')
+@patch('generators.models.claude_code.shutil.copy2')
+@patch('generators.models.claude_code.os.path.isdir', return_value=True)
+def test_setup_triggers_plugin_install(mock_isdir, mock_copy, mock_makedirs, monkeypatch):
+    monkeypatch.setenv("HOME", "/fake/real_home")
+
+    config = {
+        "model": "claude-opus-4-6",
+        "setup": {
+            "skills": [
+                {
+                    "action": "install_from_repo",
+                    "url": "https://github.com/user/repo.git"
+                }
+            ]
+        }
+    }
+
+    # Custom side effect for open to handle different files
+    def mock_open_side_effect(filepath, mode='r', *args, **kwargs):
+        mock_file = MagicMock()
+        if "marketplace.json" in filepath:
+            mock_file.read.return_value = '{"name": "repo", "plugins": [{"name": "my-plugin"}]}'
+        elif "settings.json" in filepath:
+            mock_file.read.return_value = '{}'
+        else:
+            mock_file.read.return_value = '{}'
+
+        context_mock = MagicMock()
+        context_mock.__enter__.return_value = mock_file
+        return context_mock
+
+    # Custom side effect for os.path.exists
+    def mock_exists_side_effect(path):
+        if "marketplace.json" in path:
+            return True
+        if "settings.json" in path:
+            return True
+        return False
+
+    with (
+        patch('generators.models.claude_code.open', side_effect=mock_open_side_effect),
+        patch('generators.models.claude_code.os.path.exists', side_effect=mock_exists_side_effect),
+        patch.object(ClaudeCodeGenerator, '_clone_marketplace_repo', return_value="/fake/real_home/.claude/plugins/marketplaces/repo") as mock_clone,
+        patch.object(ClaudeCodeGenerator, '_install_plugin') as mock_install
+    ):
+        ClaudeCodeGenerator(config)
+
+        mock_clone.assert_called_once()
+        # Verify it called install with correct plugin ID and some env dict
+        mock_install.assert_called_once_with("my-plugin@repo", ANY)
+
+
+@patch('generators.models.claude_code.os.makedirs')
+@patch('generators.models.claude_code.open', create=True)
+def test_install_plugin_runs_init_and_install(mock_open, mock_makedirs, monkeypatch):
+    monkeypatch.setenv("HOME", "/fake/real_home")
+
+    # Mock open to return empty json for settings.json during init
+    mock_open.return_value.__enter__.return_value.read.return_value = '{}'
+
+    generator = ClaudeCodeGenerator({"model": "claude-opus-4-6"})
+
+    with patch.object(generator, '_execute_cli_command') as mock_execute:
+        mock_execute.return_value = MagicMock(returncode=0)
+
+        generator._install_plugin("my-plugin")
+
+        assert mock_execute.call_count == 2
+
+        # First call: init
+        first_call_args = mock_execute.call_args_list[0][0][0]
+        assert "initialize_session" in first_call_args
+        assert "-p" in first_call_args
+
+        # Second call: install
+        second_call_args = mock_execute.call_args_list[1][0][0]
+        assert "plugins" in second_call_args
+        assert "install" in second_call_args
+        assert "my-plugin" in second_call_args


### PR DESCRIPTION
# CL Description: Synchronous Plugin Installation for Claude Code Generator

## Problem
Claude Code evaluation runs (using `claude-opus-4-6`) recently started failing to activate registered skills (e.g. `dak:dataform-bigquery`), leading to a significant drop in evaluation scores. The agent was bypassing the skill and using standard `Bash` and `Write` tools instead.

---

## Root Cause Analysis & Proof of Issue

The root cause was identified as **Plugin Installation Latency** combined with asynchronous installation behavior in Claude Code.

### 1. Asynchronous Installation Timing
During setup, `claude_code.py` registers the plugin marketplace by writing to `.claude/settings.json`. However, Claude Code does not install the plugin immediately; it syncs and installs plugins asynchronously in the background.

In a fresh evaluation workspace, the first prompt is sent to the model almost immediately after registration. Server logs showed:
```
19:08:47.643 - Cloned plugin marketplace ...
19:08:47.644 - Registered plugin 'dak@...'
19:08:47.785 - Turn 1/1 - Prompt sent to Claude Code CLI
```
The prompt was sent only **141ms** after registration. Because the background installation takes ~1 minute, the plugin was not yet installed when the model received the prompt.

### 2. Evidence of Missing Skills (Initial Run)
As a result of the latency, `.claude/plugins/installed_plugins.json` was empty (`"plugins": {}`), and the model did not see the skills. 

We verified this by running a sanity check config (`ask_skills_claude_config.yaml`) prompting the model: *"List all skills available to you. Return their names."*

The raw output in `evals.csv` showed that the model only saw the 4 built-in skills:
```json
{
  "session_id": "177fd34c-48cb-4147-9711-32d162dabf6a",
  "response": "Here are the skills available to me:\n\n1. **update-config** — Configure Claude Code settings, hooks, permissions, and env vars\n2. **simplify** — Review changed code for reuse, quality, and efficiency\n3. **loop** — Run a prompt or slash command on a recurring interval\n4. **claude-api** — Build apps with the Claude API or Anthropic SDK"
}
```

### 3. Fresh vs. Warmed Workspace Proof
We proved it was a timing/workspace state issue by running the same command:
*   **In a fresh workspace (Automated Run):** Failed to use the skill because `installed_plugins.json` was empty at startup.
*   **In a reused/warmed workspace (Manual Run):** Succeeded because the background sync from the previous run had finished, populating `installed_plugins.json` before we ran the command.

---

## The Fix

To ensure skills are always available from the very first turn, we forced **synchronous plugin installation** during the setup phase:

1.  **Synchronous Install command:** Patched `claude_code.py` to run `npm exec ... -- plugins install <plugin_id>` during setup. This blocks generator initialization until the plugin is fully installed.
2.  **Initialization Hook:** We discovered that `plugins install` fails with `Plugin not found` on fresh workspaces if Claude Code has never been executed in that directory. We added a pre-install hook that runs a fast dummy command (`npm exec ... -- -p initialize_session`) to force Claude Code to initialize the `.claude/projects/` and `.claude/sessions/` directory structure.

---

## Verification & Proof of Fix

We re-ran the sanity check evaluation (`ask_skills_claude_config.yaml`) with the patch applied. 

### 1. Installation Logs
The server logs confirmed that the plugin was successfully installed synchronously during setup:
```
19:18:47.644 - Registered plugin 'dak@data-agent-kit-starter-pack-marketplace'
19:18:47.644 - Synchronously installing plugin: npm exec --yes @anthropic-ai/claude-code@2.1.85 -- plugins install dak@data-agent-kit-starter-pack-marketplace
19:18:51.329 - Successfully installed plugin 'dak@data-agent-kit-starter-pack-marketplace'
19:18:51.465 - Turn 1/1 - Prompt sent to Claude Code CLI
```

### 2. Available Skills (Patched Run)
The raw output in the new `evals.csv` confirmed that the model now successfully sees all 24 `dak` skills on the very first turn:
```json
{
  "session_id": "65217563-cac1-42ea-8c0f-7b74064abd5d",
  "response": "Here are all the skills available to me:\n\n1. update-config\n2. simplify\n3. loop\n4. claude-api\n5. dak:bigquery\n6. dak:bigquery-data-transfer-service\n7. dak:accidental-data-loss-prevention\n8. dak:building-data-apps\n9. dak:dataform-bigquery\n10. dak:dbt-bigquery\n11. dak:discovering-gcp-data-assets\n12. dak:gcloud-auth-verification\n13. dak:federate-lakehouse-catalog\n14. dak:gcp-composer-troubleshooting\n15. dak:gcp-data-pipelines\n16. dak:data-autocleaning\n17. dak:gcp-dataflow\n18. dak:gcp-managed-airflow-migrations\n19. dak:gcp-pipeline-orchestration\n20. dak:gcp-spark\n21. dak:gcp-pipeline-resource-provisioning\n22. dak:ml-best-practices\n23. dak:notebook-guidance\n24. dak:managing-python-dependencies"
}
```
