### PR TITLE
feat(dea): add autopush option to model_env and update documentation

### DIFF
--- a/datasets/dea-tools/README.md
+++ b/datasets/dea-tools/README.md
@@ -46,15 +46,15 @@ gcp_project_id: !ENV ${EVAL_GCP_PROJECT_ID}
 gcp_region: !ENV ${EVAL_GCP_PROJECT_REGION}
 
 # Parameterized Agent Options:
-model_env: local                # Target environment: "local", "staging", or "prod" (defaults to "prod")
-port: 9876                      # Required port for local Boq servers when env="local"
+model_env: local                # Target environment: "local", "staging", "autopush", or "prod" (defaults to "prod")
+port: 9876                      # Required port for local Boq servers when model_env="local"
 agent_type: sparkagent          # Desired agent persona (e.g., "sparkagent", "dataengineeringagent")
 
 ```
 
-* **`model_env`**: Configures the host environment (`local` uses `http://localhost:{port}`, `staging` uses `https://staging-geminidataanalytics.sandbox.googleapis.com`, `prod` uses `https://geminidataanalytics.googleapis.com`).
+* **`model_env`**: Configures the host environment (`local` uses `http://localhost:{port}`, `staging` uses `https://staging-geminidataanalytics.sandbox.googleapis.com`, `autopush` uses `https://autopush-geminidataanalytics.sandbox.googleapis.com`, `prod` uses `https://geminidataanalytics.googleapis.com`).
 
-* **`port`**: Specifies the HTTP port for local Boq servers (required when `env="local"`).
+* **`port`**: Specifies the HTTP port for local Boq servers (required when `model_env="local"`).
 * **`agent_type`**: Sets the desired agent persona (e.g., "sparkagent", "dataengineeringagent").
 
 ## 4. Run EvalBench

--- a/evalbench/generators/models/gcp_data_engineering_agent.py
+++ b/evalbench/generators/models/gcp_data_engineering_agent.py
@@ -340,12 +340,17 @@ class DataEngineeringAgentGenerator(QueryGenerator):
                 "https://staging-geminidataanalytics."
                 "sandbox.googleapis.com"
             )
+        elif env == "autopush":
+            host = (
+                "https://autopush-geminidataanalytics."
+                "sandbox.googleapis.com"
+            )
         elif env == "prod":
             host = "https://geminidataanalytics.googleapis.com"
         else:
             raise ValueError(
                 f"Unsupported env: '{env}'. "
-                "Expected 'local', 'staging', or 'prod'."
+                "Expected 'local', 'staging', 'autopush', or 'prod'."
             )
 
         self.endpoint = (

--- a/evalbench/test/gcp_data_engineering_agent_test.py
+++ b/evalbench/test/gcp_data_engineering_agent_test.py
@@ -186,6 +186,25 @@ def test_generator_parameterized_staging_env(valid_config):
         assert generator.agent_type_uri is None
 
 
+def test_generator_parameterized_autopush_env(valid_config):
+    config = valid_config.copy()
+    config["model_env"] = "autopush"
+    with patch("google.auth.default") as mock_auth_default:
+        mock_creds = MagicMock()
+        mock_creds.valid = True
+        mock_auth_default.return_value = (mock_creds, "test-project")
+
+        generator = DataEngineeringAgentGenerator(config)
+
+        expected_endpoint = (
+            "https://autopush-geminidataanalytics.sandbox.googleapis.com/"
+            "v1/a2a/projects/test-project-123/locations/us-east1/agents/"
+            "dataengineeringagent"
+        )
+        assert generator.endpoint == expected_endpoint
+        assert generator.agent_type_uri is None
+
+
 def test_generator_parameterized_sparkagent(valid_config):
     config = valid_config.copy()
     config["model_env"] = "staging"


### PR DESCRIPTION
Adds support for setting `model_env: autopush` in DataEngineeringAgent generator configs and updates the documentation to correctly document parameter names.