### PR TITLE
fix(analyzer): aggregate binary_rubric_scorer results by matching comparator prefix

### DIFF
--- a/evalbench/reporting/analyzer.py
+++ b/evalbench/reporting/analyzer.py
@@ -53,7 +53,10 @@ def analyze_one_metric(
                 .drop_duplicates()
             )
     else:
-        df_metric = df[df["comparator"] == metric_name]
+        if metric_name == "binary_rubric_scorer":
+            df_metric = df[df["comparator"].astype(str).str.startswith("binary_rubric_scorer")]
+        else:
+            df_metric = df[df["comparator"] == metric_name]
 
         if (
             "prompt_id" in df_metric.columns

--- a/evalbench/test/binaryrubricscorer_test.py
+++ b/evalbench/test/binaryrubricscorer_test.py
@@ -98,6 +98,55 @@ class TestBinaryRubricScorer(unittest.TestCase):
         self.assertIn("No rubric defined", reason)
         mock_model.generate.assert_not_called()
 
+    def test_binary_rubric_scorer_aggregation(self):
+        from reporting.analyzer import analyze_result
+
+        scores = [
+            {
+                "id": "1",
+                "comparator": "binary_rubric_scorer_0",
+                "score": 100,
+                "generated_sql": "SELECT 1",
+                "generated_error": None,
+            },
+            {
+                "id": "1",
+                "comparator": "binary_rubric_scorer_1",
+                "score": 100,
+                "generated_sql": "SELECT 1",
+                "generated_error": None,
+            },
+            {
+                "id": "2",
+                "comparator": "binary_rubric_scorer_0",
+                "score": 0,
+                "generated_sql": "SELECT 1",
+                "generated_error": None,
+            },
+            {
+                "id": "2",
+                "comparator": "binary_rubric_scorer_1",
+                "score": 100,
+                "generated_sql": "SELECT 1",
+                "generated_error": None,
+            },
+        ]
+        experiment_config = {
+            "scorers": {
+                "binary_rubric_scorer": {
+                    "model_config": "fake_config"
+                }
+            }
+        }
+
+        _, summary_df = analyze_result(scores, experiment_config)
+        summary_dict = summary_df.set_index("metric_name").to_dict(orient="index")
+
+        self.assertIn("binary_rubric_scorer", summary_dict)
+        # Total scores = 4 rows, 3 scored 100 -> 3/4 = 75%
+        self.assertEqual(summary_dict["binary_rubric_scorer"]["correct_results_count"], 3)
+        self.assertEqual(summary_dict["binary_rubric_scorer"]["total_results_count"], 4)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Problem
In `binaryrubricscorer.py`, each rubric criterion sets its comparator name dynamically to `binary_rubric_scorer_0`, `binary_rubric_scorer_1`, etc. However, `analyzer.py` previously looked for exact match `df["comparator"] == "binary_rubric_scorer"`. As a result, 0 matching rows were found, causing binary rubric scoring summary aggregation to always report 0/0 (0.0% accuracy).

## Fix
Updated `evalbench/reporting/analyzer.py` so that when `metric_name == "binary_rubric_scorer"`, `df_metric` matches all comparator strings starting with `binary_rubric_scorer` (`df["comparator"].astype(str).str.startswith("binary_rubric_scorer")`).

## Testing
Added `test_binary_rubric_scorer_aggregation` to `evalbench/test/binaryrubricscorer_test.py`.
All 4 tests in `binaryrubricscorer_test.py` pass (`./.venv/bin/python -m unittest evalbench/test/binaryrubricscorer_test.py`).