### PR TITLE
Add ADC support for onemcp+codex

### DIFF
--- a/docs/codex_cli_agent_testing.md
+++ b/docs/codex_cli_agent_testing.md
@@ -117,7 +117,7 @@ EvalBench's Codex CLI integration enables automated, multi-turn evaluation of ag
    export EVAL_GCP_PROJECT_ID=your_project_id
    export EVAL_GCP_PROJECT_REGION=us-central1
    ```
-6. **gcloud** (only if any MCP server uses `authProviderType: google_credentials` — the generator shells out to `gcloud auth print-access-token`)
+6. **gcloud** (only if any MCP server uses `authProviderType: google_credentials` — the generator shells out to `gcloud auth application-default print-access-token`; run `gcloud auth application-default login` first)
 
 ---
 
@@ -304,7 +304,7 @@ EvalBench accepts the **same MCP server config schema as Gemini CLI and Claude C
 |---|---|
 | `httpUrl` | → `url` (TOML, streamable HTTP server) |
 | `headers` | → `http_headers` (TOML inline table) |
-| `authProviderType: google_credentials` | → fetches a token via `gcloud auth print-access-token` and injects `Authorization: Bearer <token>` into `http_headers` |
+| `authProviderType: google_credentials` | → mints an **ADC** token (`gcloud auth application-default print-access-token`, falling back to `gcloud auth print-access-token`) and passes it to Codex via `bearer_token_env_var` (env var `EVALBENCH_GCLOUD_MCP_TOKEN`). The generator re-mints a fresh token before **every turn** (each `codex exec` re-reads the env var), so it doesn't expire mid-suite. `X-Goog-User-Project` stays a static `http_headers` entry. Google API MCP endpoints reject the plain user token on tool calls — see [Troubleshooting](#mcp-server-fails-with-401-unauthorized-real-cloud-sql-endpoint). |
 | `oauth.scopes` | (dropped — Codex doesn't use Gemini's OAuth delegation) |
 | `command` / `args` / `env` / `cwd` (stdio) | → passed through as-is into a `[mcp_servers.NAME]` stdio block |
 
@@ -569,10 +569,11 @@ json_flag: "--experimental-json"
 
 ### MCP server fails with `401 Unauthorized` (real Cloud SQL endpoint)
 
-The injected gcloud access token has insufficient scopes or your principal lacks IAM access. Make sure:
-- `gcloud auth application-default login` was run with `--scopes=https://www.googleapis.com/auth/cloud-platform`
-- Your account / service account has the required IAM roles (e.g., `roles/cloudsql.admin`)
-- `X-Goog-User-Project` header points at a project that has the Cloud SQL Admin API enabled
+The injected token is missing, expired, the **wrong kind**, or your principal lacks IAM access. Note Google API MCP endpoints leave `initialize`/`tools/list` unauthenticated but require a valid bearer token on the actual **tool call**, and they only accept an **ADC** token — the plain gcloud *user* token (`gcloud auth print-access-token`) is rejected. The generator now injects the ADC token (`gcloud auth application-default print-access-token`); make sure:
+- You ran **`gcloud auth application-default login`** (with `--scopes=https://www.googleapis.com/auth/cloud-platform`) — not just `gcloud auth login`.
+- Your account / service account has the required IAM roles (e.g., `roles/cloudsql.admin`).
+- `X-Goog-User-Project` header points at a project that has the Cloud SQL Admin API enabled.
+- Token expiry is handled automatically: the generator mints a fresh ADC token into `EVALBENCH_GCLOUD_MCP_TOKEN` before every turn and Codex reads it via `bearer_token_env_var`, so long suites don't hit stale-token 401s. (Requires a Codex build that supports `bearer_token_env_var`; if yours doesn't, the token won't be applied — fall back to a static `http_headers` `Authorization`.)
 
 ### `Invalid TOML` when Codex starts
 

--- a/evalbench/generators/models/codex_cli.py
+++ b/evalbench/generators/models/codex_cli.py
@@ -53,6 +53,10 @@ class CLICommand:
 class CodexCliGenerator(AgentCliGenerator):
     """Generator queries using OpenAI Codex CLI (`codex exec`)."""
 
+    # Env var Codex sources the Google MCP bearer token from
+    # (`bearer_token_env_var`); refreshed per turn in _run_codex_cli.
+    _GCLOUD_MCP_TOKEN_ENV = "EVALBENCH_GCLOUD_MCP_TOKEN"
+
     def __init__(self, querygenerator_config):
         super().__init__(querygenerator_config)
         self.name = "codex_cli"
@@ -524,30 +528,75 @@ class CodexCliGenerator(AgentCliGenerator):
 
         auth_provider = config.get("authProviderType")
         if auth_provider == "google_credentials" and "Authorization" not in headers:
+            # Supply the bearer token via `bearer_token_env_var` rather than a
+            # static header so it can be refreshed on every turn: each
+            # `codex exec` is a fresh process that re-reads the env var, and
+            # _run_codex_cli re-mints a fresh ADC token into it per turn -- so
+            # the token never expires mid-suite (Codex's closest equivalent to
+            # Claude Code's per-connection headersHelper). X-Goog-User-Project
+            # stays a static header.
+            out["bearer_token_env_var"] = self._GCLOUD_MCP_TOKEN_ENV
+            self._needs_gcloud_mcp_token = True
             token = self._fetch_gcloud_access_token()
             if token:
-                headers["Authorization"] = f"Bearer {token}"
+                self.env[self._GCLOUD_MCP_TOKEN_ENV] = token  # initial value
             else:
                 logging.warning(
-                    f"MCP server '{server_name}' requires google_credentials but "
-                    "failed to fetch access token via `gcloud auth print-access-token`."
+                    f"MCP server '{server_name}' requires google_credentials "
+                    "but failed to fetch an access token via gcloud."
                 )
         if headers:
             out["http_headers"] = headers
         return out
 
     def _fetch_gcloud_access_token(self) -> str:
-        try:
-            result = subprocess.run(
-                ["gcloud", "auth", "print-access-token"],
-                check=True,
-                capture_output=True,
-                text=True,
-            )
-            return result.stdout.strip()
-        except (subprocess.CalledProcessError, FileNotFoundError) as e:
-            logging.error(f"Failed to retrieve gcloud access token: {e}")
-            return ""
+        """Fetches a Google Cloud access token for MCP `google_credentials` auth.
+
+        Prefers Application Default Credentials (``gcloud auth
+        application-default print-access-token``) over the gcloud *user* token
+        (``gcloud auth print-access-token``). Google API MCP endpoints such as
+        Cloud SQL Managed (``sqladmin.googleapis.com/mcp``) reject the plain
+        user token on tool calls ("Request had invalid authentication
+        credentials") and only accept an ADC token; a rejected token makes the
+        tool call return 401 and auth fails. (See the Claude Code generator for
+        the full write-up -- the same MCP endpoints and token requirement apply
+        here.)
+
+        The token is fetched with the host environment (real HOME / gcloud
+        config), NOT the sandboxed fake HOME, so gcloud finds the developer's /
+        host's credentials. An explicit service-account or ADC file is honored
+        if one was configured.
+        """
+        token_env = os.environ.copy()
+        adc = self.env.get("GOOGLE_APPLICATION_CREDENTIALS")
+        if adc and os.path.exists(adc):
+            token_env["GOOGLE_APPLICATION_CREDENTIALS"] = adc
+        commands = [
+            ["gcloud", "auth", "application-default", "print-access-token"],
+            ["gcloud", "auth", "print-access-token"],
+        ]
+        for cmd in commands:
+            try:
+                result = subprocess.run(
+                    cmd, check=True, capture_output=True, text=True,
+                    env=token_env,
+                )
+                token = result.stdout.strip()
+                if token:
+                    logging.info(
+                        f"MCP google_credentials token via `{' '.join(cmd)}` "
+                        f"({len(token)} chars)"
+                    )
+                    return token
+            except (subprocess.CalledProcessError, FileNotFoundError) as e:
+                stderr = getattr(e, "stderr", "") or ""
+                logging.warning(
+                    f"`{' '.join(cmd)}` failed: {e}. {stderr.strip()}")
+        logging.error(
+            "Failed to fetch a Google Cloud access token via gcloud (tried ADC "
+            "and user credentials). Run `gcloud auth application-default login`."
+        )
+        return ""
 
     @staticmethod
     def _toml_key(key: str) -> str:
@@ -688,6 +737,14 @@ class CodexCliGenerator(AgentCliGenerator):
         env = os.environ.copy()
         env.update(self.env)
         env.update(cli_cmd.env)
+
+        # Refresh the Google MCP bearer token for this turn. Each `codex exec`
+        # is a fresh process that re-reads `bearer_token_env_var`, so minting a
+        # new ADC token here keeps it from expiring across a long suite.
+        if getattr(self, "_needs_gcloud_mcp_token", False):
+            token = self._fetch_gcloud_access_token()
+            if token:
+                env[self._GCLOUD_MCP_TOKEN_ENV] = token
 
         # Pin a specific npm version when the spec looks like an npm package.
         cli = cli_cmd.cli


### PR DESCRIPTION
### Codex (`evalbench/generators/models/codex_cli.py`)
- **Inject an ADC token** (same ADC-first + host-env fetch + stderr logging as Claude Code).
- **Per-turn refresh via `bearer_token_env_var`**: the token is passed through env var `EVALBENCH_GCLOUD_MCP_TOKEN` and re-minted before every `codex exec` (each turn is a fresh process), so it doesn't expire mid-suite. `X-Goog-User-Project` stays a static `http_headers` entry.