### PR TITLE
perf(viewer): send only plotted columns to the D3 charts

### DIFF
--- a/viewer/trends.py
+++ b/viewer/trends.py
@@ -24,8 +24,9 @@ def get_results_dir():
     return results_dir_candidates[1]  # Fallback to default
 
 def generate_d3_chart(df, x_col, y_col, hue_col, title, ylabel):
-    df_sorted = df.sort_values(by=x_col)
-    
+    # job_id is unplotted but read by the tooltip in chart.js.
+    df_sorted = df[[x_col, y_col, hue_col, "job_id"]].sort_values(by=x_col)
+
     # Convert dataframe to records for JSON
     data_records = df_sorted.to_dict(orient='records')
     import json


### PR DESCRIPTION
generate_d3_chart serialized every column of the trends cache into each
sandboxed iframe, including ai_summary — a ~1.7 KB LLM paragraph per run
that no chart reads. Four charts on 300 runs shipped 2.56 MB of HTML.

Project to the columns the chart actually uses: 131 KB, ~19x smaller.
job_id is kept because chart.js reads it for the hover tooltip.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>