### PR TITLE
Support timeout configuration for Antigravity (agy) CLI generator

### DIFF
--- a/datasets/model_configs/agy_cli_model.yaml
+++ b/datasets/model_configs/agy_cli_model.yaml
@@ -11,6 +11,9 @@ generator: agy_cli
 # model. Omit this key to leave the flag off, so agy uses its own default.
 model: "Gemini 3.1 Pro (High)"
 
+# Timeout for print mode wait (default 5m). Passed via --print-timeout.
+timeout: "20m"
+
 env:
   # Set to your project, or export EVAL_GCP_PROJECT_ID and keep the !ENV form.
   # Key stays GOOGLE_CLOUD_PROJECT -- the var the agy subprocess reads.

--- a/docs/agy_cli_agent_testing.md
+++ b/docs/agy_cli_agent_testing.md
@@ -182,6 +182,7 @@ reporting:
 |-----|----------|-------------|
 | `generator` | Yes | Must be `agy_cli` |
 | `model` | Optional | agy UI model label, e.g. `"Gemini 3.1 Pro (High)"`. Passed via the `--model` flag. Must be a valid label, not an API id. |
+| `timeout` | Optional | Timeout duration string, e.g. `"20m"`. Passed via the `--print-timeout` flag. If omitted, defaults to agy's internal default (5 minutes). |
 | `env` | Optional | Environment variables passed to the CLI process |
 | `setup` | Optional | Tool setup block containing `mcp_servers`, `skills`, or `fake_mcp_servers` |
 

--- a/evalbench/generators/models/agy_cli.py
+++ b/evalbench/generators/models/agy_cli.py
@@ -33,7 +33,8 @@ class AgyCliGenerator(AgentCliGenerator):
     """Generator that queries via the Antigravity CLI (``agy``).
 
     The eval turn runs ``agy -p <prompt> --dangerously-skip-permissions
-    --output-format stream-json [--model <label>] [--continue]``. The on-disk
+    --output-format stream-json [--model <label>] [--print-timeout <timeout>]
+    [--continue]``. The on-disk
     layout lives under ``~/.gemini/antigravity-cli/`` (the binary calls this
     ``appDataDir``). Skills are delivered via plugins (see _setup_skills).
     ``--output-format stream-json`` emits newline-delimited events (an
@@ -59,6 +60,7 @@ class AgyCliGenerator(AgentCliGenerator):
         # flag (None -> flag omitted). See _base_agy_command for the value
         # format and resolution semantics.
         self.model = querygenerator_config.get("model")
+        self.timeout = querygenerator_config.get("timeout")
 
         # Order is load-bearing: paths/dirs must exist before the binary
         # installs and settings/auth write into them, and self.env must carry
@@ -441,7 +443,9 @@ class AgyCliGenerator(AgentCliGenerator):
         before = set(os.listdir(log_dir)) if os.path.isdir(log_dir) else set()
 
         env = self._merged_env()
-        cmd = self._base_agy_command(self.agy_bin, "ping", model=self.model)
+        cmd = self._base_agy_command(
+            self.agy_bin, "ping", model=self.model, timeout=self.timeout
+        )
         try:
             subprocess.run(
                 cmd, env=env, cwd=self.fake_home,
@@ -755,6 +759,7 @@ class AgyCliGenerator(AgentCliGenerator):
     def _base_agy_command(
         cli: str, prompt: str, resume: bool = False, model: str = None,
         output_format: str = None, log_file: str = None,
+        timeout: str = None,
     ) -> list:
         """Builds the non-interactive ``agy -p`` argv shared by the eval
         turn path and the setup-time MCP probe.
@@ -779,6 +784,8 @@ class AgyCliGenerator(AgentCliGenerator):
             command += ["--output-format", output_format]
         if log_file:
             command += ["--log-file", log_file]
+        if timeout:
+            command += ["--print-timeout", timeout]
         if resume:
             command.append("--continue")
         return command
@@ -818,6 +825,7 @@ class AgyCliGenerator(AgentCliGenerator):
         command = self._base_agy_command(
             self.agy_bin, cli_cmd.prompt, cli_cmd.resume, self.model,
             output_format="stream-json", log_file=self.cli_log_path,
+            timeout=self.timeout,
         )
         cwd = cli_cmd.cwd if cli_cmd.cwd else self.fake_home
         result = self._execute_cli_command(command, env=env, cwd=cwd)

--- a/evalbench/generators/models/agy_cli.py
+++ b/evalbench/generators/models/agy_cli.py
@@ -62,6 +62,8 @@ class AgyCliGenerator(AgentCliGenerator):
         self.model = querygenerator_config.get("model")
         self.timeout = querygenerator_config.get("timeout")
 
+        self._validate_timeout(self.timeout)
+
         # Order is load-bearing: paths/dirs must exist before the binary
         # installs and settings/auth write into them, and self.env must carry
         # HOME before the installer stages files (and auth resolves ADC) into
@@ -75,6 +77,21 @@ class AgyCliGenerator(AgentCliGenerator):
         self.setup_config = querygenerator_config.get("setup", {})
         if self.setup_config:
             self._setup_tools()
+
+    @staticmethod
+    def _validate_timeout(timeout):
+        if timeout is not None:
+            if not isinstance(timeout, str):
+                raise TypeError(
+                    "timeout must be a string (e.g., '20m', '1h30m', '300s')"
+                )
+            # Strict regex for common units (s, m, h).
+            # Allows things like "20m", "1h30m", "300s".
+            if not re.match(r'^(\d+(s|m|h))+$', timeout):
+                raise ValueError(
+                    f"Invalid timeout format: '{timeout}'. "
+                    "Must be a valid duration string (e.g., '20m', '1h30m', '300s')."
+                )
 
     def _init_paths(self, querygenerator_config):
         """Resolves the sandbox ``HOME`` and all derived agy paths, and
@@ -444,7 +461,7 @@ class AgyCliGenerator(AgentCliGenerator):
 
         env = self._merged_env()
         cmd = self._base_agy_command(
-            self.agy_bin, "ping", model=self.model, timeout=self.timeout
+            self.agy_bin, "ping", model=self.model
         )
         try:
             subprocess.run(
@@ -456,8 +473,8 @@ class AgyCliGenerator(AgentCliGenerator):
             raise RuntimeError(
                 f"agy MCP verification probe failed to run: {e}. "
                 f"Configured MCP servers: {configured_servers}.\n"
-                f"STDOUT:\n{getattr(e, 'stdout', '')}\n"
-                f"STDERR:\n{getattr(e, 'stderr', '')}"
+                f"STDOUT: \n{getattr(e, 'stdout', '')}\n"
+                f"STDERR: \n{getattr(e, 'stderr', '')}"
             ) from e
 
         # Collect fatal log markers (diagnostic context for any failure).
@@ -776,6 +793,9 @@ class AgyCliGenerator(AgentCliGenerator):
 
         ``log_file`` maps to ``--log-file``, pinning the CLI log to a known
         path for deterministic model detection.
+
+        ``timeout`` maps to ``--print-timeout`` (e.g. "20m"). If omitted,
+        defaults to agy's internal default (5 minutes).
         """
         command = [cli, "-p", prompt, "--dangerously-skip-permissions"]
         if model:

--- a/evalbench/test/agy_cli_test.py
+++ b/evalbench/test/agy_cli_test.py
@@ -282,6 +282,19 @@ def test_run_command_argv_shape_with_continue(mock_run, sandbox):
     ]
 
 
+def test_run_command_argv_shape_with_timeout(mock_run, sandbox):
+    generator = AgyCliGenerator({"timeout": "20m"})
+    cmd = CLICommand(cli="agy", prompt="hello world")
+    generator._run_agy_cli(cmd)
+
+    sent_argv = mock_run.call_args[0][0]
+    assert sent_argv == [
+        generator.agy_bin, "-p", "hello world",
+        "--dangerously-skip-permissions", "--output-format", "stream-json",
+        "--log-file", generator.cli_log_path, "--print-timeout", "20m",
+    ]
+
+
 def test_run_agy_cli_parses_stream_on_nonzero_exit(mock_run, sandbox):
     """A timed-out/errored run exits non-zero but still emits a full stream
     ending in an ERROR result -- its usage tokens and tool calls must be kept,

--- a/evalbench/test/agy_cli_test.py
+++ b/evalbench/test/agy_cli_test.py
@@ -282,6 +282,28 @@ def test_run_command_argv_shape_with_continue(mock_run, sandbox):
     ]
 
 
+def test_init_raises_on_non_string_timeout(sandbox):
+    """The generator should raise TypeError if timeout is not a string."""
+    with pytest.raises(TypeError, match="timeout must be a string"):
+        AgyCliGenerator({"timeout": 20})
+
+
+def test_init_raises_on_invalid_timeout_format(sandbox):
+    """The generator should raise ValueError if timeout format is invalid."""
+    invalid_timeouts = ["20", "20 minutes", "20d", "abc", "m", "20m10"]
+    for timeout in invalid_timeouts:
+        with pytest.raises(ValueError, match="Invalid timeout format"):
+            AgyCliGenerator({"timeout": timeout})
+
+
+def test_init_accepts_valid_timeout_formats(sandbox):
+    """The generator should accept valid timeout formats without raising."""
+    valid_timeouts = ["20m", "300s", "1h30m", "1h", "10s"]
+    for timeout in valid_timeouts:
+        gen = AgyCliGenerator({"timeout": timeout})
+        assert gen.timeout == timeout
+
+
 def test_run_command_argv_shape_with_timeout(mock_run, sandbox):
     generator = AgyCliGenerator({"timeout": "20m"})
     cmd = CLICommand(cli="agy", prompt="hello world")


### PR DESCRIPTION

**Overview**
The `agy` CLI defaults to a 5-minute timeout for agent execution. Some complex tasks require more time, and previously this behavior would cause the agent to terminate prematurely during evaluation runs. This PR introduces the ability to configure an explicit timeout limit for `agy` execution directly from the model configuration.

**Changes**
*   **`AgyCliGenerator`**: Added parsing for the `timeout` key in `querygenerator_config`.
*   **Command Execution**: Updated `_base_agy_command` to accept a `timeout` argument. If provided, the generator now automatically translates this into the `--print-timeout <timeout>` flag when invoking `agy`.
*   **Documentation**: Updated `docs/agy_cli_agent_testing.md` to document the new `timeout` field in the Model Configuration. Also updated the class docstring in `agy_cli.py`.
*   **Testing**: Added `test_run_command_argv_shape_with_timeout` to `agy_cli_test.py` to verify the argv shaping correctly includes `--print-timeout`. 

**Example Usage**
In an agy model configuration file (e.g., `agy_cli_model.yaml`):
```yaml
generator: agy_cli
model: "Gemini 3.1 Pro"
timeout: "20m"       
```