### PR TITLE
refactor(viewer): collapse five copies of get_results_dir into paths.py

### DIFF
--- a/viewer/ai_comparer.py
+++ b/viewer/ai_comparer.py
@@ -11,6 +11,7 @@ sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "../eval
 from evalbench.generators.models import get_generator
 from evalbench.util.config import load_yaml_config
 from summarizer import get_summarizer
+from paths import get_results_dir
 
 # Setup logging
 logging.basicConfig(level=logging.INFO)
@@ -18,28 +19,6 @@ logger = logging.getLogger(__name__)
 
 # Global models dict for get_generator
 global_models = {"lock": threading.Lock(), "registered_models": {}}
-
-def get_results_dir():
-    # Try to read from environment variable
-    res_dir = os.environ.get("RESULTS_DIR")
-    if res_dir:
-        return res_dir
-        
-    # Check multiple locations for results directory
-    results_dir_candidates = [
-        "/tmp_session_files/results",
-        os.path.join(os.path.dirname(os.path.dirname(__file__)), "results"),
-        os.path.join(os.getcwd(), "results"),
-        "/evalbench/results"
-    ]
-    
-    for candidate in results_dir_candidates:
-        if os.path.exists(candidate):
-            logger.info(f"Found results directory at: {candidate}")
-            return candidate
-            
-    logger.warning("Results directory not found in candidates, defaulting to current directory results")
-    return os.path.join(os.getcwd(), "results")
 
 def compare_evals(id1, id2):
     """Compares two evaluation runs using Gemini."""

--- a/viewer/dataset_quality.py
+++ b/viewer/dataset_quality.py
@@ -13,13 +13,13 @@ import os
 
 import mesop as me
 
+from paths import get_results_dir
 from precompute_dataset_quality import (
     CACHE_FILENAME,
     DATASET_FORMAT_CONFIG_KEY,
     DATASET_QUALITY_FORMAT,
     SUMMARY_COMPARATOR,
     artifact_paths,
-    get_results_dir,
 )
 
 csv.field_size_limit(10**9)

--- a/viewer/main.py
+++ b/viewer/main.py
@@ -12,6 +12,7 @@ import precompute_trends
 import dataset_quality
 from summarizer import summarize_eval_scoring
 from ai_comparer import compare_evals
+from paths import get_results_dir
 
 @me.stateclass
 class State:
@@ -114,26 +115,6 @@ def df_to_config(df: pd.DataFrame) -> dict:
 
 
 
-
-
-def get_results_dir():
-    # Try to read from environment variable
-    res_dir = os.environ.get("RESULTS_DIR")
-    if res_dir:
-        return res_dir
-        
-    # Check multiple locations for results directory
-    results_dir_candidates = [
-        "/tmp_session_files/results",
-        os.path.join(os.path.dirname(os.path.dirname(__file__)), "results"),
-        os.path.join(os.getcwd(), "results"),
-    ]
-
-    for candidate in results_dir_candidates:
-        if os.path.exists(candidate) and os.path.isdir(candidate):
-            return candidate
-
-    return results_dir_candidates[1]  # Fallback to default
 
 
 # (mtime, value). Each is replaced as a whole so a concurrent reader never sees a

--- a/viewer/paths.py
+++ b/viewer/paths.py
@@ -1,0 +1,21 @@
+import os
+
+
+def get_results_dir():
+    res_dir = os.environ.get("RESULTS_DIR")
+    if res_dir:
+        return res_dir
+
+    # Candidate 1 is the repo root, which is /evalbench in the container, so the
+    # deployed image resolves it to the same /evalbench/results the runs write to.
+    candidates = [
+        "/tmp_session_files/results",
+        os.path.join(os.path.dirname(os.path.dirname(__file__)), "results"),
+        os.path.join(os.getcwd(), "results"),
+    ]
+
+    for candidate in candidates:
+        if os.path.isdir(candidate):
+            return candidate
+
+    return candidates[1]

--- a/viewer/precompute_dataset_quality.py
+++ b/viewer/precompute_dataset_quality.py
@@ -13,6 +13,8 @@ import json
 import logging
 import os
 
+from paths import get_results_dir
+
 logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
 
 CACHE_FILENAME = "dataset_quality_cache.json"
@@ -29,26 +31,6 @@ SUMMARY_COMPARATOR = "dataset_quality"
 # Category JSON blobs embed per-CUJ evidence and prose, and scores.csv rows are
 # correspondingly huge.
 csv.field_size_limit(10**9)
-
-
-def get_results_dir():
-    # Try to read from environment variable
-    res_dir = os.environ.get("RESULTS_DIR")
-    if res_dir:
-        return res_dir
-
-    # Check multiple locations for results directory
-    results_dir_candidates = [
-        "/tmp_session_files/results",
-        os.path.join(os.path.dirname(os.path.dirname(__file__)), "results"),
-        os.path.join(os.getcwd(), "results"),
-    ]
-
-    for candidate in results_dir_candidates:
-        if os.path.exists(candidate) and os.path.isdir(candidate):
-            return candidate
-
-    return results_dir_candidates[1]  # Fallback to default
 
 
 def _read_configs(configs_file):

--- a/viewer/precompute_trends.py
+++ b/viewer/precompute_trends.py
@@ -4,6 +4,8 @@ import json
 import argparse
 import pandas as pd
 
+from paths import get_results_dir
+
 logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
 
 BATCH_SIZE = int(os.environ.get("PRECOMPUTE_BATCH_SIZE", 50))
@@ -13,26 +15,6 @@ BATCH_SIZE = int(os.environ.get("PRECOMPUTE_BATCH_SIZE", 50))
 # backlog in about two hours, 16 would take closer to six. 50 is also about
 # where the summarizer starts seeing 429s, so raising it further buys nothing.
 MAX_WORKERS = int(os.environ.get("PRECOMPUTE_WORKERS", 50))
-
-
-def get_results_dir():
-    # Try to read from environment variable
-    res_dir = os.environ.get("RESULTS_DIR")
-    if res_dir:
-        return res_dir
-        
-    # Check multiple locations for results directory
-    results_dir_candidates = [
-        "/tmp_session_files/results",
-        os.path.join(os.path.dirname(os.path.dirname(__file__)), "results"),
-        os.path.join(os.getcwd(), "results"),
-    ]
-
-    for candidate in results_dir_candidates:
-        if os.path.exists(candidate) and os.path.isdir(candidate):
-            return candidate
-
-    return results_dir_candidates[1]  # Fallback to default
 
 
 def process_directory(d, results_dir):

--- a/viewer/precompute_trends.py
+++ b/viewer/precompute_trends.py
@@ -4,26 +4,9 @@ import json
 import argparse
 import pandas as pd
 
+from paths import get_results_dir
+
 logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
-
-def get_results_dir():
-    # Try to read from environment variable
-    res_dir = os.environ.get("RESULTS_DIR")
-    if res_dir:
-        return res_dir
-        
-    # Check multiple locations for results directory
-    results_dir_candidates = [
-        "/tmp_session_files/results",
-        os.path.join(os.path.dirname(os.path.dirname(__file__)), "results"),
-        os.path.join(os.getcwd(), "results"),
-    ]
-
-    for candidate in results_dir_candidates:
-        if os.path.exists(candidate) and os.path.isdir(candidate):
-            return candidate
-
-    return results_dir_candidates[1]  # Fallback to default
 
 
 def process_directory(d, results_dir):

--- a/viewer/trends.py
+++ b/viewer/trends.py
@@ -3,25 +3,8 @@ import logging
 import mesop as me
 import pandas as pd
 from main import State, list_run_dirs, load_trends_df
+from paths import get_results_dir
 
-def get_results_dir():
-    # Try to read from environment variable
-    res_dir = os.environ.get("RESULTS_DIR")
-    if res_dir:
-        return res_dir
-        
-    # Check multiple locations for results directory
-    results_dir_candidates = [
-        "/tmp_session_files/results",
-        os.path.join(os.path.dirname(os.path.dirname(__file__)), "results"),
-        os.path.join(os.getcwd(), "results"),
-    ]
-
-    for candidate in results_dir_candidates:
-        if os.path.exists(candidate) and os.path.isdir(candidate):
-            return candidate
-
-    return results_dir_candidates[1]  # Fallback to default
 
 def generate_d3_chart(df, x_col, y_col, hue_col, title, ylabel):
     # job_id is unplotted but read by the tooltip in chart.js.


### PR DESCRIPTION
Four of the five were byte-identical; ai_comparer's had drifted, accepting a
non-directory candidate and carrying an extra /evalbench/results entry that the
repo-root candidate already resolves to inside the container.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>