### PR TITLE
Fix UnboundLocalError in evaluator timeout handling

### DIFF
--- a/evalbench/evaluator/evaluator.py
+++ b/evalbench/evaluator/evaluator.py
@@ -2,6 +2,7 @@ import collections
 import concurrent.futures
 import datetime
 import logging
+import queue
 from queue import Queue
 import time
 from typing import Any, List
@@ -290,8 +291,6 @@ class Evaluator:
                         logging.error(f"Multi-trial scoring future error: {e}")
 
         if close_connections and db_queue:
-            import queue
-
             while True:
                 try:
                     db = db_queue.get(block=False)


### PR DESCRIPTION
Fix UnboundLocalError in evaluator timeout handling

Move `import queue` to the global scope in `evaluator.py`.

Previously, `import queue` was performed locally near the end of the `evaluate` method. This caused Python to treat `queue` as a local variable for the entire method. When a database timeout occurred and `except queue.Empty` was triggered, it attempted to access `queue.Empty` before the local `queue` variable was bound, resulting in an `UnboundLocalError`.

Moving the import to the global scope resolves this shadowing/binding issue.'
