### PR TITLE
feat(scorers): add non_final_output_tokens metric robust to answer-verbosity variance

### DIFF
--- a/datasets/claude-code-tools/claude-code-smoke.evalset.json
+++ b/datasets/claude-code-tools/claude-code-smoke.evalset.json
@@ -1,0 +1,18 @@
+{
+  "scenarios": [
+    {
+      "id": "cloud-sql-list-instances-01",
+      "starting_prompt": "list all Cloud SQL instances in project astana-evaluation",
+      "conversation_plan": "Ask the agent to list instances in project astana-evaluation. Once all instances are listed if nl2code exist get its state and validate its RUNNABLE",
+      "expected_trajectory": [
+        "cloud-sql__list_instances",
+        "cloud-sql__get_instance"
+      ],
+      "env": {
+        "GOOGLE_CLOUD_PROJECT": "astana-evaluation"
+      },
+      "kind": "tools",
+      "max_turns": 3
+    }
+  ]
+}

--- a/datasets/claude-code-tools/example_run_config.yaml
+++ b/datasets/claude-code-tools/example_run_config.yaml
@@ -39,6 +39,7 @@ scorers:
   token_consumption: {}
   tokens_processed: {}
   effective_billed_tokens: {}
+  non_final_output_tokens: {}
 
 ############################################################
 ### Reporting Related Configs

--- a/datasets/claude-code-tools/example_run_fake_config.yaml
+++ b/datasets/claude-code-tools/example_run_fake_config.yaml
@@ -26,6 +26,7 @@ scorers:
   token_consumption: {}
   tokens_processed: {}
   effective_billed_tokens: {}
+  non_final_output_tokens: {}
 
 ############################################################
 ### Reporting Related Configs

--- a/datasets/claude-code-tools/example_run_skills_config.yaml
+++ b/datasets/claude-code-tools/example_run_skills_config.yaml
@@ -30,6 +30,7 @@ scorers:
   token_consumption: {}
   tokens_processed: {}
   effective_billed_tokens: {}
+  non_final_output_tokens: {}
 
 ############################################################
 ### Reporting Related Configs

--- a/datasets/claude-code-tools/example_run_smoke_config.yaml
+++ b/datasets/claude-code-tools/example_run_smoke_config.yaml
@@ -1,32 +1,29 @@
 ############################################################
 ### Dataset / Eval Items
 ############################################################
-dataset_config: datasets/claude-code-tools/claude-code-skills.evalset.json
+# Single read-only scenario (list Cloud SQL instances) for a fast, cheap
+# smoke test of the token scorers -- in particular non_final_output_tokens,
+# which strips the high-variance rendered-answer text from output tokens.
+dataset_config: datasets/claude-code-tools/claude-code-smoke.evalset.json
 dataset_format: agent-format
 
 # Orchestrator Configuration
+# `agent` works for both Gemini CLI and Claude Code (alias of `geminicli`).
 orchestrator: agent
-model_config: datasets/model_configs/claude_code_mcp_repo_model.yaml
+model_config: datasets/model_configs/claude_code_model.yaml
 simulated_user_model_config: datasets/model_configs/gemini_2.5_pro_model.yaml
 
+# Concurrency: number of scenarios to run in parallel.
 runners:
   agent_runners: 1
 
 ############################################################
 ### Scorer Related Configs
 ############################################################
+# Only the deterministic token scorers -- no LLM-based scorers -- so this
+# runs fast and cheap while still exercising non_final_output_tokens.
 scorers:
-  skills_trajectory:
-    enforce_order: false
-  skills_best_practices:
-    model_config: datasets/model_configs/gemini_2.5_pro_model.yaml
-  goal_completion:
-    model_config: datasets/model_configs/gemini_2.5_pro_model.yaml
-  behavioral_metrics:
-    model_config: datasets/model_configs/gemini_2.5_pro_model.yaml
   turn_count: {}
-  end_to_end_latency: {}
-  tool_call_latency: {}
   token_consumption: {}
   tokens_processed: {}
   effective_billed_tokens: {}

--- a/datasets/model_configs/claude_code_model.yaml
+++ b/datasets/model_configs/claude_code_model.yaml
@@ -13,13 +13,11 @@ model: "claude-opus-4-6"
 
 # --- Auth Option 1: Vertex AI (GCP ADC, no API key) ---
 # Requires Claude models enabled in your GCP project via Model Garden.
-# use_vertex: true
-# vertex_project_id: "astana-evaluation"
-# vertex_region: "us-east5"
+use_vertex: true
+vertex_project_id: "astana-evaluation"
+vertex_region: "us-east5"
 
-use_vertex: false
 env:
-  ANTHROPIC_API_KEY: <API_KEY>
   GOOGLE_CLOUD_PROJECT: "astana-evaluation"
   GOOGLE_CLOUD_LOCATION: "us-central1"
 

--- a/docs/claude_code_agent_testing.md
+++ b/docs/claude_code_agent_testing.md
@@ -183,6 +183,7 @@ scorers:
   end_to_end_latency: {}
   tool_call_latency: {}
   token_consumption: {}
+  non_final_output_tokens: {}
 
 reporting:
   csv:
@@ -355,6 +356,7 @@ Quick reference:
 | `end_to_end_latency` | Deterministic | Total latency (model + tool execution) |
 | `tool_call_latency` | Deterministic | Sum of tool execution durations |
 | `token_consumption` | Deterministic | Total input + output tokens |
+| `non_final_output_tokens` | Deterministic | Output tokens spent on reasoning + tool-call orchestration, excluding the final rendered answer text. Robust to answer-verbosity variance for side-by-side efficiency comparison. |
 
 ---
 

--- a/docs/codex_cli_agent_testing.md
+++ b/docs/codex_cli_agent_testing.md
@@ -187,6 +187,7 @@ scorers:
   end_to_end_latency: {}
   tool_call_latency: {}
   token_consumption: {}
+  non_final_output_tokens: {}
 
 reporting:
   csv:
@@ -462,6 +463,7 @@ Quick reference:
 | `end_to_end_latency` | Deterministic | Total wall-clock latency of the `codex exec` subprocess |
 | `tool_call_latency` | Deterministic | Sum of per-tool durations measured between `item.started` and `item.completed` arrival times (Codex events carry no timestamps, so the generator stamps arrival in-process) |
 | `token_consumption` | Deterministic | Total input + output + cached tokens, plus `cost_usd` from the `pricing` block |
+| `non_final_output_tokens` | Deterministic | Output tokens spent on reasoning + tool-call orchestration, excluding the final rendered answer text. Robust to answer-verbosity variance for side-by-side efficiency comparison. |
 
 The Codex generator extracts tool calls from the following NDJSON ThreadItem kinds: `mcp_tool_call`, `command_execution` (reported as `shell`), `web_search`, and `file_change`.
 

--- a/docs/gemini_cli_agent_testing.md
+++ b/docs/gemini_cli_agent_testing.md
@@ -182,6 +182,7 @@ scorers:
   end_to_end_latency: {}
   tool_call_latency: {}
   token_consumption: {}
+  non_final_output_tokens: {}
 
 ############################################################
 ### Reporting Related Configs
@@ -623,6 +624,7 @@ These require no additional model:
 | `end_to_end_latency` | Milliseconds | Total latency = model API latency + tool execution latency. |
 | `tool_call_latency` | Milliseconds | Sum of all tool execution durations across all turns. |
 | `token_consumption` | Count | Total tokens consumed (input + output) across all turns. |
+| `non_final_output_tokens` | Count | Output tokens spent on reasoning + tool-call orchestration, excluding the final rendered answer text. Robust to answer-verbosity variance for side-by-side efficiency comparison. |
 | `python_scorer` | 0–100 | Delegates evaluation to an external Python script executed via `uv run`. |
 
 ### Scorer Configuration Example
@@ -641,6 +643,7 @@ scorers:
   end_to_end_latency: {}
   tool_call_latency: {}
   token_consumption: {}
+  non_final_output_tokens: {}
 
   # LLM-based scorers (require model_config)
   goal_completion:

--- a/evalbench/reporting/analyzer.py
+++ b/evalbench/reporting/analyzer.py
@@ -81,6 +81,7 @@ def analyze_one_metric(
                 "token_consumption",
                 "tokens_processed",
                 "effective_billed_tokens",
+                "non_final_output_tokens",
             ]
             if metric_name in non_binary_metrics:
                 avg_val = df_metric["score"].mean(

--- a/evalbench/scorers/nonfinaloutputtokens.py
+++ b/evalbench/scorers/nonfinaloutputtokens.py
@@ -1,0 +1,125 @@
+"""
+NonFinalOutputTokens Scorer
+
+Measures the output tokens spent on the *path* to the answer -- reasoning and
+tool-call emission -- while excluding the final rendered response text, whose
+verbosity is a presentation choice rather than a signal of how efficiently the
+agent fulfilled the request.
+
+Rationale: two runs may invoke the identical tool calls yet differ wildly in how
+much they narrate the result (a terse summary vs. a full table view). That
+variance lands entirely in output tokens and makes ``token_consumption`` noisy
+for side-by-side efficiency comparison -- especially for one-shot runs.
+Subtracting an estimate of each turn's user-facing ``response`` text isolates the
+stable "work" component (output spent on reasoning and emitting tool calls; note
+that tool-call arguments are counted as output but are not part of ``response``).
+
+The response-size estimate reuses the same ``len / 4`` chars-per-token heuristic
+as ``scorers.mcp_tool_metrics`` so token approximations stay consistent across
+the codebase.
+"""
+from typing import Tuple, Any
+from scorers import comparator
+import json
+
+# Rough chars-per-token heuristic for estimating the response's token footprint.
+# Mirrors ``scorers.mcp_tool_metrics._CHARS_PER_TOKEN``.
+_CHARS_PER_TOKEN = 4
+
+
+class NonFinalOutputTokens(comparator.Comparator):
+    """
+    NonFinalOutputTokens class implements the Comparator base class for measuring
+    output tokens excluding the final rendered response text.
+    """
+
+    def __init__(self, config: dict):
+        self.name = "non_final_output_tokens"
+        self.config = config
+
+    def compare(
+        self,
+        nl_prompt: str,
+        golden_query: str,
+        query_type: str,
+        golden_execution_result: Any,
+        golden_eval_result: str,
+        golden_error: str,
+        generated_query: str,
+        generated_execution_result: Any,
+        generated_eval_result: str,
+        generated_error: str,
+    ) -> Tuple[float, str]:
+        """
+        Calculates non-final output tokens from the conversation history.
+
+        For each turn, sums output tokens (``candidates``) across model buckets
+        and subtracts an estimate of the turn's user-facing ``response`` text.
+        The per-turn contribution is clamped at zero so heuristic overshoot never
+        drives the total negative.
+
+        Args:
+            generated_eval_result: String representing JSON history.
+
+        Returns:
+            Tuple (score, explanation) where score is the non-final output tokens.
+        """
+        if generated_error:
+            return 0.0, f"Generation error: {generated_error}"
+
+        if not generated_eval_result:
+            return 0.0, "No conversation history provided."
+
+        try:
+            history = (
+                json.loads(generated_eval_result)
+                if isinstance(generated_eval_result, str)
+                else generated_eval_result
+            )
+            if isinstance(history, dict):
+                history = history.get("conversation_history", "[]")
+            if isinstance(history, str):
+                history = json.loads(history)
+
+            total_tokens = 0.0
+            malformed_agent_entries = 0
+
+            if isinstance(history, list):
+                for turn in history:
+                    agent_resp = turn.get("agent", "")
+                    try:
+                        resp_json = json.loads(agent_resp)
+                        stats = resp_json.get("stats", {})
+                        models = stats.get("models", {})
+                        turn_output = 0.0
+                        for model_stats in models.values():
+                            tokens = model_stats.get("tokens", {})
+                            # `candidates` is the output channel. Tool-call
+                            # arguments are counted here but are not part of
+                            # `response`, so they survive the subtraction.
+                            turn_output += tokens.get("candidates", 0.0)
+
+                        response_text = resp_json.get("response", "") or ""
+                        est_response = round(
+                            len(response_text) / _CHARS_PER_TOKEN
+                        )
+                        # Clamp so a response estimate exceeding the reported
+                        # output never pushes the running total negative.
+                        total_tokens += max(0.0, turn_output - est_response)
+                    except json.JSONDecodeError:
+                        malformed_agent_entries += 1
+
+                malformed_note = (
+                    f" Skipped {malformed_agent_entries} malformed agent "
+                    f"response(s)."
+                    if malformed_agent_entries
+                    else ""
+                )
+                return float(total_tokens), (
+                    f"Non-final output: {total_tokens} tokens "
+                    f"(output excl. est. response text).{malformed_note}"
+                )
+            else:
+                return 0.0, "Conversation history is not a list."
+        except json.JSONDecodeError:
+            return 0.0, "Failed to parse conversation history as JSON."

--- a/evalbench/scorers/score.py
+++ b/evalbench/scorers/score.py
@@ -20,6 +20,7 @@ from scorers import toolcalllatency
 from scorers import tokenconsumption
 from scorers import tokensprocessed
 from scorers import effectivebilledtokens
+from scorers import nonfinaloutputtokens
 from scorers import binaryrubricscorer
 from scorers import pythonscorer
 from scorers import dataformscorer
@@ -125,6 +126,12 @@ def compare(
         comparators.append(
             effectivebilledtokens.EffectiveBilledTokens(
                 scorers["effective_billed_tokens"]
+            )
+        )
+    if "non_final_output_tokens" in scorers:
+        comparators.append(
+            nonfinaloutputtokens.NonFinalOutputTokens(
+                scorers["non_final_output_tokens"]
             )
         )
     if "binary_rubric_scorer" in scorers:

--- a/evalbench/test/tokenscorers_test.py
+++ b/evalbench/test/tokenscorers_test.py
@@ -1,8 +1,10 @@
-"""Tests for the tokens_processed and effective_billed_tokens scorers."""
+"""Tests for the tokens_processed, effective_billed_tokens, and
+non_final_output_tokens scorers."""
 import json
 
 from scorers.tokensprocessed import TokensProcessed
 from scorers.effectivebilledtokens import EffectiveBilledTokens
+from scorers.nonfinaloutputtokens import NonFinalOutputTokens
 
 
 def _history(tokens: dict) -> str:
@@ -11,6 +13,22 @@ def _history(tokens: dict) -> str:
     (turn -> agent JSON -> stats.models.<m>.tokens)."""
     agent = json.dumps({"stats": {"models": {"claude-opus-4-8": {"tokens": tokens}}}})
     return json.dumps([{"user": "hi", "agent": agent}])
+
+
+def _turn(candidates: float, response: str = "") -> dict:
+    """Builds one conversation turn carrying an output-token count and the
+    turn's user-facing `response` text, matching what the generators emit
+    (turn -> agent JSON -> {stats.models.<m>.tokens.candidates, response})."""
+    agent = json.dumps({
+        "stats": {"models": {"claude-opus-4-8": {"tokens": {"candidates": candidates}}}},
+        "response": response,
+    })
+    return {"user": "hi", "agent": agent}
+
+
+def _output_history(candidates: float, response: str = "") -> str:
+    """One-turn history for the non_final_output_tokens scorer."""
+    return json.dumps([_turn(candidates, response)])
 
 
 # Full bucket as emitted by claude_code.py. `prompt` duplicates `input` and
@@ -80,3 +98,43 @@ def test_generation_error_returns_zero():
 def test_empty_history_returns_zero():
     for scorer in (TokensProcessed({}), EffectiveBilledTokens({})):
         assert _compare(scorer, "")[0] == 0.0
+
+
+def test_non_final_output_subtracts_response_estimate():
+    scorer = NonFinalOutputTokens({})
+    # candidates=200, response of 400 chars -> est 400/4 = 100 -> 200 - 100.
+    score, _ = _compare(scorer, _output_history(200, "x" * 400))
+    assert score == 100.0
+
+
+def test_non_final_output_clamps_at_zero():
+    scorer = NonFinalOutputTokens({})
+    # Response estimate (800/4 = 200) exceeds output (50) -> clamp to 0.
+    score, _ = _compare(scorer, _output_history(50, "y" * 800))
+    assert score == 0.0
+
+
+def test_non_final_output_sums_across_turns():
+    scorer = NonFinalOutputTokens({})
+    history = json.dumps([
+        _turn(200, "x" * 400),   # 200 - 100 = 100
+        _turn(300, "z" * 40),    # 300 - 10  = 290
+    ])
+    score, _ = _compare(scorer, history)
+    assert score == 390.0
+
+
+def test_non_final_output_missing_response_degrades_to_full_output():
+    scorer = NonFinalOutputTokens({})
+    # No response text -> nothing subtracted -> full candidates.
+    score, _ = _compare(scorer, _output_history(200))
+    assert score == 200.0
+
+
+def test_non_final_output_generation_error_returns_zero():
+    scorer = NonFinalOutputTokens({})
+    assert _compare(scorer, _output_history(200, "x" * 400), "boom")[0] == 0.0
+
+
+def test_non_final_output_empty_history_returns_zero():
+    assert _compare(NonFinalOutputTokens({}), "")[0] == 0.0


### PR DESCRIPTION
## What & why

`token_consumption` (input + output) is noisy for comparing agent efficiency
because output tokens carry high, presentation-driven variance: two runs can
invoke the *identical* tool calls yet differ widely in output because one writes
a terse summary while the other renders a full table. That variance makes
side-by-side efficiency comparison unreliable, especially for one-shot runs.

This adds **`non_final_output_tokens`**, a new deterministic scorer that reports
the output tokens spent on the *path to the answer* (reasoning + tool-call
emission) while excluding the final rendered response text. Per turn it computes
`sum(candidates) − estimate(response)` (clamped at 0), where the response-size
estimate reuses the existing `len/4` chars-per-token heuristic from
`mcp_tool_metrics.py`. `token_consumption` is left unchanged — this is added as a
sibling, mirroring how `tokens_processed` / `effective_billed_tokens` were
introduced.

## Tested
https://paste.googleplex.com/6298204256731136