### PR TITLE
feat: add prompt templates for vague examples, composition coverage, and CUJ path classification

### DIFF
--- a/evalbench/scorers/prompt/composition_coverage.py
+++ b/evalbench/scorers/prompt/composition_coverage.py
@@ -1,0 +1,57 @@
+COMPOSITION_COVERAGE_PROMPT = """\
+You are an expert evaluator of conversational AI evaluation datasets. You are given
+an ENTIRE dataset of Critical User Journeys (CUJs): each CUJ is one user-agent test
+scenario, which may be single- or multi-turn. For EVERY CUJ, make two independent
+judgments about how it exercises TOOL COMPOSITION.
+
+Why this matters: real tasks rarely resolve with a single isolated tool call. Strong
+datasets test whether the agent can chain tools together, pass data across
+skills/tools, and respect ordering constraints. A dataset of one-tool-per-scenario
+requests overstates how well the product handles realistic, composite work. Your
+judgments drive a composition-coverage score.
+
+### JUDGMENT 1 -- is_multi_tool
+Does the CUJ genuinely require MORE THAN ONE distinct tool (or a skill-plus-tool, or
+cross-skill data passing) working together to succeed?
+- Judge from what the starting_prompt and conversation_plan actually demand, using
+  expected_trajectory as a strong hint -- NOT from the trajectory list alone. A
+  trajectory may list several tools that the task does not truly require, or the same
+  tool repeated; treat repeats of one tool as single-tool.
+- true: the task's success depends on two or more DIFFERENT tools/skills
+  contributing (e.g. read a file, then run a test; search, then summarize; produce
+  data in one skill and consume it in another).
+- false: the task is satisfiable with a single tool/skill (even if called more than
+  once).
+
+### JUDGMENT 2 -- has_sequence_dependency
+Does success require a SPECIFIC ORDER of operations -- tool A must happen before
+tool B, and doing them out of order would fail or produce a wrong result?
+- true: there is a real ordering constraint (e.g. create the table before inserting
+  rows; check out the branch before editing; fetch an id before using it).
+- false: the tools are independent / order does not matter, or there is only one
+  operation.
+- Note: needing multiple tools (Judgment 1 = true) does NOT by itself imply an
+  ordering constraint. Judge ordering separately.
+
+When genuinely borderline on either judgment, answer false.
+
+### Input Data
+**Available Tools:** {tool_names}
+
+**CUJs (JSON list):** Each object has "id", "starting_prompt", "conversation_plan",
+and "expected_trajectory".
+{cujs_json}
+
+### OUTPUT
+Return ONLY a JSON object (no markdown, no prose) with exactly this shape:
+{{
+  "tags": [
+    {{
+      "id": "<the CUJ id, copied verbatim from the input>",
+      "is_multi_tool": true|false,
+      "has_sequence_dependency": true|false
+    }}
+  ]
+}}
+Return one entry in "tags" for EVERY CUJ in the input. Each "id" MUST match an input
+CUJ id exactly."""

--- a/evalbench/scorers/prompt/composition_coverage.py
+++ b/evalbench/scorers/prompt/composition_coverage.py
@@ -42,7 +42,7 @@ When genuinely borderline on either judgment, answer false.
 and "expected_trajectory".
 {cujs_json}
 
-### OUTPUT
+### Output Format
 Return ONLY a JSON object (no markdown, no prose) with exactly this shape:
 {{
   "tags": [

--- a/evalbench/scorers/prompt/cuj_path_classification.py
+++ b/evalbench/scorers/prompt/cuj_path_classification.py
@@ -36,16 +36,18 @@ so judge what each scenario ACTUALLY exercises, not what it superficially resemb
   -- a query/tool fails, returns an error, hits a nonexistent resource, or the user
   identifies a mistake and asks the agent to correct course. Example: "That query
   failed with a syntax error, can you fix the join?".
-- "Out-of-Domain": The user requests something the agent should refuse or redirect
-  -- e.g. PII/sensitive data, disallowed actions, or data/tables that do not exist
-  -- and the expected behavior is a polite refusal plus redirection (guardrail).
+- "Out-of-Domain": The user requests something out-of-scope or disallowed that the
+  agent should refuse or redirect -- e.g. PII/sensitive data, disallowed actions, or
+  data the product is not meant to serve -- and the expected behavior is a polite
+  refusal plus redirection (guardrail). The request itself is illegitimate; the point
+  is the refusal, not fixing anything.
 
 ### How to classify
 For each CUJ, base your judgment primarily on the conversation_plan (it describes
 the intended multi-turn dynamic), then the starting_prompt and expected_trajectory.
 Pick the ONE path that best characterizes the scenario. If more than one seems to
 apply, choose the dominant path using this priority order (top wins):
-1. "Out-of-Domain" -- if the core request targets PII / disallowed / nonexistent
+1. "Out-of-Domain" -- if the core request targets PII / disallowed / out-of-scope
    data and the point of the scenario is a refusal or redirect.
 2. "Error Recovery" -- if the scenario is built around recovering from a failure,
    error, or a user-identified mistake.
@@ -55,6 +57,13 @@ apply, choose the dominant path using this priority order (top wins):
    agent must seek details before acting.
 5. "Happy" -- only when it is a direct, well-formed request with no ambiguity,
    refinement, error, or guardrail element.
+
+Out-of-Domain vs Error Recovery: choose "Out-of-Domain" when the user's request is
+itself out-of-scope or disallowed and the agent should refuse (e.g. asking for other
+users' SSNs, or for a table the product never exposes). Choose "Error Recovery" when
+the request is legitimate but execution fails or the user corrects a mistake and the
+scenario is about recovering (e.g. a valid query references a column that turns out
+not to exist, then the user asks to fix it).
 
 Do not invent behavior that is not implied by the scenario. When genuinely
 uncertain between an edge path and Happy, prefer the edge path only if the
@@ -67,7 +76,7 @@ conversation_plan clearly describes that dynamic; otherwise classify as "Happy".
 and "expected_trajectory".
 {cujs_json}
 
-### OUTPUT
+### Output Format
 Return ONLY a JSON object (no markdown, no prose) with exactly this shape:
 {{
   "tags": [

--- a/evalbench/scorers/prompt/cuj_path_classification.py
+++ b/evalbench/scorers/prompt/cuj_path_classification.py
@@ -1,0 +1,82 @@
+# Canonical CUJ path labels. The judge MUST return one of these exact strings;
+# downstream scorers key off them, so keep them in sync with any consumer.
+CUJ_PATHS = (
+    "Happy",
+    "Ambiguity & Clarification",
+    "Iterative Refinement",
+    "Error Recovery",
+    "Out-of-Domain",
+)
+
+
+CUJ_PATH_CLASSIFICATION_PROMPT = """\
+You are an expert evaluator of conversational AI evaluation datasets. You are given
+an ENTIRE dataset of Critical User Journeys (CUJs): each CUJ is one user-agent test
+scenario, which may be single- or multi-turn. Classify EVERY CUJ into EXACTLY ONE of
+the five CUJ paths defined below.
+
+Why this matters: most datasets only test the "Happy Path" -- a perfectly phrased
+question that yields a perfect answer -- which gives false confidence. A healthy
+dataset also exercises "unhappy paths" and edge cases (ambiguity, refinement,
+error recovery, guardrails). Your classification drives a dataset-diversity score,
+so judge what each scenario ACTUALLY exercises, not what it superficially resembles.
+
+### CUJ PATHS (choose exactly one per CUJ)
+- "Happy": Standard query. A direct, well-formed request that leads straight to an
+  accurate response. Necessary as a baseline. Example: "Who are our top customers?"
+  -> [accurate list].
+- "Ambiguity & Clarification": The user's initial request is incomplete or
+  underspecified, and the agent must ask for specific details before it can
+  proceed. Example: user says "I need a database." and the agent must ask what kind
+  / what name; or "top customers?" -> "by revenue or by purchase volume?".
+- "Iterative Refinement": The user progressively narrows or adjusts scope across
+  turns, building on the agent's previous outputs. Example: "Show Q1 sales" ->
+  "actually, exclude enterprise accounts" -> "now filter to EMEA".
+- "Error Recovery": The interaction centers on pivoting after something goes wrong
+  -- a query/tool fails, returns an error, hits a nonexistent resource, or the user
+  identifies a mistake and asks the agent to correct course. Example: "That query
+  failed with a syntax error, can you fix the join?".
+- "Out-of-Domain": The user requests something the agent should refuse or redirect
+  -- e.g. PII/sensitive data, disallowed actions, or data/tables that do not exist
+  -- and the expected behavior is a polite refusal plus redirection (guardrail).
+
+### How to classify
+For each CUJ, base your judgment primarily on the conversation_plan (it describes
+the intended multi-turn dynamic), then the starting_prompt and expected_trajectory.
+Pick the ONE path that best characterizes the scenario. If more than one seems to
+apply, choose the dominant path using this priority order (top wins):
+1. "Out-of-Domain" -- if the core request targets PII / disallowed / nonexistent
+   data and the point of the scenario is a refusal or redirect.
+2. "Error Recovery" -- if the scenario is built around recovering from a failure,
+   error, or a user-identified mistake.
+3. "Iterative Refinement" -- if the user successively refines scope across turns
+   based on prior results.
+4. "Ambiguity & Clarification" -- if the request starts underspecified and the
+   agent must seek details before acting.
+5. "Happy" -- only when it is a direct, well-formed request with no ambiguity,
+   refinement, error, or guardrail element.
+
+Do not invent behavior that is not implied by the scenario. When genuinely
+uncertain between an edge path and Happy, prefer the edge path only if the
+conversation_plan clearly describes that dynamic; otherwise classify as "Happy".
+
+### Input Data
+**Available Tools:** {tool_names}
+
+**CUJs (JSON list):** Each object has "id", "starting_prompt", "conversation_plan",
+and "expected_trajectory".
+{cujs_json}
+
+### OUTPUT
+Return ONLY a JSON object (no markdown, no prose) with exactly this shape:
+{{
+  "tags": [
+    {{
+      "id": "<the CUJ id, copied verbatim from the input>",
+      "cuj_path": "Happy | Ambiguity & Clarification | Iterative Refinement | Error Recovery | Out-of-Domain"
+    }}
+  ]
+}}
+Return one entry in "tags" for EVERY CUJ in the input. Each "id" MUST match an input
+CUJ id exactly. Each "cuj_path" value MUST be exactly one of the five strings listed
+above."""

--- a/evalbench/scorers/prompt/parameter_coverage.py
+++ b/evalbench/scorers/prompt/parameter_coverage.py
@@ -1,0 +1,60 @@
+PARAMETER_COVERAGE_PROMPT = """\
+You are an expert evaluator of conversational AI evaluation datasets. You are given
+the full TOOL SCHEMA for a product and an ENTIRE dataset of Critical User Journeys
+(CUJs): each CUJ is one user-agent test scenario, which may be single- or
+multi-turn. For EVERY named parameter of EVERY tool in the schema, decide which CUJs
+EXERCISE that parameter.
+
+Why this matters: a tool's parameters define its behavior surface. If a dataset only
+ever hits a tool's required identifiers and never its optional filters, enums, or
+flags, those parameters are effectively untested -- the product could regress on them
+silently. A named parameter that appears in zero (or very few) CUJs is a coverage
+gap. Your judgments drive a parameter-coverage score, so ground every decision in
+what each scenario actually demands.
+
+### What "exercises a parameter" means
+A CUJ exercises a tool's parameter when the scenario would require the agent to
+supply a meaningful, scenario-specific value for that parameter while calling that
+tool -- i.e. the request cannot succeed as described unless that parameter is set.
+- Count a parameter for a CUJ only if that parameter's tool is actually used by the
+  CUJ. Use expected_trajectory as the authoritative signal for which tools a CUJ
+  invokes; a parameter belonging to a tool the CUJ never calls is NOT exercised.
+- A required parameter is exercised whenever its tool is invoked (the call cannot be
+  made without it). An optional parameter is exercised only when the scenario
+  explicitly demands its behavior -- e.g. a filter, page size, enum choice, ordering,
+  or flag that the starting_prompt or conversation_plan calls for.
+- Judge from what the starting_prompt and conversation_plan actually demand, using
+  expected_trajectory to confirm which tools run. Do NOT assume an optional parameter
+  is used just because it exists; absence of any demand for it means it is NOT
+  exercised by that CUJ.
+- The same CUJ may exercise several parameters (across one or more tools). List the
+  CUJ under every parameter it genuinely exercises.
+
+When genuinely borderline on whether an optional parameter is exercised, do NOT count
+it.
+
+### Input Data
+**Tool Schema (JSON):** A list of tools. Each tool has "name" and an "inputSchema"
+whose "properties" are the named parameters and whose "required" lists the mandatory
+ones.
+{tool_schema}
+
+**CUJs (JSON list):** Each object has "id", "starting_prompt", "conversation_plan",
+and "expected_trajectory".
+{cujs_json}
+
+### Output Format
+Return ONLY a JSON object (no markdown, no prose) with exactly this shape:
+{{
+  "coverage": [
+    {{
+      "tool": "<tool name, copied verbatim from the schema>",
+      "parameter": "<parameter name, copied verbatim from the schema>",
+      "required": true|false,
+      "cuj_ids": ["<id of each CUJ that exercises this parameter>"]
+    }}
+  ]
+}}
+Emit exactly ONE entry for EVERY named parameter of EVERY tool in the schema --
+including parameters exercised by no CUJ, whose "cuj_ids" MUST be an empty list. Each
+id in "cuj_ids" MUST match an input CUJ id exactly, with no duplicates."""

--- a/evalbench/scorers/prompt/parameter_coverage.py
+++ b/evalbench/scorers/prompt/parameter_coverage.py
@@ -50,7 +50,6 @@ Return ONLY a JSON object (no markdown, no prose) with exactly this shape:
     {{
       "tool": "<tool name, copied verbatim from the schema>",
       "parameter": "<parameter name, copied verbatim from the schema>",
-      "required": true|false,
       "cuj_ids": ["<id of each CUJ that exercises this parameter>"]
     }}
   ]

--- a/evalbench/scorers/prompt/vague_examples.py
+++ b/evalbench/scorers/prompt/vague_examples.py
@@ -34,7 +34,7 @@ exact operation and target, it is DIRECT. When genuinely borderline, prefer DIRE
 "conversation_plan".
 {cujs_json}
 
-### OUTPUT
+### Output Format
 Return ONLY a JSON object (no markdown, no prose) with exactly this shape:
 {{
   "tags": [

--- a/evalbench/scorers/prompt/vague_examples.py
+++ b/evalbench/scorers/prompt/vague_examples.py
@@ -1,0 +1,48 @@
+VAGUE_EXAMPLES_PROMPT = """\
+You are an expert evaluator of conversational AI evaluation datasets. You are given
+an ENTIRE dataset of Critical User Journeys (CUJs): each CUJ is one user-agent test
+scenario, which may be single- or multi-turn. For EVERY CUJ, decide whether the
+user's request is VAGUE / INDIRECT or DIRECT.
+
+Why this matters: a healthy dataset must test discoverability -- can the agent infer
+WHICH tool or operation to use when the user describes an outcome or intent instead
+of naming the tool explicitly. Datasets stuffed only with direct, tool-naming
+commands overstate how usable the product is, because real users rarely know the
+exact tool names. Your judgments drive a discoverability score, so reward scenarios
+that force the agent to interpret intent.
+
+### DEFINITIONS
+- VAGUE / INDIRECT (is_vague = true): The user expresses a GOAL, outcome, or intent
+  without naming the specific tool, operation, or exact object to act on. The agent
+  must infer what to do. Examples: "My tests are flaky, can you help?"; "I want to
+  understand where our latency is coming from"; "Clean up this file."
+- DIRECT (is_vague = false): The user names the operation, tool, or exact target so
+  there is little inference needed. Examples: "Run pytest on test_auth.py";
+  "Read config.yaml and list the keys"; "Call the search_customers tool for 'Acme'".
+
+### How to judge
+Base your judgment primarily on the starting_prompt (how the user first phrases the
+task), then the conversation_plan. A CUJ is VAGUE if the user's initial goal is
+non-obvious -- expressed by intent rather than by naming the tool/operation/target.
+If the request explicitly names a tool from the available tools, or spells out the
+exact operation and target, it is DIRECT. When genuinely borderline, prefer DIRECT.
+
+### Input Data
+**Available Tools:** {tool_names}
+
+**CUJs (JSON list):** Each object has "id", "starting_prompt", and
+"conversation_plan".
+{cujs_json}
+
+### OUTPUT
+Return ONLY a JSON object (no markdown, no prose) with exactly this shape:
+{{
+  "tags": [
+    {{
+      "id": "<the CUJ id, copied verbatim from the input>",
+      "is_vague": true|false
+    }}
+  ]
+}}
+Return one entry in "tags" for EVERY CUJ in the input. Each "id" MUST match an input
+CUJ id exactly."""


### PR DESCRIPTION
## Overview
This PR introduces the foundational LLM prompt templates required for the new dataset quality scorers. These templates act as LLM judges to evaluate different holistic metrics of a given CUJ dataset. 

## Changes Included
Added prompt templates for four dataset quality metrics:
* **Composition Coverage (`composition_coverage.py`):** Evaluates whether a CUJ requires multiple distinct tools (`is_multi_tool`) and if it has a strict sequence dependency (`has_sequence_dependency`).
* **CUJ Path Classification (`cuj_path_classification.py`):** Classifies each CUJ into one of five predefined paths (Happy, Ambiguity & Clarification, Iterative Refinement, Error Recovery, Out-of-Domain) to measure dataset diversity.
* **Parameter Coverage (`parameter_coverage.py`):** Determines which specific named parameters in the tool schema are actually exercised by the CUJs.
* **Vague Examples (`vague_examples.py`):** Analyzes whether a user's initial request is direct (naming the tool explicitly) or vague/indirect (forcing the agent to infer intent).

## Technical Details
* Each prompt is structured to consume the available tools schema and a JSON list of CUJs.
* The prompts enforce strict JSON output formatting (without markdown or prose) to ensure seamless parsing by the downstream scoring pipeline.
