### PR TITLE
Fix 5-tuple unpacking error in EvalServicer.Interact()

### DIFF
--- a/evalbench/eval_service.py
+++ b/evalbench/eval_service.py
@@ -411,7 +411,13 @@ class EvalServicer(eval_service_pb2_grpc.EvalServiceServicer):
                 logging.debug("Read task cancelled as expected.")
 
             # Process final scoring and reporting
-            job_id, run_time, results_tf, scores_tf = orchestrator.process()
+            (
+                job_id,
+                run_time,
+                results_tf,
+                scores_tf,
+                multi_trial_scores_tf,
+            ) = orchestrator.process()
             reporters = get_reporters(config.get(
                 "reporting") or {}, job_id, run_time)
 


### PR DESCRIPTION
In PR #364 (commit `fafdb8a`), `Orchestrator.process()` was updated to return a 5th tuple element (`multi_trial_scores_tf`). While `EvalServicer.Eval()` was updated to unpack 5 variables, `EvalServicer.Interact()` was missed and left unpacking 4 variables.

This causes callers of `Interact()` to fail with:
```
ValueError: too many values to unpack (expected 4)
```

This PR updates `EvalServicer.Interact()` to unpack 5 variables from `orchestrator.process()`, bringing it into parity with `Eval()`.