### PR TITLE
feat(dea): support pushing workspace environment files in dynamic workspace mode

### DIFF
--- a/datasets/dea-tools/example_run_config.yaml
+++ b/datasets/dea-tools/example_run_config.yaml
@@ -5,6 +5,7 @@ simulated_user_model_config: datasets/model_configs/gemini_2.5_pro_model.yaml
 dataset_config: datasets/dea-tools/dea-live-conversational.evalset.json
 env:
   SCENARIO_ID: "dea-live-conversational"
+  EVAL_DATAFORM_SETUP_ENV_FILES_DIR: "datasets/dea-tools/templates/default_workspace"
 scorers:
   binary_rubric_scorer:
     model_config: datasets/model_configs/gemini_2.5_pro_model.yaml

--- a/datasets/dea-tools/scripts/setup_dataform.sh
+++ b/datasets/dea-tools/scripts/setup_dataform.sh
@@ -13,11 +13,12 @@ REGION="${EVAL_GCP_PROJECT_REGION}"
 JOB_ID=$(basename "$SESSION_DIR")
 
 SCENARIO_ID="${SCENARIO_ID:-default}"
+ENV_FILES_DIR="${EVAL_DATAFORM_SETUP_ENV_FILES_DIR}"
 
 WORKSPACE_URI=$(PYTHONPATH=evalbench .venv/bin/python3 -c "
 from util.dataform_workspace import DataformWorkspaceManager
 manager = DataformWorkspaceManager('$PROJECT_ID', '$REGION')
-uri = manager.setup_workspace('$JOB_ID', '$SCENARIO_ID')
+uri = manager.setup_workspace('$JOB_ID', '$SCENARIO_ID', env_files_dir='$ENV_FILES_DIR')
 print(uri)
 ")
 

--- a/datasets/dea-tools/templates/default_workspace/example.txt
+++ b/datasets/dea-tools/templates/default_workspace/example.txt
@@ -1,0 +1,1 @@
+This is an example file injected by EvalBench.


### PR DESCRIPTION
### Description
Enable pushing workspace environment files by:
- adding an example directory `datasets/dea-tools/templates/default_workspace`
- update config and set up script for pushing env files
