### PR TITLE
refactor(reporting): rename BigQuery dataset_name config to dataset_id

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -224,7 +224,7 @@ To upload metrics directly to Google BigQuery and create Looker Studio dashboard
 reporting:
   bigquery:
     gcp_project_id: 'your-gcp-project-id'
-    dataset_name: 'evalbench' # Optional, defaults to 'evalbench'
+    dataset_id: 'evalbench' # Optional, defaults to 'evalbench'
     dataset_location: 'US' # Optional, defaults to 'US'
 ```
 

--- a/docs/configs/run-config.md
+++ b/docs/configs/run-config.md
@@ -92,7 +92,7 @@ The `reporting` section specifies how and where the evaluation results will be r
 | ---------- | ------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `truncate_execution_outputs`| Optional (defaults to 250 rows)          | This allows overriding the truncation of outputs in reporting (CSVs, BQ) to the number of rows specified. This affects the following reporting fields: `generated_result`, `golden_result`, `golden_eval_results` `eval_results`. This prevents logging incredibly large results with potentially thousands or millions of rows. *NOTE: This does not affect any logic other than reporting.* |
 | `csv`      | Optional     | Configuration for CSV reporting. <br>**Subkey:** `output_directory` specifies the directory where CSV results will be saved (e.g., `'results'`).          |
-| `bigquery` | Optional     | Configuration for reporting to Google BigQuery. <br>**Subkeys:** `gcp_project_id` specifies the Google Cloud Project ID for BigQuery integration (e.g., `my_cool_gcp_project`). `dataset_name` overrides the BigQuery dataset that results are written to (`<project>.<dataset_name>`), defaulting to `evalbench`. |
+| `bigquery` | Optional     | Configuration for reporting to Google BigQuery. <br>**Subkeys:** `gcp_project_id` specifies the Google Cloud Project ID for BigQuery integration (e.g., `my_cool_gcp_project`). `dataset_id` overrides the BigQuery dataset that results are written to (`<project>.<dataset_id>`), defaulting to `evalbench`. |
 
 ---
 > bigquery project_id: You can globally set your GCP project_id using the environment variables `EVAL_GCP_PROJECT_ID` or identify it separately.
@@ -141,5 +141,5 @@ reporting:
     output_directory: 'results'
   bigquery:
     gcp_project_id: my_cool_gcp_project
-    dataset_name: evalbench # Optional, defaults to 'evalbench'
+    dataset_id: evalbench # Optional, defaults to 'evalbench'
 ```

--- a/evalbench/reporting/bqstore.py
+++ b/evalbench/reporting/bqstore.py
@@ -88,12 +88,12 @@ class BigQueryReporter(Reporter):
             reporting_config.get("gcp_project_id"))
         self.location = reporting_config.get("dataset_location") or "US"
         self.client = bigquery.Client(project=self.project_id)
-        self.dataset_name = reporting_config.get("dataset_name") or "evalbench"
-        self.dataset_id = "{}.{}".format(self.project_id, self.dataset_name)
-        self.configs_table = "{}.configs".format(self.dataset_id)
-        self.results_table = "{}.results".format(self.dataset_id)
-        self.scores_table = "{}.scores".format(self.dataset_id)
-        self.summary_table = "{}.summary".format(self.dataset_id)
+        self.dataset_id = reporting_config.get("dataset_id") or "evalbench"
+        self.dataset_path = "{}.{}".format(self.project_id, self.dataset_id)
+        self.configs_table = "{}.configs".format(self.dataset_path)
+        self.results_table = "{}.results".format(self.dataset_path)
+        self.scores_table = "{}.scores".format(self.dataset_path)
+        self.summary_table = "{}.summary".format(self.dataset_path)
 
         # Make chunk size configurable, defaulting to 500
         self.chunk_size = int(reporting_config.get(
@@ -104,7 +104,7 @@ class BigQueryReporter(Reporter):
             logging.info(f"No results to store for {type}")
             return
 
-        dataset = bigquery.Dataset(self.dataset_id)
+        dataset = bigquery.Dataset(self.dataset_path)
         dataset.location = self.location
         dataset = self.client.create_dataset(
             dataset, exists_ok=True, timeout=30)
@@ -199,7 +199,7 @@ class BigQueryReporter(Reporter):
         report_params = "{" + f'"eval_results.eval_id": "{self.job_id}"' + "}"
         report_query = _REPORT_QUERY.replace(
             "__PROJECT_ID__", self.project_id
-        ).replace("__DATASET__", self.dataset_name)
+        ).replace("__DATASET__", self.dataset_id)
         report_link = (
             "https://lookerstudio.google.com/reporting/create?"
             + "c.reportId=e7d7fc00-4268-45d6-b17b-160ca271a4d0"


### PR DESCRIPTION
## Summary
- Renames the `reporting.bigquery.dataset_name` config key (added in #522, released in 1.14.0) to `dataset_id`, matching BigQuery's own terminology — BQ calls the short dataset identifier the "dataset ID" (console field, `bq` CLI, and `bigquery.Dataset(...).dataset_id`).
- Renames the internal project-qualified `self.dataset_id` attribute (which held `<project>.<dataset>`) to `self.dataset_path`, avoiding a collision with the new short-name key.
- Updates docs (`docs/configs/run-config.md`) and `AGENTS.md` accordingly.

## Note
This is a breaking change to a config key first released in 1.14.0 (2026-07-24). Adoption should still be minimal, so renaming now is the cheapest window. No dual-key fallback is provided.

## Test plan
- [x] `python3 -m py_compile evalbench/reporting/bqstore.py`
- [x] Run with no `dataset_id` and confirm tables land in `<project>.evalbench.*` (default unchanged).
- [x] Run with `dataset_id: dataset_quality` and confirm the four tables are created under `<project>.dataset_quality.*`.
- [x] Confirm the printed dashboard link references the configured dataset.