### PR TITLE
fix(evaluator): return 5-tuple in CortadoOrchestrator.process() to match Orchestrator contract

### DIFF
--- a/evalbench/evaluator/cortadoorchestrator.py
+++ b/evalbench/evaluator/cortadoorchestrator.py
@@ -34,4 +34,4 @@ class CortadoOrchestrator(Orchestrator):
             json.dump(self.total_scoring_results, f,
                       sort_keys=True, indent=4, default=str)
             scores_tf = f.name
-        return self.job_id, self.run_time, results_tf, scores_tf
+        return self.job_id, self.run_time, results_tf, scores_tf, None

--- a/evalbench/test/cortadoorchestrator_test.py
+++ b/evalbench/test/cortadoorchestrator_test.py
@@ -1,0 +1,54 @@
+import json
+import unittest
+from unittest.mock import MagicMock, patch
+from evaluator.cortadoorchestrator import CortadoOrchestrator
+
+
+class TestCortadoOrchestrator(unittest.TestCase):
+
+    @patch("evaluator.cortadoorchestrator.CortadoEvaluator")
+    def test_evaluate_and_process_returns_5_tuple(self, mock_evaluator_class):
+        mock_evaluator = MagicMock()
+        mock_evaluator.evaluate.return_value = (
+            [{"eval_id": "c1", "output": "sample_output"}],
+            [{"eval_id": "c1", "score": 100}],
+        )
+        mock_evaluator_class.return_value = mock_evaluator
+
+        config = {
+            "runners": {"eval_runners": 1},
+            "model_config": "fake_model_config",
+        }
+        orchestrator = CortadoOrchestrator(
+            config=config,
+            db_configs={},
+            setup_config={},
+        )
+
+        orchestrator.evaluate([MagicMock()])
+
+        # Call process and verify it returns a 5-tuple matching the Orchestrator contract
+        result = orchestrator.process()
+        self.assertEqual(len(result), 5)
+
+        job_id, run_time, results_tf, scores_tf, multi_trial_scores_tf = result
+        self.assertEqual(job_id, orchestrator.job_id)
+        self.assertEqual(run_time, orchestrator.run_time)
+        self.assertIsNotNone(results_tf)
+        self.assertIsNotNone(scores_tf)
+        self.assertIsNone(multi_trial_scores_tf)
+
+        # Verify contents dumped to temp files
+        with open(results_tf, "r") as f:
+            results_data = json.load(f)
+            self.assertEqual(len(results_data), 1)
+            self.assertEqual(results_data[0]["eval_id"], "c1")
+
+        with open(scores_tf, "r") as f:
+            scores_data = json.load(f)
+            self.assertEqual(len(scores_data), 1)
+            self.assertEqual(scores_data[0]["score"], 100)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Summary
Fixes a `ValueError: not enough values to unpack (expected 5, got 4)` in `eval_service.py` when running evaluation jobs with `cortado-format` / `CortadoOrchestrator`.

### Problem & Deep Research Verification

In `eval_service.py` (line 202), `eval_server.py` unpacks the result of `evaluator.process()` into a 5-tuple:
[`evalbench/eval_service.py:L202`](https://github.com/GoogleCloudPlatform/evalbench/blob/main/evalbench/eval_service.py#L202)
```python
job_id, run_time, results_tf, scores_tf, multi_trial_scores_tf = evaluator.process()
```

Every other `Orchestrator` subclass in the repo adheres to this 5-tuple return signature:
1. **Base `Orchestrator`**: [`evalbench/evaluator/orchestrator.py:L56-L63`](https://github.com/GoogleCloudPlatform/evalbench/blob/main/evalbench/evaluator/orchestrator.py#L56-L63)
   ```python
   def process(self):
       return (self.job_id, self.run_time, None, None, None)
   ```
2. **`AgentOrchestrator`**: [`evalbench/evaluator/agentorchestrator.py:L49-L55`](https://github.com/GoogleCloudPlatform/evalbench/blob/main/evalbench/evaluator/agentorchestrator.py#L49-L55)
   ```python
   return (self.job_id, self.run_time, results_tf, scores_tf, None)
   ```
3. **`DataEngineeringAgentOrchestrator`**: [`evalbench/evaluator/dataengineeringagentorchestrator.py:L69`](https://github.com/GoogleCloudPlatform/evalbench/blob/main/evalbench/evaluator/dataengineeringagentorchestrator.py#L69)
   ```python
   return self.job_id, self.run_time, results_tf, scores_tf, None
   ```
4. **`DataAgentOrchestrator`**: [`evalbench/evaluator/dataagentorchestrator.py:L222-L228`](https://github.com/GoogleCloudPlatform/evalbench/blob/main/evalbench/evaluator/dataagentorchestrator.py#L222-L228)
   ```python
   return (self.job_id, self.run_time, results_tf, scores_tf, None)
   ```
5. **`InteractOrchestrator`**: [`evalbench/evaluator/interactorchestrator.py:L223-L229`](https://github.com/GoogleCloudPlatform/evalbench/blob/main/evalbench/evaluator/interactorchestrator.py#L223-L229)
   ```python
   return (self.job_id, self.run_time, results_tf, scores_tf, None)
   ```
6. **`McpReadabilityOrchestrator`**: [`evalbench/evaluator/mcp_readability/orchestrator.py:L218`](https://github.com/GoogleCloudPlatform/evalbench/blob/main/evalbench/evaluator/mcp_readability/orchestrator.py#L218)
   ```python
   return (self.job_id, self.run_time, results_tf, scores_tf, None)
   ```
7. **`OneShotOrchestrator`**: [`evalbench/evaluator/oneshotorchestrator.py:L280-L286`](https://github.com/GoogleCloudPlatform/evalbench/blob/main/evalbench/evaluator/oneshotorchestrator.py#L280-L286)
   ```python
   return (self.job_id, self.run_time, results_tf, scores_tf, multi_trial_scores_tf)
   ```
8. **`StreamingOrchestrator`**: [`evalbench/evaluator/streamingorchestrator.py:L199-L205`](https://github.com/GoogleCloudPlatform/evalbench/blob/main/evalbench/evaluator/streamingorchestrator.py#L199-L205)
   ```python
   return (self.job_id, self.run_time, results_tf, scores_tf, multi_trial_scores_tf)
   ```

However, **`CortadoOrchestrator`** previously returned only a 4-tuple:
[`evalbench/evaluator/cortadoorchestrator.py:L37`](https://github.com/GoogleCloudPlatform/evalbench/blob/main/evalbench/evaluator/cortadoorchestrator.py#L37)
```python
# Before (4 elements):
return self.job_id, self.run_time, results_tf, scores_tf
```

When running `eval_server.py` with `cortado-format`, unpacking at line 202 failed with `ValueError: not enough values to unpack (expected 5, got 4)`.

### Solution
1. Updated `CortadoOrchestrator.process()` in `evalbench/evaluator/cortadoorchestrator.py` to return `(self.job_id, self.run_time, results_tf, scores_tf, None)`.
2. Added unit test `evalbench/test/cortadoorchestrator_test.py` to assert the 5-tuple contract and verify the dumped temp files.
