### PR TITLE
Add allow_extra_skills config option to SkillsTrajectoryMatcher

### DIFF
--- a/evalbench/scorers/skillstrajectorymatcher.py
+++ b/evalbench/scorers/skillstrajectorymatcher.py
@@ -1,8 +1,9 @@
 """
 SkillsTrajectoryMatcher
 
-Compares expected activated skills vs actual activated skill names,
-using the same Jaccard/Levenshtein approach as TrajectoryMatcher.
+Compares expected activated skills vs actual activated skill names.
+Supports flexible coverage matching (when ignore_extra_skills is True),
+Jaccard set similarity (default), and strict Levenshtein sequence alignment.
 """
 from typing import Tuple, Any, List
 from scorers import comparator
@@ -22,6 +23,7 @@ class SkillsTrajectoryMatcher(comparator.Comparator):
         self.name = "skills_trajectory"
         self.config = config
         self.enforce_order = config.get("enforce_order", False)
+        self.ignore_extra_skills = config.get("ignore_extra_skills", False)
 
     def _levenshtein_distance(self, seq1: List[str], seq2: List[str]) -> int:
         n, m = len(seq1), len(seq2)
@@ -85,8 +87,8 @@ class SkillsTrajectoryMatcher(comparator.Comparator):
         if not isinstance(expected, list) or not isinstance(actual, list):
             return 0.0, "Skills data must be lists."
 
-        if not expected and not actual:
-            return 100.0, "Both expected and actual skill lists are empty."
+        if not expected:
+            return 100.0, "No expected skills specified."
 
         if self.enforce_order:
             distance = self._levenshtein_distance(expected, actual)
@@ -98,6 +100,16 @@ class SkillsTrajectoryMatcher(comparator.Comparator):
                 f"Skills Sequence Alignment: {score:.2f} "
                 f"(Distance: {distance}, Max: {max_len}). "
                 f"Expected: {expected}, Actual: {actual}"
+            )
+        elif self.ignore_extra_skills:
+            expected_set = set(expected)
+            actual_set = set(actual)
+            matched = expected_set & actual_set
+            similarity = len(matched) / len(expected_set)
+            score = similarity * 100.0
+            return score, (
+                f"Skills Coverage (ignore_extra_skills=True): {score:.2f}%. "
+                f"Expected: {expected_set}, Actual: {actual_set}, Matched: {matched}"
             )
         else:
             similarity = self._jaccard_similarity(set(expected), set(actual))

--- a/evalbench/scorers/skillstrajectorymatcher.py
+++ b/evalbench/scorers/skillstrajectorymatcher.py
@@ -92,16 +92,11 @@ class SkillsTrajectoryMatcher(comparator.Comparator):
         if not isinstance(expected, list) or not isinstance(actual, list):
             return 0.0, "Skills data must be lists."
 
-        if not expected:
-            if not actual:
-                return 100.0, "Both expected and actual skill lists are empty."
-            elif self.allow_extra_skills:
-                return 100.0, "No expected skills required and extra skills are allowed."
-            else:
-                actual_set = set(actual)
-                return 0.0, (
-                    f"Skills Jaccard Similarity: 0.00. Expected: set(), Actual: {actual_set}"
-                )
+        if not expected and not actual:
+            return 100.0, "Both expected and actual skill lists are empty."
+
+        if not expected and self.allow_extra_skills:
+            return 100.0, "No expected skills specified and extra skills are allowed."
 
         if self.enforce_order:
             distance = self._levenshtein_distance(expected, actual)

--- a/evalbench/scorers/skillstrajectorymatcher.py
+++ b/evalbench/scorers/skillstrajectorymatcher.py
@@ -25,6 +25,11 @@ class SkillsTrajectoryMatcher(comparator.Comparator):
         self.enforce_order = config.get("enforce_order", False)
         self.allow_extra_skills = config.get("allow_extra_skills", False)
 
+        if self.enforce_order and self.allow_extra_skills:
+            raise ValueError(
+                "Cannot set both 'enforce_order' and 'allow_extra_skills' to True."
+            )
+
     def _levenshtein_distance(self, seq1: List[str], seq2: List[str]) -> int:
         n, m = len(seq1), len(seq2)
         if n == 0:

--- a/evalbench/scorers/skillstrajectorymatcher.py
+++ b/evalbench/scorers/skillstrajectorymatcher.py
@@ -2,7 +2,7 @@
 SkillsTrajectoryMatcher
 
 Compares expected activated skills vs actual activated skill names.
-Supports flexible coverage matching (when ignore_extra_skills is True),
+Supports flexible coverage matching (when allow_extra_skills is True),
 Jaccard set similarity (default), and strict Levenshtein sequence alignment.
 """
 from typing import Tuple, Any, List
@@ -23,7 +23,7 @@ class SkillsTrajectoryMatcher(comparator.Comparator):
         self.name = "skills_trajectory"
         self.config = config
         self.enforce_order = config.get("enforce_order", False)
-        self.ignore_extra_skills = config.get("ignore_extra_skills", False)
+        self.allow_extra_skills = config.get("allow_extra_skills", False)
 
     def _levenshtein_distance(self, seq1: List[str], seq2: List[str]) -> int:
         n, m = len(seq1), len(seq2)
@@ -88,7 +88,15 @@ class SkillsTrajectoryMatcher(comparator.Comparator):
             return 0.0, "Skills data must be lists."
 
         if not expected:
-            return 100.0, "No expected skills specified."
+            if not actual:
+                return 100.0, "Both expected and actual skill lists are empty."
+            elif self.allow_extra_skills:
+                return 100.0, "No expected skills required and extra skills are allowed."
+            else:
+                actual_set = set(actual)
+                return 0.0, (
+                    f"Skills Jaccard Similarity: 0.00. Expected: set(), Actual: {actual_set}"
+                )
 
         if self.enforce_order:
             distance = self._levenshtein_distance(expected, actual)
@@ -101,14 +109,14 @@ class SkillsTrajectoryMatcher(comparator.Comparator):
                 f"(Distance: {distance}, Max: {max_len}). "
                 f"Expected: {expected}, Actual: {actual}"
             )
-        elif self.ignore_extra_skills:
+        elif self.allow_extra_skills:
             expected_set = set(expected)
             actual_set = set(actual)
             matched = expected_set & actual_set
             similarity = len(matched) / len(expected_set)
             score = similarity * 100.0
             return score, (
-                f"Skills Coverage (ignore_extra_skills=True): {score:.2f}%. "
+                f"Skills Coverage (allow_extra_skills=True): {score:.2f}%. "
                 f"Expected: {expected_set}, Actual: {actual_set}, Matched: {matched}"
             )
         else:

--- a/evalbench/test/skillstrajectorymatcher_test.py
+++ b/evalbench/test/skillstrajectorymatcher_test.py
@@ -88,6 +88,12 @@ class SkillsTrajectoryMatcherTest(unittest.TestCase):
         self.assertLess(score, 100.0)
         self.assertIn("Sequence Alignment", explanation)
 
+    def test_empty_expected_skills_with_extra_skills_when_enforce_order_true(self):
+        matcher = SkillsTrajectoryMatcher({"enforce_order": True})
+        score, explanation = _compare(matcher, [], ["dataform_bigquery"])
+        self.assertEqual(score, 0.0)
+        self.assertIn("Sequence Alignment", explanation)
+
     def test_invalid_config_combination_raises_error(self):
         with self.assertRaises(ValueError):
             SkillsTrajectoryMatcher({"enforce_order": True, "allow_extra_skills": True})

--- a/evalbench/test/skillstrajectorymatcher_test.py
+++ b/evalbench/test/skillstrajectorymatcher_test.py
@@ -88,6 +88,10 @@ class SkillsTrajectoryMatcherTest(unittest.TestCase):
         self.assertLess(score, 100.0)
         self.assertIn("Sequence Alignment", explanation)
 
+    def test_invalid_config_combination_raises_error(self):
+        with self.assertRaises(ValueError):
+            SkillsTrajectoryMatcher({"enforce_order": True, "allow_extra_skills": True})
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/evalbench/test/skillstrajectorymatcher_test.py
+++ b/evalbench/test/skillstrajectorymatcher_test.py
@@ -35,11 +35,23 @@ def _compare(matcher, expected_skills, accumulated_skills):
 
 class SkillsTrajectoryMatcherTest(unittest.TestCase):
 
-    def test_empty_expected_skills_returns_full_score(self):
+    def test_both_empty_returns_full_score(self):
         matcher = SkillsTrajectoryMatcher({})
+        score, explanation = _compare(matcher, [], [])
+        self.assertEqual(score, 100.0)
+        self.assertIn("Both expected and actual skill lists are empty", explanation)
+
+    def test_empty_expected_skills_with_extra_skills_when_allow_extra_false(self):
+        matcher = SkillsTrajectoryMatcher({"allow_extra_skills": False})
+        score, explanation = _compare(matcher, [], ["dataform_bigquery"])
+        self.assertEqual(score, 0.0)
+        self.assertIn("Jaccard Similarity: 0.00", explanation)
+
+    def test_empty_expected_skills_with_extra_skills_when_allow_extra_true(self):
+        matcher = SkillsTrajectoryMatcher({"allow_extra_skills": True})
         score, explanation = _compare(matcher, [], ["dataform_bigquery"])
         self.assertEqual(score, 100.0)
-        self.assertIn("No expected skills specified", explanation)
+        self.assertIn("extra skills are allowed", explanation)
 
     def test_default_uses_jaccard_similarity(self):
         matcher = SkillsTrajectoryMatcher({})
@@ -50,17 +62,17 @@ class SkillsTrajectoryMatcherTest(unittest.TestCase):
         self.assertEqual(score, 50.0)
         self.assertIn("Jaccard Similarity", explanation)
 
-    def test_ignore_extra_skills_enabled(self):
-        matcher = SkillsTrajectoryMatcher({"ignore_extra_skills": True})
+    def test_allow_extra_skills_enabled(self):
+        matcher = SkillsTrajectoryMatcher({"allow_extra_skills": True})
         expected = ["dataform_bigquery"]
         actual = ["dataform_bigquery", "gcp_pipeline_orchestration"]
 
         score, explanation = _compare(matcher, expected, actual)
         self.assertEqual(score, 100.0)
-        self.assertIn("ignore_extra_skills=True", explanation)
+        self.assertIn("allow_extra_skills=True", explanation)
 
     def test_partial_coverage(self):
-        matcher = SkillsTrajectoryMatcher({"ignore_extra_skills": True})
+        matcher = SkillsTrajectoryMatcher({"allow_extra_skills": True})
         expected = ["dataform_bigquery", "dbt_bigquery"]
         actual = ["dataform_bigquery"]
 

--- a/evalbench/test/skillstrajectorymatcher_test.py
+++ b/evalbench/test/skillstrajectorymatcher_test.py
@@ -1,0 +1,81 @@
+"""Unit tests for SkillsTrajectoryMatcher."""
+
+import json
+import os
+import sys
+import unittest
+
+sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from scorers.skillstrajectorymatcher import SkillsTrajectoryMatcher
+
+
+def _make_context(expected_skills, accumulated_skills):
+    return json.dumps({
+        "scenario": {"expected_skills": expected_skills},
+        "accumulated_skills": accumulated_skills,
+    })
+
+
+def _compare(matcher, expected_skills, accumulated_skills):
+    context = _make_context(expected_skills, accumulated_skills)
+    return matcher.compare(
+        nl_prompt=None,
+        golden_query=None,
+        query_type=None,
+        golden_execution_result=None,
+        golden_eval_result=None,
+        golden_error=None,
+        generated_query=None,
+        generated_execution_result=None,
+        generated_eval_result=context,
+        generated_error=None,
+    )
+
+
+class SkillsTrajectoryMatcherTest(unittest.TestCase):
+
+    def test_empty_expected_skills_returns_full_score(self):
+        matcher = SkillsTrajectoryMatcher({})
+        score, explanation = _compare(matcher, [], ["dataform_bigquery"])
+        self.assertEqual(score, 100.0)
+        self.assertIn("No expected skills specified", explanation)
+
+    def test_default_uses_jaccard_similarity(self):
+        matcher = SkillsTrajectoryMatcher({})
+        expected = ["dataform_bigquery"]
+        actual = ["dataform_bigquery", "gcp_pipeline_orchestration"]
+
+        score, explanation = _compare(matcher, expected, actual)
+        self.assertEqual(score, 50.0)
+        self.assertIn("Jaccard Similarity", explanation)
+
+    def test_ignore_extra_skills_enabled(self):
+        matcher = SkillsTrajectoryMatcher({"ignore_extra_skills": True})
+        expected = ["dataform_bigquery"]
+        actual = ["dataform_bigquery", "gcp_pipeline_orchestration"]
+
+        score, explanation = _compare(matcher, expected, actual)
+        self.assertEqual(score, 100.0)
+        self.assertIn("ignore_extra_skills=True", explanation)
+
+    def test_partial_coverage(self):
+        matcher = SkillsTrajectoryMatcher({"ignore_extra_skills": True})
+        expected = ["dataform_bigquery", "dbt_bigquery"]
+        actual = ["dataform_bigquery"]
+
+        score, explanation = _compare(matcher, expected, actual)
+        self.assertEqual(score, 50.0)
+
+    def test_enforce_order(self):
+        matcher = SkillsTrajectoryMatcher({"enforce_order": True})
+        expected = ["skill_a", "skill_b"]
+        actual = ["skill_b", "skill_a"]
+
+        score, explanation = _compare(matcher, expected, actual)
+        self.assertLess(score, 100.0)
+        self.assertIn("Sequence Alignment", explanation)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Summary of Changes

- **Added `allow_extra_skills` Config Flag**: Added `allow_extra_skills` configuration option to `SkillsTrajectoryMatcher` (defaults to `False` for backward compatibility).
- **Skill Coverage Matching**: When `allow_extra_skills: true` is configured, evaluates skill recall/coverage ($\frac{|\text{expected} \cap \text{actual}|}{|\text{expected}|}$) without penalizing extra activated skills.
- **Empty `expected_skills` Handling**: Returns `100.0%` score if `expected_skills` is empty/omitted and `allow_extra_skills: true`, preserving legacy Jaccard behavior when `allow_extra_skills: false`.
- **Unit Tests**: Added unit test suite in `evalbench/test/skillstrajectorymatcher_test.py` covering coverage matching, backward compatibility, and empty expected skill sets.