### PR TITLE
feat(scorers): add NamedScorer wrapper to support custom scorer names

### DIFF
--- a/evalbench/reporting/analyzer.py
+++ b/evalbench/reporting/analyzer.py
@@ -4,6 +4,57 @@ import logging
 import pandas as pd
 
 
+def _is_sub_comparator(comp: str, metric_name: str) -> bool:
+    if comp == metric_name:
+        return True
+    if comp.startswith(f"{metric_name}_"):
+        suffix = comp[len(metric_name) + 1:]
+        return suffix.isdigit()
+    return False
+
+
+def _extract_base_metric_name(comp: str) -> str:
+    """Extract base metric name from sub-comparator (e.g. 'rubric_0')."""
+    if "_" in comp and comp.rsplit("_", 1)[1].isdigit():
+        return comp.rsplit("_", 1)[0]
+    return comp
+
+
+def _resolve_metric_names_to_analyze(
+    scorers: dict, df: pd.DataFrame
+) -> list[str]:
+    """Determine top-level metric names to analyze."""
+    configured_scorers = [
+        k.strip()
+        for k in (scorers.keys() if isinstance(scorers, dict) else [])
+        if k and k.strip() != "executable"
+    ]
+
+    metric_names = []
+
+    # 1. Always include configured scorers so zero-result scorers are kept
+    for key in configured_scorers:
+        if key not in metric_names:
+            metric_names.append(key)
+
+    # 2. Add unconfigured comparators present in the DataFrame
+    if "comparator" in df.columns:
+        raw_comparators = [
+            str(comp).strip() for comp in df["comparator"].dropna().unique()
+            if comp and str(comp).strip() != "executable"
+        ]
+        for comp in raw_comparators:
+            has_sub = any(
+                _is_sub_comparator(comp, metric) for metric in metric_names
+            )
+            if not has_sub:
+                base_name = _extract_base_metric_name(comp)
+                if base_name not in metric_names:
+                    metric_names.append(base_name)
+
+    return metric_names
+
+
 def analyze_one_metric(
     df: pd.DataFrame,
     metric_name: str,
@@ -31,7 +82,11 @@ def analyze_one_metric(
         df_exec = df[df["generated_sql"].notna()]
 
         # Use prompt_id to count unique successful prompts if available
-        if "prompt_id" in df_exec.columns and not df_exec["prompt_id"].isna().all():
+        has_prompt_id = (
+            "prompt_id" in df_exec.columns
+            and not df_exec["prompt_id"].isna().all()
+        )
+        if has_prompt_id:
             id_col = "prompt_id"
         else:
             id_col = "id"
@@ -53,10 +108,11 @@ def analyze_one_metric(
                 .drop_duplicates()
             )
     else:
-        if metric_name == "binary_rubric_scorer":
-            df_metric = df[df["comparator"].astype(str).str.startswith("binary_rubric_scorer")]
-        else:
-            df_metric = df[df["comparator"] == metric_name]
+        df_metric = df[
+            df["comparator"].astype(str).apply(
+                lambda c: _is_sub_comparator(c, metric_name)
+            )
+        ]
 
         if (
             "prompt_id" in df_metric.columns
@@ -150,13 +206,18 @@ def analyze_result(
     df = pd.DataFrame.from_dict(scores)
 
     # Ensure expected columns exist to avoid KeyErrors
-    for col in ["generated_sql", "generated_error", "comparator", "score", "id"]:
+    cols = ["generated_sql", "generated_error", "comparator", "score", "id"]
+    for col in cols:
         if col not in df.columns:
             df[col] = None
 
-    # Adjust num_prompts to the count of unique evaluated items ONLY for agent/geminicli orchestrators where multiple scenarios are packed into one prompt.
-    orchestrator = experiment_config.get("orchestrator", "") if isinstance(experiment_config, dict) else ""
-    if orchestrator in ("agent", "geminicli"):
+    # Adjust num_prompts for agent/geminicli orchestrators
+    orch = (
+        experiment_config.get("orchestrator", "")
+        if isinstance(experiment_config, dict)
+        else ""
+    )
+    if orch in ("agent", "geminicli"):
         if "id" in df.columns and not df["id"].isna().all():
             unique_ids = len(df["id"].dropna().unique())
             if num_prompts is None or unique_ids > num_prompts:
@@ -171,7 +232,9 @@ def analyze_result(
         "skills_best_practices",
     ]
 
-    for metric_name in scorers:
+    metric_names_to_analyze = _resolve_metric_names_to_analyze(scorers, df)
+
+    for metric_name in metric_names_to_analyze:
         metric_name = metric_name.strip()
         metric_score = 100
 

--- a/evalbench/scorers/namedscorer.py
+++ b/evalbench/scorers/namedscorer.py
@@ -1,0 +1,86 @@
+"""NamedScorer class to wrap any base comparator with a custom metric name."""
+
+from typing import Any, Tuple
+from scorers import comparator
+
+
+class NamedScorer(comparator.Comparator):
+    """Wraps an underlying base comparator with a custom metric name."""
+
+    def __init__(
+        self,
+        name: str,
+        base_scorer: comparator.Comparator,
+        target_type: str | None = None
+    ):
+        super().__init__({})
+        self.base_scorer = base_scorer
+        self.target_type = target_type
+
+        base_name = getattr(base_scorer, "name", "")
+        if target_type and base_name.startswith(target_type):
+            suffix = base_name[len(target_type):]
+            self.name = f"{name}{suffix}"
+        elif "_" in base_name and base_name.rsplit("_", 1)[1].isdigit():
+            suffix = f"_{base_name.rsplit('_', 1)[1]}"
+            self.name = f"{name}{suffix}"
+        else:
+            self.name = name
+
+    def compare(
+        self,
+        nl_prompt: Any,
+        golden_query: Any,
+        query_type: Any,
+        golden_execution_result: Any,
+        golden_eval_result: Any,
+        golden_error: Any,
+        generated_query: Any,
+        generated_execution_result: Any,
+        generated_eval_result: Any,
+        generated_error: Any,
+        database: str = "",
+        **kwargs,
+    ) -> Tuple[float, str] | list[Tuple[str, float | None, str]]:
+        """Delegate comparison to the underlying base scorer."""
+        import inspect
+        sig = inspect.signature(self.base_scorer.compare)
+        call_kwargs = {}
+        if "database" in sig.parameters and database:
+            call_kwargs["database"] = database
+        for k, v in kwargs.items():
+            if k in sig.parameters:
+                call_kwargs[k] = v
+
+        res = self.base_scorer.compare(
+            nl_prompt,
+            golden_query,
+            query_type,
+            golden_execution_result,
+            golden_eval_result,
+            golden_error,
+            generated_query,
+            generated_execution_result,
+            generated_eval_result,
+            generated_error,
+            **call_kwargs,
+        )
+        if isinstance(res, list):
+            new_list = []
+            base_name = getattr(self.base_scorer, "name", "")
+            for item in res:
+                row_name = item[0]
+                rest = item[1:]
+                if self.target_type and row_name.startswith(self.target_type):
+                    suffix = row_name[len(self.target_type):]
+                    new_name = f"{self.name}{suffix}"
+                elif base_name and row_name.startswith(base_name):
+                    suffix = row_name[len(base_name):]
+                    new_name = f"{self.name}{suffix}"
+                elif row_name == base_name:
+                    new_name = self.name
+                else:
+                    new_name = row_name
+                new_list.append((new_name, *rest))
+            return new_list
+        return res

--- a/evalbench/scorers/score.py
+++ b/evalbench/scorers/score.py
@@ -18,6 +18,7 @@ from scorers import exactmatcher
 from scorers import generatedqueryregexpmatcher
 from scorers import goalcompletionrate
 from scorers import llmrater
+from scorers import namedscorer
 from scorers import parameteranalysis
 from scorers import pythonscorer
 from scorers import recallmatcher
@@ -77,17 +78,28 @@ def _build_instances(
     config = dict(config) if isinstance(config, dict) else {}
     sig_params = inspect.signature(scorer_cls.__init__).parameters
 
-    if "database_configs" in sig_params or scorer_cls in (llmrater.LLMRater, pythonscorer.PythonScorer):
-        config["database_configs"] = experiment_config.get("database_configs", [])
+    if (
+        "database_configs" in sig_params
+        or scorer_cls in (llmrater.LLMRater, pythonscorer.PythonScorer)
+    ):
+        config["database_configs"] = experiment_config.get(
+            "database_configs", []
+        )
 
     if scorer_cls == DatasetQualityScorer and not config.get("product_name"):
         config["product_name"] = experiment_config.get("product_name")
 
     if scorer_cls == binaryrubricscorer.BinaryRubricScorer:
         import json
-        context_str = eval_output_item.get("eval_results", "") if eval_output_item else ""
+        context_str = (
+            eval_output_item.get("eval_results", "")
+            if eval_output_item else ""
+        )
         try:
-            context = context_str if isinstance(context_str, dict) else (json.loads(context_str) if context_str else {})
+            if isinstance(context_str, dict):
+                context = context_str
+            else:
+                context = json.loads(context_str) if context_str else {}
             rubric = context.get("scenario", {}).get("binary_rubric", [])
             if rubric:
                 return [
@@ -106,8 +118,11 @@ def _build_instances(
 
     if scorer_cls == pythonscorer.PythonScorer:
         custom_name = config.get("scorer_name")
-        if not custom_name and config.get("script_path") and isinstance(config["script_path"], str):
-            custom_name = os.path.splitext(os.path.basename(config["script_path"]))[0].strip()
+        script_path = config.get("script_path")
+        if not custom_name and script_path and isinstance(script_path, str):
+            custom_name = os.path.splitext(
+                os.path.basename(script_path)
+            )[0].strip()
         if custom_name:
             kwargs["name"] = custom_name
 
@@ -121,15 +136,48 @@ def get_scorer_instance(
     eval_output_item: EvalOutput,
     global_models: Any,
 ) -> list[comparator.Comparator]:
-    """Resolve and return comparator instances for a given scorer config entry."""
+    """Resolve comparator instances for a given scorer config entry."""
     if not isinstance(scorer_config, dict):
         return []
 
     # Direct match in global DEFAULT_SCORERS map
     if scorer_name in DEFAULT_SCORERS:
         return _build_instances(
-            DEFAULT_SCORERS[scorer_name], scorer_config, experiment_config, eval_output_item, global_models
+            DEFAULT_SCORERS[scorer_name],
+            scorer_config,
+            experiment_config,
+            eval_output_item,
+            global_models,
         )
+
+    # Named Scorer: check `type` attribute or nested type dictionary
+    target_type = scorer_config.get("type")
+    cfg = scorer_config
+    if not target_type:
+        for default_type in DEFAULT_SCORERS:
+            if (
+                default_type in scorer_config
+                and isinstance(scorer_config[default_type], dict)
+            ):
+                target_type = default_type
+                cfg = scorer_config[default_type]
+                break
+
+    if target_type and target_type in DEFAULT_SCORERS:
+        base_instances = _build_instances(
+            DEFAULT_SCORERS[target_type],
+            cfg,
+            experiment_config,
+            eval_output_item,
+            global_models,
+        )
+        custom_name = scorer_config.get("scorer_name") or scorer_name
+        return [
+            namedscorer.NamedScorer(
+                name=custom_name, base_scorer=base, target_type=target_type
+            )
+            for base in base_instances
+        ]
 
     return []
 
@@ -146,7 +194,13 @@ def compare(
 
     for name, config in scorers.items():
         comparators.extend(
-            get_scorer_instance(name, config, experiment_config, eval_output_item, global_models)
+            get_scorer_instance(
+                name,
+                config,
+                experiment_config,
+                eval_output_item,
+                global_models,
+            )
         )
 
     for comp in comparators:
@@ -159,7 +213,9 @@ def compare(
                 sig = inspect.signature(comp.compare)
                 compare_kwargs = {}
                 if "database" in sig.parameters:
-                    compare_kwargs["database"] = eval_output_item.get("database", "")
+                    compare_kwargs["database"] = eval_output_item.get(
+                        "database", ""
+                    )
                 result = comp.compare(
                     eval_output_item["nl_prompt"],
                     eval_output_item["golden_sql"],
@@ -195,5 +251,7 @@ def compare(
                 "database": eval_output_item["database"],
                 "job_id": eval_output_item["job_id"],
             })
-            logging.debug("scoring: %s %s %s", score_dict["id"], name, score_val)
+            logging.debug(
+                "scoring: %s %s %s", score_dict["id"], name, score_val
+            )
             scoring_results.append(score_dict)

--- a/evalbench/test/binaryrubricscorer_test.py
+++ b/evalbench/test/binaryrubricscorer_test.py
@@ -140,12 +140,73 @@ class TestBinaryRubricScorer(unittest.TestCase):
         }
 
         _, summary_df = analyze_result(scores, experiment_config)
-        summary_dict = summary_df.set_index("metric_name").to_dict(orient="index")
+        summary_dict = summary_df.set_index(
+            "metric_name"
+        ).to_dict(orient="index")
 
         self.assertIn("binary_rubric_scorer", summary_dict)
         # Total scores = 4 rows, 3 scored 100 -> 3/4 = 75%
-        self.assertEqual(summary_dict["binary_rubric_scorer"]["correct_results_count"], 3)
-        self.assertEqual(summary_dict["binary_rubric_scorer"]["total_results_count"], 4)
+        self.assertEqual(
+            summary_dict["binary_rubric_scorer"]["correct_results_count"], 3
+        )
+        self.assertEqual(
+            summary_dict["binary_rubric_scorer"]["total_results_count"], 4
+        )
+
+    def test_custom_named_binary_rubric_scorer_aggregation(self):
+        from reporting.analyzer import analyze_result
+
+        scores = [
+            {
+                "id": "1",
+                "comparator": "my_rubric_0",
+                "score": 100,
+                "generated_sql": "SELECT 1",
+                "generated_error": None,
+            },
+            {
+                "id": "1",
+                "comparator": "my_rubric_1",
+                "score": 100,
+                "generated_sql": "SELECT 1",
+                "generated_error": None,
+            },
+            {
+                "id": "2",
+                "comparator": "my_rubric_0",
+                "score": 0,
+                "generated_sql": "SELECT 1",
+                "generated_error": None,
+            },
+            {
+                "id": "2",
+                "comparator": "my_rubric_1",
+                "score": 100,
+                "generated_sql": "SELECT 1",
+                "generated_error": None,
+            },
+        ]
+        experiment_config = {
+            "scorers": {
+                "my_rubric": {
+                    "type": "binary_rubric_scorer",
+                    "model_config": "fake_config"
+                }
+            }
+        }
+
+        _, summary_df = analyze_result(scores, experiment_config)
+        summary_dict = summary_df.set_index(
+            "metric_name"
+        ).to_dict(orient="index")
+
+        self.assertIn("my_rubric", summary_dict)
+        self.assertEqual(
+            summary_dict["my_rubric"]["correct_results_count"], 3
+        )
+        self.assertEqual(
+            summary_dict["my_rubric"]["total_results_count"], 4
+        )
 
 
 if __name__ == '__main__':

--- a/evalbench/test/named_python_scorer_test.py
+++ b/evalbench/test/named_python_scorer_test.py
@@ -1,0 +1,133 @@
+import sys
+from unittest.mock import patch, MagicMock
+
+# Mock optional/missing mcp submodules for unit tests if not installed in env
+for mod in [
+    'mcp', 'mcp.types', 'mcp.client', 'mcp.client.session',
+    'mcp.client.stdio', 'mcp.client.streamable_http', 'mcp.client.sse'
+]:
+    if mod not in sys.modules:
+        sys.modules[mod] = MagicMock()
+
+import json  # noqa: E402
+import unittest  # noqa: E402
+
+from scorers import score  # noqa: E402
+from scorers.namedscorer import NamedScorer  # noqa: E402
+from scorers.pythonscorer import PythonScorer  # noqa: E402
+
+
+class TestNamedPythonScorer(unittest.TestCase):
+
+    @patch('scorers.pythonscorer.subprocess.run')
+    def test_type_python_scorer_and_nested_dict(self, mock_run):
+        mock_result = MagicMock()
+        mock_result.returncode = 0
+        mock_result.stdout = json.dumps({
+            "score": 1.0,
+            "reason": "OK"
+        })
+        mock_result.stderr = ""
+        mock_run.return_value = mock_result
+
+        eval_output_item = {
+            "id": 101,
+            "nl_prompt": "test prompt",
+            "golden_sql": "SELECT 1",
+            "query_type": "DQL",
+            "golden_result": None,
+            "golden_error": None,
+            "generated_sql": "SELECT 1",
+            "generated_result": None,
+            "generated_error": None,
+            "dialects": ["sqlite"],
+            "database": "test_db",
+            "job_id": "job123",
+        }
+
+        experiment_config = {
+            "scorers": {
+                "rubric_pass_fail": {
+                    "type": "python_scorer",
+                    "script_path": "script_pf.py"
+                },
+                "rubric_validator": {
+                    "python_scorer": {
+                        "script_path": "script_val.py"
+                    }
+                }
+            }
+        }
+
+        scoring_results = []
+        score.compare(
+            eval_output_item=eval_output_item,
+            experiment_config=experiment_config,
+            scoring_results=scoring_results,
+            global_models={},
+        )
+
+        comparators = [r["comparator"] for r in scoring_results]
+        self.assertIn("rubric_pass_fail", comparators)
+        self.assertIn("rubric_validator", comparators)
+        self.assertEqual(len(scoring_results), 2)
+
+    def test_named_scorer_wrapper(self):
+        base_mock = MagicMock(spec=PythonScorer)
+        base_mock.compare.return_value = (85.0, "Good performance")
+
+        wrapper = NamedScorer(name="custom_metric", base_scorer=base_mock)
+        self.assertEqual(wrapper.name, "custom_metric")
+
+        res_score, res_logs = wrapper.compare(
+            nl_prompt="p", golden_query="g", query_type="DQL",
+            golden_execution_result=None, golden_eval_result=None,
+            golden_error=None, generated_query="gen",
+            generated_execution_result=None, generated_eval_result=None,
+            generated_error=None, database="db"
+        )
+        self.assertEqual(res_score, 85.0)
+        self.assertEqual(res_logs, "Good performance")
+
+    def test_named_scorer_fan_out(self):
+        base_mock_0 = MagicMock()
+        base_mock_0.name = "binary_rubric_scorer_0"
+        base_mock_0.compare.return_value = (100.0, "Pass Criterion 0")
+
+        base_mock_1 = MagicMock()
+        base_mock_1.name = "binary_rubric_scorer_1"
+        base_mock_1.compare.return_value = (0.0, "Fail Criterion 1")
+
+        wrapper_0 = NamedScorer(
+            name="my_rubric",
+            base_scorer=base_mock_0,
+            target_type="binary_rubric_scorer"
+        )
+        wrapper_1 = NamedScorer(
+            name="my_rubric",
+            base_scorer=base_mock_1,
+            target_type="binary_rubric_scorer"
+        )
+
+        self.assertEqual(wrapper_0.name, "my_rubric_0")
+        self.assertEqual(wrapper_1.name, "my_rubric_1")
+
+    def test_resolve_metric_names_includes_zero_result_scorers(self):
+        from reporting.analyzer import _resolve_metric_names_to_analyze
+        import pandas as pd
+
+        scorers = {
+            "exact_match": {},
+            "rubric_pass_fail": {"type": "python_scorer"},
+            "missing_scorer": {},
+        }
+        df = pd.DataFrame([{"comparator": "exact_match", "score": 100}])
+
+        metric_names = _resolve_metric_names_to_analyze(scorers, df)
+        self.assertIn("exact_match", metric_names)
+        self.assertIn("rubric_pass_fail", metric_names)
+        self.assertIn("missing_scorer", metric_names)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/evalbench/test/score_test.py
+++ b/evalbench/test/score_test.py
@@ -5,6 +5,10 @@ import unittest
 from unittest.mock import MagicMock, patch
 
 from scorers import score
+from scorers.namedscorer import NamedScorer
+from scorers.exactmatcher import ExactMatcher
+from scorers.pythonscorer import PythonScorer
+from scorers.turncount import TurnCount
 
 
 class TestScoreModule(unittest.TestCase):
@@ -130,6 +134,92 @@ class TestScoreModule(unittest.TestCase):
         self.assertIn("exact_match", results_by_comp)
         self.assertIn("turn_count", results_by_comp)
         self.assertIn("rubric", results_by_comp)
+
+    def test_get_scorer_instance_named_scorer_type_attr(self):
+        """Verify get_scorer_instance wraps custom metric names using type attribute."""
+        eval_output_item = {"id": 1, "eval_results": ""}
+        experiment_config = {"database_configs": []}
+        global_models = {}
+
+        # rubric_pass_fail -> type: python_scorer
+        instances = score.get_scorer_instance(
+            "rubric_pass_fail",
+            {"type": "python_scorer", "script_path": "rubric.py"},
+            experiment_config,
+            eval_output_item,
+            global_models,
+        )
+        self.assertEqual(len(instances), 1)
+        self.assertIsInstance(instances[0], NamedScorer)
+        self.assertEqual(instances[0].name, "rubric_pass_fail")
+        self.assertIsInstance(instances[0].base_scorer, PythonScorer)
+
+    def test_get_scorer_instance_named_scorer_nested_dict(self):
+        """Verify get_scorer_instance wraps custom metric names using nested type dict."""
+        eval_output_item = {"id": 1, "eval_results": ""}
+        experiment_config = {"database_configs": []}
+        global_models = {}
+
+        # rubric_validator -> python_scorer: { script_path: ... }
+        instances = score.get_scorer_instance(
+            "rubric_validator",
+            {"python_scorer": {"script_path": "rubric_val.py"}},
+            experiment_config,
+            eval_output_item,
+            global_models,
+        )
+        self.assertEqual(len(instances), 1)
+        self.assertIsInstance(instances[0], NamedScorer)
+        self.assertEqual(instances[0].name, "rubric_validator")
+        self.assertIsInstance(instances[0].base_scorer, PythonScorer)
+
+    @patch("scorers.pythonscorer.subprocess.run")
+    def test_score_compare_execution(self, mock_run):
+        """Verify score.compare runs both standard and NamedScorer comparators."""
+        mock_res = MagicMock()
+        mock_res.returncode = 0
+        mock_res.stdout = '{"score": 100.0, "reason": "Passed"}'
+        mock_res.stderr = ""
+        mock_run.return_value = mock_res
+
+        eval_output_item = {
+            "id": 1,
+            "nl_prompt": "prompt",
+            "golden_sql": "SELECT 1",
+            "query_type": "DQL",
+            "golden_result": None,
+            "golden_error": None,
+            "generated_sql": "SELECT 1",
+            "generated_result": None,
+            "generated_error": None,
+            "dialects": ["sqlite"],
+            "database": "db",
+            "job_id": "j1",
+        }
+
+        experiment_config = {
+            "scorers": {
+                "exact_match": {},
+                "rubric_pass_fail": {
+                    "type": "python_scorer",
+                    "script_path": "rubric.py",
+                },
+            }
+        }
+
+        scoring_results = []
+        score.compare(
+            eval_output_item=eval_output_item,
+            experiment_config=experiment_config,
+            scoring_results=scoring_results,
+            global_models={},
+        )
+
+        results_by_comp = {r["comparator"]: r for r in scoring_results}
+        self.assertIn("exact_match", results_by_comp)
+        self.assertIn("rubric_pass_fail", results_by_comp)
+        self.assertEqual(results_by_comp["exact_match"]["score"], 100)
+        self.assertEqual(results_by_comp["rubric_pass_fail"]["score"], 100.0)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Introduces the NamedScorer wrapper class to support custom top-level YAML keys in run configurations (e.g. rubric_pass_fail: {type: python_scorer}).                           
                                                                                           
## Summary of Changes
                                                           
1. NamedScorer Wrapper (evalbench/scorers/namedscorer.py):                             
  - A lightweight Comparator wrapper that stores the custom metric name (name) and delegates compare(...) to its base_scorer.                                               
                                                                                           
2. Resolution Logic in score.py (evalbench/scorers/score.py):                          
  - get_scorer_instance checks if a YAML key exists in DEFAULT_SCORERS. If not, it inspects the type: attribute (e.g., rubric_pass_fail: {type: python_scorer, script_path: ...}) or nested dictionary (rubric_validator: {python_scorer: ...}) and wraps the underlying comparator in NamedScorer.                                                    
                                                                                           
3. Summary Reporting in analyzer.py (evalbench/reporting/analyzer.py):                 
  - Dynamically includes custom named comparators from df["comparator"] in summary reports.
  
## Test Plan & Verification

1. NamedScorer Unit Tests (evalbench/test/named_python_scorer_test.py):
  - test_type_python_scorer_and_nested_dict: Tests configuration resolution for custom top-level keys using both type: python_scorer attribute syntax and nested dictionary syntax.
  - test_named_scorer_wrapper: Verifies delegation of compare() calls and metric name property forwarding.
  
2. Resolution & Execution Tests in score_test.py (evalbench/test/score_test.py):
  - test_get_scorer_instance_named_scorer_type_attr: Asserts get_scorer_instance returns a NamedScorer wrapping PythonScorer for top-level keys specifying type: python_scorer.
  - test_get_scorer_instance_named_scorer_nested_dict: Asserts get_scorer_instance returns a NamedScorer for nested dictionary declarations.
  - test_score_compare_execution: Asserts score.compare(...) executes named comparators and correctly sets comparator = custom_name in output results.
  
3. Full Suite Execution:
  - All test cases passed.