### PR TITLE
refactor(scorers): simplify score.py with DEFAULT_SCORERS map and generic instance builder

### DIFF
--- a/evalbench/scorers/score.py
+++ b/evalbench/scorers/score.py
@@ -1,35 +1,137 @@
 import inspect
-
-from scorers import comparator
-from scorers import exactmatcher
-from scorers import generatedqueryregexpmatcher
-from scorers import recallmatcher
-from scorers import setmatcher
-from scorers import llmrater
-from scorers import returnedsql
-from scorers import executablesql
-from scorers import trajectorymatcher
-from scorers import skillstrajectorymatcher
-from scorers import goalcompletionrate
-from scorers import behavioralmetrics
-from scorers import parameteranalysis
-from scorers import skillsbestpractices
-from scorers import turncount
-from scorers import agentsteps
-from scorers import endtoendlatency
-from scorers import toolcalllatency
-from scorers import tokenconsumption
-from scorers import tokensprocessed
-from scorers import effectivebilledtokens
-from scorers import binaryrubricscorer
-from scorers import pythonscorer
-from scorers import dataformscorer
-from scorers import dataformcloudscorer
-from scorers import dbtscorer
-from scorers.dataset_quality.scorer import DatasetQualityScorer
-from dataset.evaloutput import EvalOutput
 import logging
 import os
+from typing import Any
+
+from dataset.evaloutput import EvalOutput
+from scorers import agentsteps
+from scorers import behavioralmetrics
+from scorers import binaryrubricscorer
+from scorers import comparator
+from scorers import dataformcloudscorer
+from scorers import dataformscorer
+from scorers import dbtscorer
+from scorers import effectivebilledtokens
+from scorers import endtoendlatency
+from scorers import executablesql
+from scorers import exactmatcher
+from scorers import generatedqueryregexpmatcher
+from scorers import goalcompletionrate
+from scorers import llmrater
+from scorers import parameteranalysis
+from scorers import pythonscorer
+from scorers import recallmatcher
+from scorers import returnedsql
+from scorers import setmatcher
+from scorers import skillsbestpractices
+from scorers import skillstrajectorymatcher
+from scorers import tokenconsumption
+from scorers import tokensprocessed
+from scorers import toolcalllatency
+from scorers import trajectorymatcher
+from scorers import turncount
+from scorers.dataset_quality.scorer import DatasetQualityScorer
+
+
+DEFAULT_SCORERS: dict[str, type[comparator.Comparator]] = {
+    "exact_match": exactmatcher.ExactMatcher,
+    "recall_match": recallmatcher.RecallMatcher,
+    "set_match": setmatcher.SetMatcher,
+    "llmrater": llmrater.LLMRater,
+    "regexp_matcher": generatedqueryregexpmatcher.GeneratedQueryRegexpMatcher,
+    "returned_sql": returnedsql.ReturnedSQL,
+    "executable_sql": executablesql.ExecutableGenerationScore,
+    "trajectory_matcher": trajectorymatcher.TrajectoryMatcher,
+    "skills_trajectory": skillstrajectorymatcher.SkillsTrajectoryMatcher,
+    "skills_best_practices": skillsbestpractices.SkillsBestPractices,
+    "goal_completion": goalcompletionrate.GoalCompletionRate,
+    "behavioral_metrics": behavioralmetrics.BehavioralMetrics,
+    "parameter_analysis": parameteranalysis.ParameterAnalysis,
+    "turn_count": turncount.TurnCount,
+    "agent_steps": agentsteps.AgentSteps,
+    "end_to_end_latency": endtoendlatency.EndToEndLatency,
+    "tool_call_latency": toolcalllatency.ToolCallLatency,
+    "token_consumption": tokenconsumption.TokenConsumption,
+    "tokens_processed": tokensprocessed.TokensProcessed,
+    "effective_billed_tokens": effectivebilledtokens.EffectiveBilledTokens,
+    "binary_rubric_scorer": binaryrubricscorer.BinaryRubricScorer,
+    "python_scorer": pythonscorer.PythonScorer,
+    "dataform_compile": dataformscorer.DataformCompileScorer,
+    "dataform_run": dataformscorer.DataformRunScorer,
+    "dataform_cloud_compile": dataformcloudscorer.DataformCloudCompileScorer,
+    "dataform_cloud_run": dataformcloudscorer.DataformCloudRunScorer,
+    "dbt_compile": dbtscorer.DbtCompileScorer,
+    "dbt_run": dbtscorer.DbtRunScorer,
+    "dataset_quality": DatasetQualityScorer,
+}
+
+
+def _build_instances(
+    scorer_cls: type[comparator.Comparator],
+    config: dict,
+    experiment_config: dict,
+    eval_output_item: EvalOutput,
+    global_models: Any,
+) -> list[comparator.Comparator]:
+    """Generically instantiate a comparator class using inspect.signature."""
+    config = dict(config) if isinstance(config, dict) else {}
+    sig_params = inspect.signature(scorer_cls.__init__).parameters
+
+    if "database_configs" in sig_params or scorer_cls in (llmrater.LLMRater, pythonscorer.PythonScorer):
+        config["database_configs"] = experiment_config.get("database_configs", [])
+
+    if scorer_cls == DatasetQualityScorer and not config.get("product_name"):
+        config["product_name"] = experiment_config.get("product_name")
+
+    if scorer_cls == binaryrubricscorer.BinaryRubricScorer:
+        import json
+        context_str = eval_output_item.get("eval_results", "") if eval_output_item else ""
+        try:
+            context = context_str if isinstance(context_str, dict) else (json.loads(context_str) if context_str else {})
+            rubric = context.get("scenario", {}).get("binary_rubric", [])
+            if rubric:
+                return [
+                    binaryrubricscorer.BinaryRubricScorer(
+                        config, global_models, criterion=c, index=i
+                    )
+                    for i, c in enumerate(rubric)
+                ]
+        except Exception:
+            pass
+        return [binaryrubricscorer.BinaryRubricScorer(config, global_models)]
+
+    kwargs = {}
+    if "global_models" in sig_params:
+        kwargs["global_models"] = global_models
+
+    if scorer_cls == pythonscorer.PythonScorer:
+        custom_name = config.get("scorer_name")
+        if not custom_name and config.get("script_path") and isinstance(config["script_path"], str):
+            custom_name = os.path.splitext(os.path.basename(config["script_path"]))[0].strip()
+        if custom_name:
+            kwargs["name"] = custom_name
+
+    return [scorer_cls(config, **kwargs)]
+
+
+def get_scorer_instance(
+    scorer_name: str,
+    scorer_config: dict,
+    experiment_config: dict,
+    eval_output_item: EvalOutput,
+    global_models: Any,
+) -> list[comparator.Comparator]:
+    """Resolve and return comparator instances for a given scorer config entry."""
+    if not isinstance(scorer_config, dict):
+        return []
+
+    # Direct match in global DEFAULT_SCORERS map
+    if scorer_name in DEFAULT_SCORERS:
+        return _build_instances(
+            DEFAULT_SCORERS[scorer_name], scorer_config, experiment_config, eval_output_item, global_models
+        )
+
+    return []
 
 
 def compare(
@@ -38,181 +140,13 @@ def compare(
     scoring_results: list[dict],
     global_models,
 ):
-    """Run comparators against eval output.
-
-    Args:
-      eval_output_item: EvalItemOutput object to compare.
-      experiment_config: Config for the scorers to run.
-    """
+    """Run comparators against eval output."""
     scorers = experiment_config["scorers"]
     comparators: list[comparator.Comparator] = []
-    if "exact_match" in scorers:
-        comparators.append(exactmatcher.ExactMatcher(scorers["exact_match"]))
-    if "recall_match" in scorers:
-        comparators.append(
-            recallmatcher.RecallMatcher(scorers["recall_match"]))
-    if "set_match" in scorers:
-        comparators.append(setmatcher.SetMatcher(scorers["set_match"]))
-    if "llmrater" in scorers:
-        llmrater_config = scorers["llmrater"]
-        llmrater_config["database_configs"] = experiment_config.get(
-            "database_configs", []
-        )
-        comparators.append(llmrater.LLMRater(llmrater_config, global_models))
-    if "regexp_matcher" in scorers:
-        comparators.append(
-            generatedqueryregexpmatcher.GeneratedQueryRegexpMatcher(
-                scorers["regexp_matcher"]
-            )
-        )
-    if "returned_sql" in scorers:
-        comparators.append(returnedsql.ReturnedSQL(scorers["returned_sql"]))
-    if "executable_sql" in scorers:
-        comparators.append(
-            executablesql.ExecutableGenerationScore(scorers["executable_sql"])
-        )
-    if "trajectory_matcher" in scorers:
-        comparators.append(
-            trajectorymatcher.TrajectoryMatcher(scorers["trajectory_matcher"])
-        )
-    if "skills_trajectory" in scorers:
-        comparators.append(
-            skillstrajectorymatcher.SkillsTrajectoryMatcher(scorers["skills_trajectory"])
-        )
-    if "skills_best_practices" in scorers:
-        comparators.append(
-            skillsbestpractices.SkillsBestPractices(
-                scorers["skills_best_practices"], global_models
-            )
-        )
-    if "goal_completion" in scorers:
-        comparators.append(
-            goalcompletionrate.GoalCompletionRate(
-                scorers["goal_completion"], global_models
-            )
-        )
-    if "behavioral_metrics" in scorers:
-        comparators.append(
-            behavioralmetrics.BehavioralMetrics(
-                scorers["behavioral_metrics"], global_models
-            )
-        )
-    if "parameter_analysis" in scorers:
-        comparators.append(
-            parameteranalysis.ParameterAnalysis(
-                scorers["parameter_analysis"], global_models
-            )
-        )
-    if "turn_count" in scorers:
-        comparators.append(
-            turncount.TurnCount(scorers["turn_count"])
-        )
-    if "agent_steps" in scorers:
-        comparators.append(
-            agentsteps.AgentSteps(scorers["agent_steps"])
-        )
-    if "end_to_end_latency" in scorers:
-        comparators.append(
-            endtoendlatency.EndToEndLatency(scorers["end_to_end_latency"])
-        )
-    if "tool_call_latency" in scorers:
-        comparators.append(
-            toolcalllatency.ToolCallLatency(scorers["tool_call_latency"])
-        )
-    if "token_consumption" in scorers:
-        comparators.append(
-            tokenconsumption.TokenConsumption(scorers["token_consumption"])
-        )
-    if "tokens_processed" in scorers:
-        comparators.append(
-            tokensprocessed.TokensProcessed(scorers["tokens_processed"])
-        )
-    if "effective_billed_tokens" in scorers:
-        comparators.append(
-            effectivebilledtokens.EffectiveBilledTokens(
-                scorers["effective_billed_tokens"]
-            )
-        )
-    if "binary_rubric_scorer" in scorers:
-        import json
 
-        context_str = eval_output_item.get("eval_results", "")
-        try:
-            if isinstance(context_str, dict):
-                context = context_str
-            else:
-                context = json.loads(context_str) if context_str else {}
-            rubric = context.get("scenario", {}).get("binary_rubric", [])
-            if rubric:
-                for index, criterion in enumerate(rubric):
-                    comparators.append(
-                        binaryrubricscorer.BinaryRubricScorer(
-                            scorers["binary_rubric_scorer"], global_models,
-                            criterion=criterion, index=index
-                        )
-                    )
-            else:
-                comparators.append(
-                    binaryrubricscorer.BinaryRubricScorer(
-                        scorers["binary_rubric_scorer"], global_models
-                    )
-                )
-        except Exception:
-
-            comparators.append(
-                binaryrubricscorer.BinaryRubricScorer(
-                    scorers["binary_rubric_scorer"], global_models
-                )
-            )
-    for key, scorer_config in scorers.items():
-        if key == "python_scorer":
-            custom_name = scorer_config.get("scorer_name")
-            if custom_name and isinstance(custom_name, str):
-                custom_name = custom_name.strip()
-            if not custom_name:
-                script_path = scorer_config.get("script_path")
-                if script_path and isinstance(script_path, str) and script_path.strip():
-                    custom_name = os.path.splitext(os.path.basename(script_path))[0].strip()
-                if not custom_name:
-                    custom_name = key
-            scorer_config["database_configs"] = experiment_config.get(
-                "database_configs", []
-            )
-            comparators.append(pythonscorer.PythonScorer(scorer_config, name=custom_name))
-    if "dataform_compile" in scorers:
-        comparators.append(
-            dataformscorer.DataformCompileScorer(scorers["dataform_compile"])
-        )
-    if "dataform_run" in scorers:
-        comparators.append(
-            dataformscorer.DataformRunScorer(scorers["dataform_run"])
-        )
-    if "dataform_cloud_compile" in scorers:
-        comparators.append(
-            dataformcloudscorer.DataformCloudCompileScorer(
-                scorers["dataform_cloud_compile"]
-            )
-        )
-    if "dataform_cloud_run" in scorers:
-        comparators.append(
-            dataformcloudscorer.DataformCloudRunScorer(
-                scorers["dataform_cloud_run"]
-            )
-        )
-    if "dbt_compile" in scorers:
-        comparators.append(
-            dbtscorer.DbtCompileScorer(scorers["dbt_compile"])
-        )
-    if "dbt_run" in scorers:
-        comparators.append(
-            dbtscorer.DbtRunScorer(scorers["dbt_run"])
-        )
-    if "dataset_quality" in scorers:
-        scorers["dataset_quality"]["product_name"] = experiment_config.get(
-            "product_name"
-        )
-        comparators.append(
-            DatasetQualityScorer(scorers["dataset_quality"], global_models)
+    for name, config in scorers.items():
+        comparators.extend(
+            get_scorer_instance(name, config, experiment_config, eval_output_item, global_models)
         )
 
     for comp in comparators:
@@ -222,15 +156,10 @@ def compare(
         rows: list = []
         try:
             if eval_output_item["generated_sql"] is not None:
-                # Dynamically inspect signature to only pass the 'database'
-                # parameter to comparators that explicitly support it,
-                # preventing TypeError crashes in other framework scorers.
-                compare_signature = inspect.signature(comp.compare)
+                sig = inspect.signature(comp.compare)
                 compare_kwargs = {}
-                if "database" in compare_signature.parameters:
-                    compare_kwargs["database"] = (
-                        eval_output_item.get("database", "")
-                    )
+                if "database" in sig.parameters:
+                    compare_kwargs["database"] = eval_output_item.get("database", "")
                 result = comp.compare(
                     eval_output_item["nl_prompt"],
                     eval_output_item["golden_sql"],
@@ -253,16 +182,18 @@ def compare(
             rows = [(comp.name, 0, None, e)]
         if not rows:
             rows = [(comp.name, 0, None, None)]
-        for name, score, logs, error in rows:
+        for name, score_val, logs, error in rows:
             score_dict = comparator.ComparisonResult(
-                comp, score, comparison_logs=logs, comparison_error=error
+                comp, score_val, comparison_logs=logs, comparison_error=error
             ).to_dict()
             score_dict["comparator"] = name
-            score_dict["id"] = eval_output_item["id"]
-            score_dict["generated_sql"] = eval_output_item["generated_sql"]
-            score_dict["generated_error"] = eval_output_item["generated_error"]
-            score_dict["dialects"] = eval_output_item["dialects"]
-            score_dict["database"] = eval_output_item["database"]
-            score_dict["job_id"] = eval_output_item["job_id"]
-            logging.debug("scoring: %s %s %s", score_dict["id"], name, score)
+            score_dict.update({
+                "id": eval_output_item["id"],
+                "generated_sql": eval_output_item["generated_sql"],
+                "generated_error": eval_output_item["generated_error"],
+                "dialects": eval_output_item["dialects"],
+                "database": eval_output_item["database"],
+                "job_id": eval_output_item["job_id"],
+            })
+            logging.debug("scoring: %s %s %s", score_dict["id"], name, score_val)
             scoring_results.append(score_dict)

--- a/evalbench/test/score_test.py
+++ b/evalbench/test/score_test.py
@@ -1,0 +1,136 @@
+"""Tests for score.py module and DEFAULT_SCORERS registration."""
+
+import json
+import unittest
+from unittest.mock import MagicMock, patch
+
+from scorers import score
+
+
+class TestScoreModule(unittest.TestCase):
+
+    def test_default_scorers_map_contents(self):
+        """Verify that standard registered scorers are present in DEFAULT_SCORERS."""
+        expected_keys = [
+            "exact_match", "recall_match", "set_match", "llmrater",
+            "regexp_matcher", "returned_sql", "executable_sql",
+            "trajectory_matcher", "skills_trajectory", "skills_best_practices",
+            "goal_completion", "behavioral_metrics", "parameter_analysis",
+            "turn_count", "agent_steps", "end_to_end_latency",
+            "tool_call_latency", "token_consumption", "tokens_processed",
+            "effective_billed_tokens", "binary_rubric_scorer", "python_scorer",
+            "dataform_compile", "dataform_run", "dataform_cloud_compile",
+            "dataform_cloud_run", "dbt_compile", "dbt_run", "dataset_quality"
+        ]
+        self.assertGreater(len(score.DEFAULT_SCORERS), 0)
+        for key in expected_keys:
+            self.assertIn(key, score.DEFAULT_SCORERS, f"Key '{key}' missing from DEFAULT_SCORERS")
+
+    @patch("generators.models.load_yaml_config")
+    def test_default_scorers_map_instantiation(self, mock_load_yaml):
+        """Verify get_scorer_instance correctly instantiates all registered comparators."""
+        mock_load_yaml.return_value = {"generator": "gemini_cli", "model_id": "test"}
+        eval_output_item = {
+            "id": 1,
+            "nl_prompt": "prompt",
+            "golden_sql": "SELECT 1",
+            "query_type": "DQL",
+            "golden_result": None,
+            "golden_error": None,
+            "generated_sql": "SELECT 1",
+            "generated_result": None,
+            "generated_error": None,
+            "dialects": ["sqlite"],
+            "database": "db",
+            "job_id": "j1",
+            "eval_results": json.dumps({"scenario": {"binary_rubric": ["Criterion A", "Criterion B"]}}),
+        }
+        experiment_config = {"database_configs": []}
+        global_models = {"lock": MagicMock(), "registered_models": {}, "rater": MagicMock(), "simulated_user": MagicMock()}
+
+        configs = {
+            "llmrater": {"model_config": "model.yaml"},
+            "skills_best_practices": {"model_config": "model.yaml"},
+            "goal_completion": {"model_config": "model.yaml"},
+            "behavioral_metrics": {"model_config": "model.yaml"},
+            "parameter_analysis": {"model_config": "model.yaml"},
+            "binary_rubric_scorer": {"model_config": "model.yaml"},
+            "dataset_quality": {
+                "model_config": "model.yaml",
+                "product_name": "test_product",
+                "sub_scorers": {"trajectory_coverage": {}},
+            },
+            "regexp_matcher": {"regexp_string_list": [".*"]},
+            "python_scorer": {"script_path": "my_script.py"},
+            "dataform_compile": {"workspace_dir": "/tmp/df"},
+            "dataform_run": {"workspace_dir": "/tmp/df"},
+            "dataform_cloud_compile": {"gcp_project_id": "p", "gcp_region": "l", "repository_id": "r", "timeout_seconds": 60},
+            "dataform_cloud_run": {"gcp_project_id": "p", "gcp_region": "l", "repository_id": "r", "timeout_seconds": 60},
+            "dbt_compile": {"project_dir": "/tmp/dbt"},
+            "dbt_run": {"project_dir": "/tmp/dbt"},
+        }
+
+        for scorer_name, expected_cls in score.DEFAULT_SCORERS.items():
+            cfg = configs.get(scorer_name, {})
+            instances = score.get_scorer_instance(
+                scorer_name, cfg, experiment_config, eval_output_item, global_models
+            )
+            self.assertGreater(
+                len(instances), 0, f"Failed to instantiate scorer '{scorer_name}'"
+            )
+            for inst in instances:
+                self.assertIsInstance(
+                    inst,
+                    expected_cls,
+                    f"Scorer '{scorer_name}' returned instance of {type(inst)}, expected {expected_cls}"
+                )
+
+    @patch("scorers.pythonscorer.subprocess.run")
+    def test_score_compare_execution_all_scorers(self, mock_run):
+        """Verify score.compare executes built-in comparators cleanly."""
+        mock_res = MagicMock()
+        mock_res.returncode = 0
+        mock_res.stdout = '{"score": 100.0, "reason": "Passed"}'
+        mock_res.stderr = ""
+        mock_run.return_value = mock_res
+
+        eval_output_item = {
+            "id": 1,
+            "nl_prompt": "prompt",
+            "golden_sql": "SELECT 1",
+            "query_type": "DQL",
+            "golden_result": None,
+            "golden_error": None,
+            "generated_sql": "SELECT 1",
+            "generated_result": None,
+            "generated_error": None,
+            "dialects": ["sqlite"],
+            "database": "db",
+            "job_id": "j1",
+            "eval_results": "",
+        }
+
+        experiment_config = {
+            "scorers": {
+                "exact_match": {},
+                "turn_count": {},
+                "python_scorer": {"script_path": "rubric.py"},
+            }
+        }
+
+        scoring_results = []
+        score.compare(
+            eval_output_item=eval_output_item,
+            experiment_config=experiment_config,
+            scoring_results=scoring_results,
+            global_models={},
+        )
+
+        results_by_comp = {r["comparator"]: r for r in scoring_results}
+        self.assertIn("exact_match", results_by_comp)
+        self.assertIn("turn_count", results_by_comp)
+        self.assertIn("rubric", results_by_comp)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Refactors score.py by replacing hardcoded if statements with a global DEFAULT_SCORERS map and a generic _build_instances builder.                                              
                                                                                           
## Test Plan & Verification                                                            
                                                                                          
1. Automated Unit Testing:
  - Added test_default_scorers_map_instantiation in evalbench/test/score_test.py, dynamically verifying instantiation and signature parameter injection (global_models, database_configs) for all registered comparators in DEFAULT_SCORERS.
  - Ran all unit tests across existing scorer test suites with 100% pass rate.     
                                                                                           
2. Constructor Signature Invariant Matching:
  - cls(config) vs cls(config, global_models) inspected via inspect.signature to match
  legacy logic.
  - Preserved custom handling for binaryrubricscorer multi-criterion list expansion   
  and python_scorer script basename resolution.