### PR TITLE
fix(codex_cli): resolve rpc_id_var for per-session fake_home isolation in eval_server

### DIFF
--- a/evalbench/generators/models/codex_cli.py
+++ b/evalbench/generators/models/codex_cli.py
@@ -9,6 +9,7 @@ import shutil
 import sys
 import threading
 import time
+from util.context import rpc_id_var
 
 
 _SECRET_MANAGER_PATH_RE = re.compile(
@@ -64,7 +65,10 @@ class CodexCliGenerator(AgentCliGenerator):
         self.real_home = os.environ.get("HOME", os.path.expanduser("~"))
 
         if sys.argv[0].endswith("eval_server.py"):
-            session_id = querygenerator_config.get("session_id", "default")
+            session_id = querygenerator_config.get("session_id")
+            if not session_id:
+                ctx_id = rpc_id_var.get()
+                session_id = ctx_id if ctx_id != "default" else "default"
             self.fake_home = os.path.join(
                 "/tmp_sessions", session_id, "fake_home")
         else:


### PR DESCRIPTION
### Summary
Fixes an issue in `CodexCliGenerator` where `fake_home` defaulted to `/tmp_sessions/default/fake_home` across all gRPC requests when running under `eval_server.py`.

### Problem & Code Comparison
When running evaluations via `eval_server.py`, `SessionManagerInterceptor` injects a unique per-scenario session ID into `util.context.rpc_id_var`.

Other generators dynamically query `rpc_id_var.get()` when `querygenerator_config` lacks an explicit `session_id`:
- **`gemini_cli.py`**: [`evalbench/generators/models/gemini_cli.py:L33-L38`](https://github.com/GoogleCloudPlatform/evalbench/blob/main/evalbench/generators/models/gemini_cli.py#L33-L38)
  ```python
  if sys.argv[0].endswith("eval_server.py"):
      session_id = querygenerator_config.get("session_id")
      if not session_id:
          ctx_id = rpc_id_var.get()
          session_id = ctx_id if ctx_id != "default" else "default"
      self.fake_home = os.path.join("/tmp_sessions", session_id, "fake_home")
  ```
- **`claude_code.py`**: [`evalbench/generators/models/claude_code.py:L35-L41`](https://github.com/GoogleCloudPlatform/evalbench/blob/main/evalbench/generators/models/claude_code.py#L35-L41)
  ```python
  if sys.argv[0].endswith("eval_server.py"):
      session_id = querygenerator_config.get("session_id")
      if not session_id:
          ctx_id = rpc_id_var.get()
          session_id = ctx_id if ctx_id != "default" else "default"
      self.fake_home = os.path.join("/tmp_sessions", session_id, "fake_home")
  ```
- **`agy_cli.py`**: [`evalbench/generators/models/agy_cli.py:L101-L108`](https://github.com/GoogleCloudPlatform/evalbench/blob/main/evalbench/generators/models/agy_cli.py#L101-L108)
  ```python
  if sys.argv[0].endswith("eval_server.py"):
      session_id = querygenerator_config.get("session_id")
      if not session_id:
          ctx_id = rpc_id_var.get()
          session_id = ctx_id if ctx_id != "default" else "default"
      self.fake_home = os.path.join("/tmp_sessions", session_id, "fake_home")
  ```

In contrast, **`codex_cli.py`** previously defaulted `session_id` directly to `"default"` without checking `rpc_id_var.get()`:
- **`codex_cli.py` (before)**: [`evalbench/generators/models/codex_cli.py:L66-L69`](https://github.com/GoogleCloudPlatform/evalbench/blob/main/evalbench/generators/models/codex_cli.py#L66-L69)
  ```python
  if sys.argv[0].endswith("eval_server.py"):
      session_id = querygenerator_config.get("session_id", "default")
      self.fake_home = os.path.join(
          "/tmp_sessions", session_id, "fake_home")
  ```

As a result:
- Other generators isolate artifacts into per-session directories (`/tmp_sessions/<session_id>/fake_home`), uploading clean per-session output archives.
- `codex_cli` routed all scenario requests in an evaluation job into the single shared `/tmp_sessions/default/fake_home` directory.
- Consequently, all generated notebook and script artifacts across multiple scenarios accumulated in `/tmp_sessions/default/fake_home`, causing subsequent scenario evaluation archives to include leftover artifacts from earlier scenarios in the same job.

### Solution
Updated `CodexCliGenerator.__init__` in `evalbench/generators/models/codex_cli.py` to import `from util.context import rpc_id_var` and resolve `rpc_id_var.get()` when `session_id` is omitted, matching the implementation of `gemini_cli.py`, `claude_code.py`, and `agy_cli.py`.
