### PR TITLE
Expose summarizer model to dataset configs

### DIFF
--- a/evalbench/test/viewer_summarizer_test.py
+++ b/evalbench/test/viewer_summarizer_test.py
@@ -55,7 +55,7 @@ class TestViewerSummarizer(unittest.TestCase):
         mock_generator = MagicMock()
         mock_get_generator.return_value = mock_generator
 
-        generator = get_summarizer(results_dir=self.temp_dir.name)
+        get_summarizer(results_dir=self.temp_dir.name)
 
         mock_get_generator.assert_called_once()
         args, _ = mock_get_generator.call_args
@@ -78,7 +78,7 @@ class TestViewerSummarizer(unittest.TestCase):
         mock_generator = MagicMock()
         mock_get_generator.return_value = mock_generator
 
-        generator = get_summarizer(results_dir=self.temp_dir.name)
+        get_summarizer(results_dir=self.temp_dir.name)
 
         mock_get_generator.assert_called_once()
         args, _ = mock_get_generator.call_args
@@ -101,7 +101,7 @@ class TestViewerSummarizer(unittest.TestCase):
         mock_generator = MagicMock()
         mock_get_generator.return_value = mock_generator
 
-        generator = get_summarizer(dataset_name="agy-cli-tools")
+        get_summarizer(dataset_name="agy-cli-tools")
 
         mock_get_generator.assert_called_once()
         args, _ = mock_get_generator.call_args
@@ -118,7 +118,7 @@ class TestViewerSummarizer(unittest.TestCase):
         mock_generator = MagicMock()
         mock_get_generator.return_value = mock_generator
 
-        generator = get_summarizer(model_config_path=custom_config_path)
+        get_summarizer(model_config_path=custom_config_path)
 
         mock_get_generator.assert_called_once()
         args, _ = mock_get_generator.call_args

--- a/evalbench/test/viewer_summarizer_test.py
+++ b/evalbench/test/viewer_summarizer_test.py
@@ -1,0 +1,129 @@
+import os
+import sys
+import tempfile
+import unittest
+from unittest.mock import patch, MagicMock
+
+# Add viewer directory and root to sys.path
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "../../viewer")))
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "../..")))
+
+from viewer.summarizer import get_summarizer
+
+
+class TestViewerSummarizer(unittest.TestCase):
+
+    def setUp(self):
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temp_dir.cleanup)
+
+    @patch("viewer.summarizer.get_generator")
+    @patch("viewer.summarizer.load_yaml_config")
+    def test_get_summarizer_default_fallback(self, mock_load_yaml, mock_get_generator):
+        """Verify fallback to default model_config_path when no run_config or dataset overrides exist."""
+        mock_load_yaml.return_value = {
+            "model_config_path": "./gemini_summarizer_model.yaml"
+        }
+        mock_generator = MagicMock()
+        mock_get_generator.return_value = mock_generator
+
+        generator = get_summarizer()
+
+        mock_get_generator.assert_called_once()
+        args, _ = mock_get_generator.call_args
+        self.assertTrue(args[1].endswith("gemini_summarizer_model.yaml"))
+        self.assertEqual(generator, mock_generator)
+
+    @patch("viewer.summarizer.get_generator")
+    @patch("viewer.summarizer.load_yaml_config")
+    def test_get_summarizer_run_config_override(self, mock_load_yaml, mock_get_generator):
+        """Verify run_config.yaml in results_dir takes precedence if summarizer_model_config is defined."""
+        custom_config_path = os.path.join(self.temp_dir.name, "custom_model.yaml")
+        with open(custom_config_path, "w") as f:
+            f.write("generator: gcp_vertex_gemini\nvertex_model: gemini-2.5-pro\n")
+
+        run_config_path = os.path.join(self.temp_dir.name, "run_config.yaml")
+        with open(run_config_path, "w") as f:
+            f.write(f"summarizer_model_config: {custom_config_path}\n")
+
+        def side_effect(path):
+            if os.path.abspath(path) == os.path.abspath(run_config_path):
+                return {"summarizer_model_config": custom_config_path}
+            return {"model_config_path": "./gemini_summarizer_model.yaml"}
+
+        mock_load_yaml.side_effect = side_effect
+        mock_generator = MagicMock()
+        mock_get_generator.return_value = mock_generator
+
+        generator = get_summarizer(results_dir=self.temp_dir.name)
+
+        mock_get_generator.assert_called_once()
+        args, _ = mock_get_generator.call_args
+        self.assertEqual(args[1], os.path.abspath(custom_config_path))
+
+    @patch("viewer.summarizer.get_generator")
+    @patch("viewer.summarizer.load_yaml_config")
+    def test_get_summarizer_run_config_missing_override_falls_back(self, mock_load_yaml, mock_get_generator):
+        """Verify fallback to default when run_config.yaml exists but has no summarizer_model_config."""
+        run_config_path = os.path.join(self.temp_dir.name, "run_config.yaml")
+        with open(run_config_path, "w") as f:
+            f.write("model_config: datasets/model_configs/gemini_cli_model.yaml\n")
+
+        def side_effect(path):
+            if os.path.abspath(path) == os.path.abspath(run_config_path):
+                return {"model_config": "datasets/model_configs/gemini_cli_model.yaml"}
+            return {"model_config_path": "./gemini_summarizer_model.yaml"}
+
+        mock_load_yaml.side_effect = side_effect
+        mock_generator = MagicMock()
+        mock_get_generator.return_value = mock_generator
+
+        generator = get_summarizer(results_dir=self.temp_dir.name)
+
+        mock_get_generator.assert_called_once()
+        args, _ = mock_get_generator.call_args
+        self.assertTrue(args[1].endswith("gemini_summarizer_model.yaml"))
+
+    @patch("viewer.summarizer.get_generator")
+    @patch("viewer.summarizer.load_yaml_config")
+    def test_get_summarizer_dataset_models_mapping(self, mock_load_yaml, mock_get_generator):
+        """Verify dataset_models mapping in summarizer_config.yaml matches dataset_name."""
+        custom_config_path = os.path.join(self.temp_dir.name, "custom_dataset_model.yaml")
+        with open(custom_config_path, "w") as f:
+            f.write("generator: gcp_vertex_gemini\n")
+
+        mock_load_yaml.return_value = {
+            "model_config_path": "./gemini_summarizer_model.yaml",
+            "dataset_models": {
+                "agy-cli-tools": custom_config_path
+            }
+        }
+        mock_generator = MagicMock()
+        mock_get_generator.return_value = mock_generator
+
+        generator = get_summarizer(dataset_name="agy-cli-tools")
+
+        mock_get_generator.assert_called_once()
+        args, _ = mock_get_generator.call_args
+        self.assertEqual(args[1], os.path.abspath(custom_config_path))
+
+    @patch("viewer.summarizer.get_generator")
+    @patch("viewer.summarizer.load_yaml_config")
+    def test_get_summarizer_explicit_model_config_override(self, mock_load_yaml, mock_get_generator):
+        """Verify passing model_config_path explicitly overrides default and dataset settings."""
+        custom_config_path = os.path.join(self.temp_dir.name, "override_model.yaml")
+        with open(custom_config_path, "w") as f:
+            f.write("generator: gcp_vertex_gemini\n")
+
+        mock_generator = MagicMock()
+        mock_get_generator.return_value = mock_generator
+
+        generator = get_summarizer(model_config_path=custom_config_path)
+
+        mock_get_generator.assert_called_once()
+        args, _ = mock_get_generator.call_args
+        self.assertEqual(args[1], os.path.abspath(custom_config_path))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/viewer/ai_comparer.py
+++ b/viewer/ai_comparer.py
@@ -10,6 +10,7 @@ sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "../eval
 
 from evalbench.generators.models import get_generator
 from evalbench.util.config import load_yaml_config
+from summarizer import get_summarizer
 
 # Setup logging
 logging.basicConfig(level=logging.INFO)
@@ -39,8 +40,6 @@ def get_results_dir():
             
     logger.warning("Results directory not found in candidates, defaulting to current directory results")
     return os.path.join(os.getcwd(), "results")
-
-from summarizer import get_summarizer
 
 def compare_evals(id1, id2):
     """Compares two evaluation runs using Gemini."""

--- a/viewer/ai_comparer.py
+++ b/viewer/ai_comparer.py
@@ -40,24 +40,7 @@ def get_results_dir():
     logger.warning("Results directory not found in candidates, defaulting to current directory results")
     return os.path.join(os.getcwd(), "results")
 
-def get_summarizer():
-    """Loads the generator based on the config in viewer/summarizer_config.yaml."""
-    config_path = os.path.join(os.path.dirname(__file__), "config", "summarizer_config.yaml")
-    if not os.path.exists(config_path):
-        raise FileNotFoundError(f"Config file not found at {config_path}")
-        
-    config = load_yaml_config(config_path)
-    model_config_path = config.get("model_config_path")
-    if not model_config_path:
-        raise ValueError("model_config_path not specified in summarizer_config.yaml")
-        
-    # Resolve path relative to the config file if it's relative
-    if not os.path.isabs(model_config_path):
-        model_config_path = os.path.abspath(os.path.join(os.path.dirname(config_path), model_config_path))
-        
-    logger.info(f"Loading generator using config: {model_config_path}")
-    generator = get_generator(global_models, model_config_path)
-    return generator
+from summarizer import get_summarizer
 
 def compare_evals(id1, id2):
     """Compares two evaluation runs using Gemini."""

--- a/viewer/summarizer.py
+++ b/viewer/summarizer.py
@@ -7,7 +7,6 @@ sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "../eval
 import logging
 import threading
 import pandas as pd
-from evalbench.generators.models import get_generator
 from evalbench.util.config import load_yaml_config
 
 # Setup logging
@@ -17,37 +16,61 @@ logger = logging.getLogger(__name__)
 # Global models dict for get_generator
 global_models = {"lock": threading.Lock(), "registered_models": {}}
 
-def get_summarizer():
-    """Loads the generator based on the config in viewer/summarizer_config.yaml."""
+def get_summarizer(results_dir: str = None, dataset_name: str = None, model_config_path: str = None):
+    """Loads the generator based on explicit parameter, run_config.yaml, dataset_models mapping, or viewer/config/summarizer_config.yaml fallback."""
+    selected_config_path = model_config_path
+
+    # Check run_config.yaml inside results_dir if provided
+    if not selected_config_path and results_dir and os.path.exists(results_dir):
+        run_config_file = os.path.join(results_dir, "run_config.yaml")
+        if os.path.exists(run_config_file):
+            try:
+                run_config = load_yaml_config(run_config_file)
+                selected_config_path = run_config.get("summarizer_model_config")
+                if selected_config_path:
+                    logger.info(f"Found run-specific summarizer model config: {selected_config_path}")
+            except Exception as e:
+                logger.warning(f"Could not load run_config.yaml from {run_config_file}: {e}")
+
+    # Check viewer/config/summarizer_config.yaml for dataset_models mapping or default model_config_path
     config_path = os.path.join(os.path.dirname(__file__), "config", "summarizer_config.yaml")
-    if not os.path.exists(config_path):
-        raise FileNotFoundError(f"Config file not found at {config_path}")
-        
-    config = load_yaml_config(config_path)
-    model_config_path = config.get("model_config_path")
-    if not model_config_path:
-        raise ValueError("model_config_path not specified in summarizer_config.yaml")
-        
-    # Resolve path relative to the config file if it's relative
-    if not os.path.isabs(model_config_path):
-        model_config_path = os.path.abspath(os.path.join(os.path.dirname(config_path), model_config_path))
-        
-    logger.info(f"Loading generator using config: {model_config_path}")
-    generator = get_generator(global_models, model_config_path)
+    if os.path.exists(config_path):
+        config = load_yaml_config(config_path)
+
+        if not selected_config_path and dataset_name:
+            dataset_models = config.get("dataset_models", {})
+            if dataset_name in dataset_models:
+                selected_config_path = dataset_models[dataset_name]
+                logger.info(f"Found dataset-specific summarizer model config for '{dataset_name}': {selected_config_path}")
+
+        if not selected_config_path:
+            selected_config_path = config.get("model_config_path")
+
+    if not selected_config_path:
+        raise ValueError("No valid model_config_path specified for summarizer.")
+
+    # Resolve path relative to config directory if it's relative
+    if not os.path.isabs(selected_config_path):
+        base_dir = os.path.dirname(config_path) if os.path.exists(config_path) else os.path.dirname(__file__)
+        selected_config_path = os.path.abspath(os.path.join(base_dir, selected_config_path))
+
+    logger.info(f"Loading generator using config: {selected_config_path}")
+    from evalbench.generators.models import get_generator
+    generator = get_generator(global_models, selected_config_path)
     return generator
 
-def summarize_eval_scoring(results_dir):
+def summarize_eval_scoring(results_dir, dataset_name=None, model_config_path=None):
     """Reads evals.csv and scores.csv from results_dir and generates a summary using Gemini."""
     evals_path = os.path.join(results_dir, "evals.csv")
     scores_path = os.path.join(results_dir, "scores.csv")
-    
+
     if not os.path.exists(evals_path):
         return f"Error: evals.csv not found in {results_dir}"
-        
+
     try:
         evals_df = pd.read_csv(evals_path)
         scores_df = pd.read_csv(scores_path) if os.path.exists(scores_path) else None
-        
+
         # Read prompt from file
         prompt_file = os.path.join(os.path.dirname(__file__), "analyzer.md")
         prompt_instructions = "Analyze and summarize the following evaluation scoring data.\n\nProvide a concise summary of the performance, highlighting key failures or successes."
@@ -56,27 +79,27 @@ def summarize_eval_scoring(results_dir):
                 prompt_instructions = f.read()
         else:
             logger.warning(f"Prompt file not found at {prompt_file}, using default instructions.")
-            
+
         prompt = prompt_instructions + "\n\n"
         prompt += "### Evals Data (Sample or Summary):\n"
         # Include first few rows or a summary of evals
         prompt += evals_df.head(5).to_string() + "\n\n"
-        
+
         if scores_df is not None:
             prompt += "### Scores Data:\n"
             prompt += scores_df.to_string() + "\n\n"
-        
+
         # Get generator or use API key directly
         from google import genai
-        
+
         api_key = os.environ.get("GOOGLE_API_KEY")
         if api_key:
             logger.info("Using GOOGLE_API_KEY for summarization")
             client = genai.Client(api_key=api_key)
             model_name = "gemini-2.5-flash"
         else:
-            logger.info("Using default generator from config")
-            generator = get_summarizer()
+            logger.info("Using generator from config")
+            generator = get_summarizer(results_dir=results_dir, dataset_name=dataset_name, model_config_path=model_config_path)
             client = generator.client
             model_name = generator.vertex_model
         

--- a/viewer/summarizer.py
+++ b/viewer/summarizer.py
@@ -8,6 +8,7 @@ import logging
 import threading
 import pandas as pd
 from evalbench.util.config import load_yaml_config
+from evalbench.generators.models import get_generator
 
 # Setup logging
 logging.basicConfig(level=logging.INFO)
@@ -19,6 +20,7 @@ global_models = {"lock": threading.Lock(), "registered_models": {}}
 def get_summarizer(results_dir: str = None, dataset_name: str = None, model_config_path: str = None):
     """Loads the generator based on explicit parameter, run_config.yaml, dataset_models mapping, or viewer/config/summarizer_config.yaml fallback."""
     selected_config_path = model_config_path
+    base_dir = os.getcwd() if selected_config_path else None
 
     # Check run_config.yaml inside results_dir if provided
     if not selected_config_path and results_dir and os.path.exists(results_dir):
@@ -28,6 +30,7 @@ def get_summarizer(results_dir: str = None, dataset_name: str = None, model_conf
                 run_config = load_yaml_config(run_config_file)
                 selected_config_path = run_config.get("summarizer_model_config")
                 if selected_config_path:
+                    base_dir = results_dir
                     logger.info(f"Found run-specific summarizer model config: {selected_config_path}")
             except Exception as e:
                 logger.warning(f"Could not load run_config.yaml from {run_config_file}: {e}")
@@ -38,24 +41,26 @@ def get_summarizer(results_dir: str = None, dataset_name: str = None, model_conf
         config = load_yaml_config(config_path)
 
         if not selected_config_path and dataset_name:
-            dataset_models = config.get("dataset_models", {})
+            dataset_models = config.get("dataset_models") or {}
             if dataset_name in dataset_models:
                 selected_config_path = dataset_models[dataset_name]
+                base_dir = os.path.dirname(config_path)
                 logger.info(f"Found dataset-specific summarizer model config for '{dataset_name}': {selected_config_path}")
 
         if not selected_config_path:
             selected_config_path = config.get("model_config_path")
+            base_dir = os.path.dirname(config_path)
 
     if not selected_config_path:
         raise ValueError("No valid model_config_path specified for summarizer.")
 
-    # Resolve path relative to config directory if it's relative
+    # Resolve path relative to base_dir if it's relative
     if not os.path.isabs(selected_config_path):
-        base_dir = os.path.dirname(config_path) if os.path.exists(config_path) else os.path.dirname(__file__)
+        if not base_dir:
+            base_dir = os.path.dirname(config_path) if os.path.exists(config_path) else os.path.dirname(__file__)
         selected_config_path = os.path.abspath(os.path.join(base_dir, selected_config_path))
 
     logger.info(f"Loading generator using config: {selected_config_path}")
-    from evalbench.generators.models import get_generator
     generator = get_generator(global_models, selected_config_path)
     return generator
 


### PR DESCRIPTION
Previously, the viewer dashboard component used a single global model configuration file (`viewer/config/summarizer_config.yaml` pointing to `viewer/config/gemini_summarizer_model.yaml`) to generate AI summaries and side-by-side run comparisons for evaluation benchmark results. 

There was no way to customize or override the summarizer model for different datasets or specific evaluation runs without manually modifying the global configuration file.

This is specifically problematically when the user doesn't have access to the `evalbench-dev` project. 

### Solution
This PR introduces flexible, priority-based summarizer model resolution with automatic fallback to defaults:

1. **Per-Run Config**: Specify `summarizer_model_config` inside a run's `run_config.yaml` (e.g. `summarizer_model_config: datasets/model_configs/gemini_3.0_pro_model.yaml`).
2. **Per-Dataset Mapping**: Map dataset names to model configs in `viewer/config/summarizer_config.yaml` under `dataset_models`.
3. **Explicit Overrides**: Accept `results_dir`, `dataset_name`, and `model_config_path` parameters directly in `get_summarizer()` and `summarize_eval_scoring()`.
4. **Default Fallback**: Automatically fall back to the default `model_config_path` in `summarizer_config.yaml` if no custom configuration is provided.


## How to Test

Run the viewer summarizer unit tests:
```bash
pytest evalbench/test/viewer_summarizer_test.py
