### PR TITLE
feat(query_data_api): support api_endpoint override in model config

### DIFF
--- a/datasets/query_data_api/model_configs/querydata_config.yaml
+++ b/datasets/query_data_api/model_configs/querydata_config.yaml
@@ -3,6 +3,10 @@ project_id: "<YOUR_GCP_PROJECT_ID>"
 location: "<YOUR_GDA_LOCATION>"
 generator: "query_data_api"
 
+# Optional. Override the default production endpoint (leave unset for prod).
+# Example — sandbox: "autopush-geminidataanalytics.sandbox.googleapis.com"
+# api_endpoint: "<HOSTNAME>"
+
 # This context block directly maps to the gda.QueryDataContext protobuf definition
 context:
   datasource_references:

--- a/evalbench/generators/models/query_data_api.py
+++ b/evalbench/generators/models/query_data_api.py
@@ -2,6 +2,7 @@ from .generator import QueryGenerator
 import google.cloud.geminidataanalytics_v1beta as gda
 import logging
 from typing import Dict, Any
+from google.api_core.client_options import ClientOptions
 from google.api_core.exceptions import ResourceExhausted, ServiceUnavailable, DeadlineExceeded
 from util.rate_limit import ResourceExhaustedError
 
@@ -23,10 +24,15 @@ class QueryDataAPIGenerator(QueryGenerator):
         self.project_id = querygenerator_config.get("project_id")
         self.location = querygenerator_config.get("location", "global")
         self.context = querygenerator_config.get("context", {})
+        api_endpoint = querygenerator_config.get("api_endpoint")
 
-        # Initialize client
-        # Authenticated via ADC automatically
-        self.client = gda.DataChatServiceClient()
+        # Initialize client. Authenticated via ADC automatically. If
+        # `api_endpoint` is supplied in the config (eg. an autopush /
+        # sandbox host), override the default production endpoint.
+        client_options = (
+            ClientOptions(api_endpoint=api_endpoint) if api_endpoint else None
+        )
+        self.client = gda.DataChatServiceClient(client_options=client_options)
 
     def generate_internal(self, prompt: str) -> Dict[str, Any]:
         """


### PR DESCRIPTION
## Summary
- Adds an optional `api_endpoint` field to the `query_data_api` model config. When set, `QueryDataAPIGenerator` overrides the default production endpoint via `google.api_core.client_options.ClientOptions`.
- Unblocks testing against non-prod GDA hosts (autopush sandbox) while the ContextStore + QueryData integration is being rolled to production.
- Updates the sample `querydata_config.yaml` to document the new field.
