### PR TITLE
Feature/default and generated columns

### DIFF
--- a/evalbench/databases/spanner.py
+++ b/evalbench/databases/spanner.py
@@ -513,6 +513,11 @@ class SpannerDB(DB):
                             break
                 if not info:
                     continue
+                # CSV files are headerless, meaning we map values positionally.
+                # If the CSV has C columns and the DB has S columns (where C < S),
+                # we slice to map values to the first C columns. This allows
+                # database columns with defaults (like surrogate_id PKs) at the end
+                # to be omitted from the insert, letting Spanner generate defaults.
                 csv_col_count = len(rows[0]) if rows else 0
                 columns = info["columns"][:csv_col_count]
                 processed_rows = []

--- a/evalbench/databases/spanner.py
+++ b/evalbench/databases/spanner.py
@@ -465,7 +465,13 @@ class SpannerDB(DB):
             schema_name = 'public' if self.expected_dialect_str == "POSTGRESQL" else ''
             with self.database.snapshot() as snapshot:
                 type_col = "spanner_type" if self.expected_dialect_str == "GOOGLESQL" else "data_type"
-                query = f"SELECT table_name, column_name, {type_col} FROM information_schema.columns WHERE table_schema = '{schema_name}' ORDER BY table_name, ordinal_position"
+                query = (
+                    f"SELECT table_name, column_name, {type_col} "
+                    f"FROM information_schema.columns "
+                    f"WHERE table_schema = '{schema_name}' "
+                    f"AND (UPPER(is_generated) != 'ALWAYS' OR is_generated IS NULL) "
+                    f"ORDER BY table_name, ordinal_position"
+                )
                 res = snapshot.execute_sql(query, timeout=self.query_timeout)
                 for row in res:
                     t_name, c_name, d_type = row[0], row[1], row[2]
@@ -507,7 +513,8 @@ class SpannerDB(DB):
                             break
                 if not info:
                     continue
-                columns = info["columns"]
+                csv_col_count = len(rows[0]) if rows else 0
+                columns = info["columns"][:csv_col_count]
                 processed_rows = []
                 for row in rows:
                     p_row = list(row)

--- a/evalbench/databases/spanner.py
+++ b/evalbench/databases/spanner.py
@@ -470,6 +470,7 @@ class SpannerDB(DB):
                     f"FROM information_schema.columns "
                     f"WHERE table_schema = '{schema_name}' "
                     f"AND (UPPER(is_generated) != 'ALWAYS' OR is_generated IS NULL) "
+                    f"AND LOWER(column_name) NOT IN ('_row_id', 'surrogate_id') "
                     f"ORDER BY table_name, ordinal_position"
                 )
                 res = snapshot.execute_sql(query, timeout=self.query_timeout)
@@ -513,13 +514,7 @@ class SpannerDB(DB):
                             break
                 if not info:
                     continue
-                # CSV files are headerless, meaning we map values positionally.
-                # If the CSV has C columns and the DB has S columns (where C < S),
-                # we slice to map values to the first C columns. This allows
-                # database columns with defaults (like surrogate_id PKs) at the end
-                # to be omitted from the insert, letting Spanner generate defaults.
-                csv_col_count = len(rows[0]) if rows else 0
-                columns = info["columns"][:csv_col_count]
+                columns = info["columns"]
                 processed_rows = []
                 for row in rows:
                     p_row = list(row)

--- a/evalbench/test/spanner_test.py
+++ b/evalbench/test/spanner_test.py
@@ -57,7 +57,7 @@ class TestSpanner:
             # Data omitting the generated column (3 values)
             data = {"ut_gen": [[1, 10, 20], [2, 100, 200]]}
             client.insert_data(data)
-            
+
             # Verify data
             res = client.execute("SELECT id, a, b, gen FROM `ut_gen` ORDER BY id")
             assert len(res[0]) == 2
@@ -70,21 +70,21 @@ class TestSpanner:
 
     @pytest.mark.filterwarnings("ignore::DeprecationWarning")
     def test_default_column_omitted(self, client):
-        # Create table with default column
-        create_table = "CREATE TABLE `ut_def` (id INT64, val INT64, def_val INT64 DEFAULT (42)) PRIMARY KEY (id)"
+        # Create table with default column (using surrogate_id which is filtered out)
+        create_table = "CREATE TABLE `ut_def` (id INT64, val INT64, surrogate_id STRING(36) DEFAULT ('default-uuid')) PRIMARY KEY (id)"
         client.batch_execute([create_table])
         try:
             # Data omitting default column (2 values)
             data = {"ut_def": [[1, 10], [2, 20]]}
             client.insert_data(data)
-            
+
             # Verify default value is populated
-            res = client.execute("SELECT id, val, def_val FROM `ut_def` ORDER BY id")
+            res = client.execute("SELECT id, val, surrogate_id FROM `ut_def` ORDER BY id")
             assert len(res[0]) == 2
             assert res[0][0]["id"] == 1
-            assert res[0][0]["def_val"] == 42
+            assert res[0][0]["surrogate_id"] == "default-uuid"
             assert res[0][1]["id"] == 2
-            assert res[0][1]["def_val"] == 42
+            assert res[0][1]["surrogate_id"] == "default-uuid"
         finally:
             client.batch_execute(["DROP TABLE `ut_def`"])
 
@@ -97,7 +97,7 @@ class TestSpanner:
             # Data including default column (3 values)
             data = {"ut_def_inc": [[1, 10, 99], [2, 20, 100]]}
             client.insert_data(data)
-            
+
             # Verify explicit value is populated
             res = client.execute("SELECT id, val, def_val FROM `ut_def_inc` ORDER BY id")
             assert len(res[0]) == 2

--- a/evalbench/test/spanner_test.py
+++ b/evalbench/test/spanner_test.py
@@ -47,3 +47,63 @@ class TestSpanner:
     def test_drop_table(self, client):
         create_table = "DROP TABLE `ut`"
         client.batch_execute([create_table])
+
+    @pytest.mark.filterwarnings("ignore::DeprecationWarning")
+    def test_generated_column(self, client):
+        # Create table with generated column
+        create_table = "CREATE TABLE `ut_gen` (id INT64, a INT64, b INT64, gen INT64 AS (a + b) STORED) PRIMARY KEY (id)"
+        client.batch_execute([create_table])
+        try:
+            # Data omitting the generated column (3 values)
+            data = {"ut_gen": [[1, 10, 20], [2, 100, 200]]}
+            client.insert_data(data)
+            
+            # Verify data
+            res = client.execute("SELECT id, a, b, gen FROM `ut_gen` ORDER BY id")
+            assert len(res[0]) == 2
+            assert res[0][0]["id"] == 1
+            assert res[0][0]["gen"] == 30
+            assert res[0][1]["id"] == 2
+            assert res[0][1]["gen"] == 300
+        finally:
+            client.batch_execute(["DROP TABLE `ut_gen`"])
+
+    @pytest.mark.filterwarnings("ignore::DeprecationWarning")
+    def test_default_column_omitted(self, client):
+        # Create table with default column
+        create_table = "CREATE TABLE `ut_def` (id INT64, val INT64, def_val INT64 DEFAULT (42)) PRIMARY KEY (id)"
+        client.batch_execute([create_table])
+        try:
+            # Data omitting default column (2 values)
+            data = {"ut_def": [[1, 10], [2, 20]]}
+            client.insert_data(data)
+            
+            # Verify default value is populated
+            res = client.execute("SELECT id, val, def_val FROM `ut_def` ORDER BY id")
+            assert len(res[0]) == 2
+            assert res[0][0]["id"] == 1
+            assert res[0][0]["def_val"] == 42
+            assert res[0][1]["id"] == 2
+            assert res[0][1]["def_val"] == 42
+        finally:
+            client.batch_execute(["DROP TABLE `ut_def`"])
+
+    @pytest.mark.filterwarnings("ignore::DeprecationWarning")
+    def test_default_column_included(self, client):
+        # Create table with default column
+        create_table = "CREATE TABLE `ut_def_inc` (id INT64, val INT64, def_val INT64 DEFAULT (42)) PRIMARY KEY (id)"
+        client.batch_execute([create_table])
+        try:
+            # Data including default column (3 values)
+            data = {"ut_def_inc": [[1, 10, 99], [2, 20, 100]]}
+            client.insert_data(data)
+            
+            # Verify explicit value is populated
+            res = client.execute("SELECT id, val, def_val FROM `ut_def_inc` ORDER BY id")
+            assert len(res[0]) == 2
+            assert res[0][0]["id"] == 1
+            assert res[0][0]["def_val"] == 99
+            assert res[0][1]["id"] == 2
+            assert res[0][1]["def_val"] == 100
+        finally:
+            client.batch_execute(["DROP TABLE `ut_def_inc`"])


### PR DESCRIPTION
I thought I had posted this months ago but it seemingly got lost somewhere, apologies!

This change updates the data ingestion logic.  For Spanner:
* When computing the set of columns to load data into, generated columns are now ignored
* Default columns aren't ignored (because loading data into them is valid but optional), but we reserve a couple special keyword names that schemas can use for default ID columns and the loader won't try to populate them

The underlying problem is as follows:  Spanner requires that all tables contain a PK, and that all PK values be unique.  Some of our datasets do not guarantee uniqueness.  The recommended workaround in this case is to construct a synthetic column where each row is a UUID, or a value from a sequence, or otherwise some synthetic and guaranteed-unique value.  (Then just ignore this column; let Spanner manage and use it itself.)

Some of our schemas do this.  Which is fine.

The issue then is, the data loader tries to populate _all_ columns on the table, and it errors out if it can't do so.  Populating generated columns with data from a .csv file isn't a correct thing to do.  (They're generated and managed by the database; they're not allowed to be provided by the user.)  Populating columns with a DEFAULT clause is permissible, but not required, and not desired for this use case.  This PR adds some logic to enable those use cases.