### PR TITLE
Fix precompute trends oom

### DIFF
--- a/evalbench/test/viewer_precompute_trends_test.py
+++ b/evalbench/test/viewer_precompute_trends_test.py
@@ -1,0 +1,414 @@
+"""Tests for the viewer's trends precompute.
+
+The precompute runs against a results directory that grew past 20k run
+directories in production, where a pass that held everything in memory and only
+wrote at the end was killed before it ever finished. These tests pin the
+properties that keep that from recurring: work happens in bounded batches, each
+batch is durably checkpointed, and a kill part way through loses only the batch
+in flight.
+"""
+
+import json
+import os
+import sys
+import tempfile
+import unittest
+from unittest.mock import patch
+
+import pandas as pd
+
+# Add viewer directory and root to sys.path
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "../../viewer")))
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "../..")))
+
+from viewer import precompute_trends
+
+
+def _row(job_id, product="prod", requester="req", dataset="ds.json"):
+    """A process_directory return value, with the fields precompute reads."""
+    return {
+        "run_time": "2026-08-05 00:00:00",
+        "requester": requester,
+        "product": product,
+        "dataset": dataset,
+        "model_config.generator": "gen",
+        "latency": 1.0,
+        "tokens": 2.0,
+        "trajectory": 3.0,
+        "executable": 4.0,
+        "turn_count": 5.0,
+        "exact_match": 6.0,
+        "llmrater": 7.0,
+        "goal_completion": 8.0,
+        "job_id": job_id,
+        "ai_score": 9.0,
+        "ai_summary": "summary",
+    }
+
+
+class PrecomputeTrendsTest(unittest.TestCase):
+
+    def setUp(self):
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temp_dir.cleanup)
+        self.results_dir = self.temp_dir.name
+
+        patcher = patch.object(
+            precompute_trends, "get_results_dir", return_value=self.results_dir
+        )
+        patcher.start()
+        self.addCleanup(patcher.stop)
+
+    def _make_runs(self, count, prefix="run"):
+        job_ids = [f"{prefix}-{i}" for i in range(count)]
+        for job_id in job_ids:
+            os.makedirs(os.path.join(self.results_dir, job_id))
+        return job_ids
+
+    def _path(self, name):
+        return os.path.join(self.results_dir, name)
+
+    def _cache(self):
+        return pd.read_csv(self._path("trends_cache.csv"))
+
+    def _processed(self):
+        with open(self._path("processed_dirs.json")) as f:
+            return json.load(f)
+
+    def _filters(self):
+        with open(self._path("filters_cache.json")) as f:
+            return json.load(f)
+
+    def test_all_runs_land_in_the_cache_across_batches(self):
+        job_ids = self._make_runs(7)
+        with patch.object(precompute_trends, "BATCH_SIZE", 2), patch.object(
+            precompute_trends, "process_directory", side_effect=lambda d, _: _row(d)
+        ):
+            precompute_trends.precompute()
+
+        self.assertCountEqual(job_ids, self._cache()["job_id"].tolist())
+        self.assertCountEqual(job_ids, self._processed())
+
+    def test_each_batch_is_checkpointed_before_the_next_one_starts(self):
+        """A pass killed mid-way must leave the completed batches on disk."""
+        self._make_runs(6)
+        seen_at_batch_boundary = []
+
+        def record_then_process(directory, _):
+            # Sampled on entry to each unit of work, so it reflects what a kill
+            # arriving at that moment would have left behind.
+            if os.path.exists(self._path("processed_dirs.json")):
+                seen_at_batch_boundary.append(len(self._processed()))
+            else:
+                seen_at_batch_boundary.append(0)
+            return _row(directory)
+
+        with patch.object(precompute_trends, "BATCH_SIZE", 2), patch.object(
+            precompute_trends, "process_directory", side_effect=record_then_process
+        ):
+            precompute_trends.precompute()
+
+        # Nothing checkpointed during batch 1, then 2 and 4 rows before the
+        # second and third batches: progress is durable as it goes.
+        self.assertEqual([0, 0, 2, 2, 4, 4], seen_at_batch_boundary)
+
+    def test_a_killed_pass_resumes_from_the_last_checkpoint(self):
+        self._make_runs(6)
+        boom = RuntimeError("SIGKILL stand-in")
+
+        calls = []
+
+        def fail_in_third_batch(directory, _):
+            calls.append(directory)
+            if len(calls) > 4:
+                raise boom
+            return _row(directory)
+
+        with patch.object(precompute_trends, "BATCH_SIZE", 2), patch.object(
+            precompute_trends, "process_directory", side_effect=fail_in_third_batch
+        ):
+            # process_directory raising is caught per directory, so the pass
+            # itself completes; the two failed runs stay unprocessed.
+            precompute_trends.precompute()
+
+        self.assertEqual(4, len(self._cache()))
+        self.assertEqual(4, len(self._processed()))
+
+        # The next pass picks up exactly what was left.
+        with patch.object(precompute_trends, "BATCH_SIZE", 2), patch.object(
+            precompute_trends, "process_directory", side_effect=lambda d, _: _row(d)
+        ):
+            precompute_trends.precompute()
+
+        self.assertEqual(6, len(self._cache()))
+        self.assertEqual(6, len(self._processed()))
+        self.assertEqual(6, self._cache()["job_id"].nunique())
+
+    def test_appending_never_reads_the_existing_rows_back(self):
+        """The cache is 57MB in production; loading it per batch is what this avoids."""
+        self._make_runs(4)
+        full_reads = []
+        real_read_csv = pd.read_csv
+
+        def spy(path, *args, **kwargs):
+            if str(path).endswith("trends_cache.csv"):
+                # nrows=0 reads the header only; usecols reads one column.
+                if kwargs.get("nrows") != 0 and "usecols" not in kwargs:
+                    full_reads.append(path)
+            return real_read_csv(path, *args, **kwargs)
+
+        with patch.object(precompute_trends, "BATCH_SIZE", 2), patch.object(
+            precompute_trends, "process_directory", side_effect=lambda d, _: _row(d)
+        ), patch.object(precompute_trends.pd, "read_csv", side_effect=spy):
+            precompute_trends.precompute()
+
+        self.assertEqual([], full_reads)
+
+    def test_a_run_still_in_flight_is_left_for_a_later_pass(self):
+        self._make_runs(2, prefix="done")
+        self._make_runs(1, prefix="running")
+
+        def skip_running(directory, _):
+            return None if directory.startswith("running") else _row(directory)
+
+        with patch.object(
+            precompute_trends, "process_directory", side_effect=skip_running
+        ):
+            precompute_trends.precompute()
+
+        self.assertCountEqual(["done-0", "done-1"], self._processed())
+        self.assertNotIn("running-0", self._processed())
+
+    def test_one_unreadable_run_does_not_cost_the_rest_of_its_batch(self):
+        self._make_runs(4)
+
+        def fail_on_one(directory, _):
+            if directory == "run-2":
+                raise OSError("transient FUSE error")
+            return _row(directory)
+
+        with patch.object(precompute_trends, "BATCH_SIZE", 4), patch.object(
+            precompute_trends, "process_directory", side_effect=fail_on_one
+        ):
+            precompute_trends.precompute()
+
+        self.assertCountEqual(
+            ["run-0", "run-1", "run-3"], self._cache()["job_id"].tolist()
+        )
+        self.assertNotIn("run-2", self._processed())
+
+    def test_filter_values_accumulate_across_passes(self):
+        self._make_runs(1, prefix="first")
+        with patch.object(
+            precompute_trends,
+            "process_directory",
+            side_effect=lambda d, _: _row(d, product="A", requester="ann", dataset="a.json"),
+        ):
+            precompute_trends.precompute()
+
+        self._make_runs(1, prefix="second")
+        with patch.object(
+            precompute_trends,
+            "process_directory",
+            side_effect=lambda d, _: _row(d, product="B", requester="bob", dataset="b.json"),
+        ):
+            precompute_trends.precompute()
+
+        filters = self._filters()
+        self.assertEqual(["A", "B"], filters["products"])
+        self.assertEqual(["ann", "bob"], filters["requesters"])
+        self.assertEqual(["a.json", "b.json"], filters["datasets"])
+        self.assertCountEqual(["first-0", "second-0"], filters["eval_ids"])
+
+    def test_filters_are_only_rewritten_when_they_change(self):
+        """Most batches add no new product or requester; rewriting is pure churn."""
+        self._make_runs(6)
+        writes = []
+        real_write_json = precompute_trends._write_json
+
+        def spy(path, data):
+            if str(path).endswith("filters_cache.json"):
+                writes.append(path)
+            return real_write_json(path, data)
+
+        with patch.object(precompute_trends, "BATCH_SIZE", 2), patch.object(
+            precompute_trends, "process_directory", side_effect=lambda d, _: _row(d)
+        ), patch.object(precompute_trends, "_write_json", side_effect=spy):
+            precompute_trends.precompute()
+
+        # Three batches, but every run carries the same product/requester/dataset,
+        # so only the first batch changes anything.
+        self.assertEqual(1, len(writes))
+
+    def test_unknown_filter_values_are_not_offered_as_choices(self):
+        self._make_runs(1)
+        with patch.object(
+            precompute_trends,
+            "process_directory",
+            side_effect=lambda d, _: _row(
+                d, product="unknown", requester="unknown", dataset="unknown"
+            ),
+        ):
+            precompute_trends.precompute()
+
+        filters = self._filters()
+        self.assertEqual([], filters["products"])
+        self.assertEqual([], filters["requesters"])
+        self.assertEqual([], filters["datasets"])
+
+    def test_a_run_already_in_the_cache_is_not_appended_twice(self):
+        """processed_dirs.json can be cleared on its own from the viewer."""
+        self._make_runs(2)
+        with patch.object(
+            precompute_trends, "process_directory", side_effect=lambda d, _: _row(d)
+        ):
+            precompute_trends.precompute()
+            os.remove(self._path("processed_dirs.json"))
+            precompute_trends.precompute()
+
+        self.assertEqual(2, len(self._cache()))
+
+    def test_no_new_directories_writes_nothing(self):
+        self._make_runs(1)
+        with patch.object(
+            precompute_trends, "process_directory", side_effect=lambda d, _: _row(d)
+        ):
+            precompute_trends.precompute()
+
+        before = os.path.getmtime(self._path("trends_cache.csv"))
+        with patch.object(
+            precompute_trends, "process_directory", side_effect=AssertionError
+        ):
+            precompute_trends.precompute()
+
+        self.assertEqual(before, os.path.getmtime(self._path("trends_cache.csv")))
+
+    def test_a_truncated_cache_is_started_over_rather_than_appended_to(self):
+        self._make_runs(1)
+        open(self._path("trends_cache.csv"), "w").close()
+
+        with patch.object(
+            precompute_trends, "process_directory", side_effect=lambda d, _: _row(d)
+        ):
+            precompute_trends.precompute()
+
+        self.assertEqual(["run-0"], self._cache()["job_id"].tolist())
+
+    def test_a_changed_row_schema_rewrites_the_cache_under_one_header(self):
+        self._make_runs(1, prefix="old")
+        with patch.object(
+            precompute_trends, "process_directory", side_effect=lambda d, _: _row(d)
+        ):
+            precompute_trends.precompute()
+
+        def with_new_field(directory, _):
+            row = _row(directory)
+            row["new_metric"] = 1.0
+            return row
+
+        self._make_runs(1, prefix="new")
+        with patch.object(
+            precompute_trends, "process_directory", side_effect=with_new_field
+        ):
+            precompute_trends.precompute()
+
+        cache = self._cache()
+        self.assertCountEqual(["old-0", "new-0"], cache["job_id"].tolist())
+        self.assertIn("new_metric", cache.columns)
+
+
+class ProcessDirectoryTest(unittest.TestCase):
+    """The per-run read, which is where the memory was actually spent."""
+
+    def setUp(self):
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temp_dir.cleanup)
+        self.results_dir = self.temp_dir.name
+        self.run_dir = os.path.join(self.results_dir, "run-0")
+        os.makedirs(self.run_dir)
+
+        # The summarizer makes a live model call per run; irrelevant here.
+        patcher = patch.dict(
+            sys.modules, {"summarizer": unittest.mock.MagicMock()}
+        )
+        patcher.start()
+        self.addCleanup(patcher.stop)
+
+        self._write("configs.csv", pd.DataFrame([
+            {"config": "experiment_config.product_name", "value": "Cloud SQL"},
+            {"config": "experiment_config.dataset_config", "value": "datasets/x/y.json"},
+            {"config": "model_config.generator", "value": "gemini"},
+        ]))
+
+    def _write(self, name, df):
+        df.to_csv(os.path.join(self.run_dir, name), index=False)
+
+    def _write_summary(self, include_goal_completion):
+        rows = [{
+            "metric_name": "end_to_end_latency",
+            "metric_score": 1.5,
+            "correct_results_count": 0,
+            "total_results_count": 0,
+            "run_time": "2026-08-05T00:00:00",
+        }]
+        if include_goal_completion:
+            rows.append({
+                "metric_name": "goal_completion",
+                "metric_score": 0,
+                "correct_results_count": 3,
+                "total_results_count": 4,
+                "run_time": "2026-08-05T00:00:00",
+            })
+        self._write("summary.csv", pd.DataFrame(rows))
+
+    def test_reads_the_metrics_a_run_reports(self):
+        self._write_summary(include_goal_completion=True)
+
+        res = precompute_trends.process_directory("run-0", self.results_dir)
+
+        self.assertEqual("Cloud SQL", res["product"])
+        self.assertEqual("y.json", res["dataset"])
+        self.assertEqual("gemini", res["model_config.generator"])
+        self.assertEqual(1.5, res["latency"])
+        self.assertEqual(75.0, res["goal_completion"])
+
+    def test_goal_completion_falls_back_to_scores_without_reading_the_log_blobs(self):
+        """scores.csv rows carry comparison_logs far larger than the scores."""
+        self._write_summary(include_goal_completion=False)
+        self._write("scores.csv", pd.DataFrame([
+            {"comparator": "goal_completion", "score": 100.0,
+             "comparison_logs": "x" * 100_000},
+            {"comparator": "goal_completion", "score": 0.0,
+             "comparison_logs": "x" * 100_000},
+        ]))
+
+        read_columns = []
+        real_read_csv = pd.read_csv
+
+        def spy(path, *args, **kwargs):
+            if str(path).endswith("scores.csv") and kwargs.get("nrows") != 0:
+                read_columns.append(kwargs.get("usecols"))
+            return real_read_csv(path, *args, **kwargs)
+
+        with patch.object(precompute_trends.pd, "read_csv", side_effect=spy):
+            res = precompute_trends.process_directory("run-0", self.results_dir)
+
+        self.assertEqual(50.0, res["goal_completion"])
+        self.assertEqual([["comparator", "score"]], read_columns)
+
+    def test_a_scores_file_without_the_expected_columns_is_left_alone(self):
+        self._write_summary(include_goal_completion=False)
+        self._write("scores.csv", pd.DataFrame([{"something_else": 1}]))
+
+        res = precompute_trends.process_directory("run-0", self.results_dir)
+
+        self.assertEqual(0.0, res["goal_completion"])
+
+    def test_a_run_without_a_summary_is_skipped(self):
+        self.assertIsNone(
+            precompute_trends.process_directory("run-0", self.results_dir)
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/evalbench/test/viewer_summarizer_test.py
+++ b/evalbench/test/viewer_summarizer_test.py
@@ -4,11 +4,20 @@ import tempfile
 import unittest
 from unittest.mock import patch, MagicMock
 
+import pandas as pd
+
 # Add viewer directory and root to sys.path
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "../../viewer")))
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "../..")))
 
-from viewer.summarizer import get_summarizer
+from viewer.summarizer import (
+    SCORES_MAX_CHARS,
+    SCORES_MAX_COLWIDTH,
+    SCORES_MAX_ROWS,
+    get_summarizer,
+    render_scores_for_prompt,
+    summarize_eval_scoring,
+)
 
 
 class TestViewerSummarizer(unittest.TestCase):
@@ -123,6 +132,114 @@ class TestViewerSummarizer(unittest.TestCase):
         mock_get_generator.assert_called_once()
         args, _ = mock_get_generator.call_args
         self.assertEqual(args[1], os.path.abspath(custom_config_path))
+
+
+class ScoresPromptBoundsTest(unittest.TestCase):
+    """The scores.csv render must stay small whatever shape the run has.
+
+    Gemini rejects prompts over 1,048,576 tokens. Production was exceeding that
+    continuously because the full render was pasted into the prompt.
+    """
+
+    def test_one_huge_cell_does_not_drag_every_row_up_with_it(self):
+        # The production shape that broke this: eight rows, one of which carries
+        # a comparison_logs blob the size of the whole file. to_string() pads
+        # each column to its widest value, so the other seven rows were each
+        # billed for the blob's width in whitespace.
+        blob = "x" * 1_200_000
+        df = pd.DataFrame({
+            "comparator": ["goal_completion"] * 8,
+            "comparison_logs": [blob] + ["{}"] * 7,
+            "score": [100.0] * 8,
+        })
+
+        rendered = render_scores_for_prompt(df)
+
+        # Unbounded this is ~9.6 MB; the blob must be paid for at most once.
+        self.assertLess(len(rendered), 8 * SCORES_MAX_COLWIDTH * len(df.columns))
+        self.assertLess(len(rendered), len(blob))
+
+    def test_the_columns_a_reader_needs_survive_truncation(self):
+        df = pd.DataFrame({
+            "comparator": ["goal_completion", "trajectory_matcher"],
+            "comparison_logs": ["y" * 900_000, "{}"],
+            "score": [100.0, 0.0],
+        })
+
+        rendered = render_scores_for_prompt(df)
+
+        # Truncating the blob must not cost the narrow columns beside it, which
+        # are the ones analyzer.md actually scores against.
+        self.assertIn("goal_completion", rendered)
+        self.assertIn("trajectory_matcher", rendered)
+        self.assertIn("100.0", rendered)
+
+    def test_a_small_scores_file_is_rendered_whole(self):
+        df = pd.DataFrame({
+            "comparator": ["executable", "exact_match"],
+            "comparison_logs": ["ran clean", "mismatched on col 3"],
+            "score": [100.0, 0.0],
+        })
+
+        rendered = render_scores_for_prompt(df)
+
+        # Nothing here is near a bound, so nothing should be elided.
+        self.assertIn("ran clean", rendered)
+        self.assertIn("mismatched on col 3", rendered)
+        self.assertNotIn("omitted", rendered)
+        self.assertNotIn("truncated", rendered)
+
+    def test_rows_past_the_cap_are_reported_rather_than_silently_dropped(self):
+        df = pd.DataFrame({
+            "comparator": ["executable"] * (SCORES_MAX_ROWS + 25),
+            "score": [100.0] * (SCORES_MAX_ROWS + 25),
+        })
+
+        rendered = render_scores_for_prompt(df)
+
+        # A summary built on a subset must say so, or it reads as complete.
+        self.assertIn("25 further rows omitted", rendered)
+
+    def test_many_wide_rows_still_land_under_the_backstop(self):
+        # Neither bound alone catches this: every cell is under the width cap
+        # and the row count is at the limit, yet the product is megabytes.
+        df = pd.DataFrame({
+            f"col_{i}": ["z" * 600] * SCORES_MAX_ROWS for i in range(10)
+        })
+
+        rendered = render_scores_for_prompt(df)
+
+        self.assertLessEqual(len(rendered), SCORES_MAX_CHARS + len("\n... truncated ..."))
+        self.assertTrue(rendered.endswith("... truncated ..."))
+
+    @patch("viewer.summarizer.get_summarizer")
+    def test_the_prompt_sent_to_gemini_is_the_bounded_render(self, mock_get_summarizer):
+        temp_dir = tempfile.TemporaryDirectory()
+        self.addCleanup(temp_dir.cleanup)
+        pd.DataFrame({"question": ["q1"], "id": [1]}).to_csv(
+            os.path.join(temp_dir.name, "evals.csv"), index=False
+        )
+        pd.DataFrame({
+            "comparator": ["goal_completion"] * 8,
+            "comparison_logs": ["x" * 1_200_000] + ["{}"] * 7,
+        }).to_csv(os.path.join(temp_dir.name, "scores.csv"), index=False)
+
+        generator = MagicMock()
+        generator.vertex_model = "gemini-2.5-flash"
+        mock_get_summarizer.return_value = generator
+        generator.client.models.generate_content.return_value.text = "General Score: 90"
+
+        env = {k: v for k, v in os.environ.items() if k != "GOOGLE_API_KEY"}
+        with patch.dict(os.environ, env, clear=True):
+            result = summarize_eval_scoring(temp_dir.name)
+
+        self.assertEqual(result, "General Score: 90")
+        _, kwargs = generator.client.models.generate_content.call_args
+        prompt = kwargs["contents"]
+        # ~1,048,576 tokens is the hard API limit; four chars per token is the
+        # usual rough conversion, so stay an order of magnitude clear of it.
+        self.assertLess(len(prompt), 400_000)
+        self.assertIn("### Scores Data:", prompt)
 
 
 if __name__ == "__main__":

--- a/viewer/precompute_trends.py
+++ b/viewer/precompute_trends.py
@@ -8,16 +8,22 @@ logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(
 
 # A pass used to submit every unprocessed run at once, hold all of it in memory,
 # and write only after the last one finished. In production that pass never
-# finished: it was SIGKILLed roughly every three minutes having got through ~183
-# of 8166 directories, and because nothing had been written it restarted from the
-# same 8166 every time. The cache stood still for six weeks.
+# finished: it was SIGKILLed roughly every two and a half minutes having got
+# through exactly 183 of 8168 directories, and because nothing had been written
+# it restarted from the same 8168 every time. The cache stood still for six
+# weeks. What exhausted the memory is fixed in summarizer.py; batching is what
+# stops a kill from costing the whole pass.
 #
-# Batching bounds how much is in flight and checkpoints as it goes, so a kill
-# costs one batch instead of the whole pass. The batch size is deliberately well
-# under the ~183 directories a cycle managed before dying, so several checkpoints
-# land inside a cycle even if the kills continue.
+# The batch size is deliberately well under the 183 directories a cycle managed
+# before dying, so several checkpoints land inside a cycle even if the kills
+# continue for some other reason.
 BATCH_SIZE = int(os.environ.get("PRECOMPUTE_BATCH_SIZE", 50))
-MAX_WORKERS = int(os.environ.get("PRECOMPUTE_WORKERS", 16))
+
+# Each directory costs one Gemini call, so the pass is latency-bound rather than
+# CPU-bound and the thread count sets the drain rate: 50 threads clear the
+# backlog in about two hours, 16 would take closer to six. 50 is also about
+# where the summarizer starts seeing 429s, so raising it further buys nothing.
+MAX_WORKERS = int(os.environ.get("PRECOMPUTE_WORKERS", 50))
 
 
 def get_results_dir():

--- a/viewer/precompute_trends.py
+++ b/viewer/precompute_trends.py
@@ -6,6 +6,20 @@ import pandas as pd
 
 logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
 
+# A pass used to submit every unprocessed run at once, hold all of it in memory,
+# and write only after the last one finished. In production that pass never
+# finished: it was SIGKILLed roughly every three minutes having got through ~183
+# of 8166 directories, and because nothing had been written it restarted from the
+# same 8166 every time. The cache stood still for six weeks.
+#
+# Batching bounds how much is in flight and checkpoints as it goes, so a kill
+# costs one batch instead of the whole pass. The batch size is deliberately well
+# under the ~183 directories a cycle managed before dying, so several checkpoints
+# land inside a cycle even if the kills continue.
+BATCH_SIZE = int(os.environ.get("PRECOMPUTE_BATCH_SIZE", 50))
+MAX_WORKERS = int(os.environ.get("PRECOMPUTE_WORKERS", 16))
+
+
 def get_results_dir():
     # Try to read from environment variable
     res_dir = os.environ.get("RESULTS_DIR")
@@ -93,8 +107,13 @@ def process_directory(d, results_dir):
 
             if file_to_read:
                 try:
-                    df = pd.read_csv(file_to_read)
-                    if 'comparator' in df.columns and 'score' in df.columns:
+                    # Only the two columns needed. These files carry per-row
+                    # comparison_logs blobs orders of magnitude larger than the
+                    # scores, and every worker thread reading one in full is the
+                    # largest allocation a batch makes.
+                    columns = pd.read_csv(file_to_read, nrows=0).columns
+                    if 'comparator' in columns and 'score' in columns:
+                        df = pd.read_csv(file_to_read, usecols=['comparator', 'score'])
                         gc_scores = df[df['comparator'] == 'goal_completion']
                         if not gc_scores.empty:
                             correct = len(gc_scores[gc_scores['score'] == 100.0])
@@ -150,120 +169,172 @@ def process_directory(d, results_dir):
         return None
 
 
+def _read_json(path, default):
+    if not os.path.exists(path):
+        return default
+    try:
+        with open(path, "r") as f:
+            return json.load(f)
+    except Exception as e:
+        logging.error(f"Error reading {path}: {e}")
+        return default
+
+
+def _write_json(path, data):
+    with open(path, "w") as f:
+        json.dump(data, f, indent=2)
+
+
+def _cached_job_ids(cache_file):
+    """Job ids already in the trends cache, read without the rest of the file.
+
+    Only needed to keep a re-processed run from being appended twice; loading
+    every column to find out would mean reading the whole cache back on startup.
+    """
+    if not os.path.exists(cache_file):
+        return set()
+    try:
+        return set(pd.read_csv(cache_file, usecols=['job_id'])['job_id'].dropna())
+    except Exception as e:
+        logging.error(f"Error reading job ids from trends cache: {e}")
+        return set()
+
+
+def _append_rows(cache_file, rows):
+    """Append a batch to the trends cache without reading the existing rows back."""
+    new_df = pd.DataFrame(rows)
+    # A zero-byte cache is the leftover of a write that was killed part way; it
+    # has no header to append under, so start it over.
+    if not os.path.exists(cache_file) or os.path.getsize(cache_file) == 0:
+        new_df.to_csv(cache_file, index=False)
+        return
+
+    header = list(pd.read_csv(cache_file, nrows=0).columns)
+    if set(header) != set(new_df.columns):
+        # process_directory gained or lost a field since the cache was written.
+        # One consistent header matters more than the memory this costs, and a
+        # rewrite only happens on the first batch after such a change.
+        logging.warning(
+            "Trends cache columns changed; rewriting %s to match", cache_file
+        )
+        combined = pd.concat([pd.read_csv(cache_file), new_df], ignore_index=True)
+        combined = combined.drop_duplicates(subset=['job_id'], keep='last')
+        combined.to_csv(cache_file, index=False)
+        return
+
+    new_df[header].to_csv(cache_file, mode="a", header=False, index=False)
+
+
 def precompute():
     results_dir = get_results_dir()
     logging.info(f"Reading results from {results_dir}")
-    
+
     if not os.path.exists(results_dir):
         logging.warning(f"Results directory not found at {results_dir}")
         return
-        
-    # Load processed directories
-    processed_dirs_file = os.path.join(results_dir, "processed_dirs.json")
-    processed_dirs = set()
-    if os.path.exists(processed_dirs_file):
-        try:
-            with open(processed_dirs_file, "r") as f:
-                processed_dirs = set(json.load(f))
-            logging.info(f"Loaded {len(processed_dirs)} processed directories from state.")
-        except Exception as e:
-            logging.error(f"Error reading processed dirs file: {e}")
 
-    # Load existing trends data
+    processed_dirs_file = os.path.join(results_dir, "processed_dirs.json")
     cache_file = os.path.join(results_dir, "trends_cache.csv")
-    existing_df = pd.DataFrame()
-    if os.path.exists(cache_file):
-        try:
-            existing_df = pd.read_csv(cache_file)
-            logging.info(f"Loaded {len(existing_df)} rows of existing trends data.")
-        except Exception as e:
-            logging.error(f"Error reading trends cache: {e}")
+    filters_file = os.path.join(results_dir, "filters_cache.json")
+
+    processed_dirs = set(_read_json(processed_dirs_file, []))
+    logging.info(f"Loaded {len(processed_dirs)} processed directories from state.")
 
     all_directories = [
         d
         for d in os.listdir(results_dir)
         if os.path.isdir(os.path.join(results_dir, d))
     ]
-    
+
     # Filter for new directories
     new_directories = [d for d in all_directories if d not in processed_dirs]
-    
+
     total_new = len(new_directories)
     logging.info(f"Found {len(all_directories)} total directories. {total_new} are new.")
-    
+
     if total_new == 0:
         logging.info("No new directories to process.")
         return
 
-    data = []
-    products = set()
-    requesters = set()
-    datasets = set()
-    eval_ids = all_directories
-    
-    # If we have existing data, populate products and requesters from it
-    if not existing_df.empty:
-        if 'product' in existing_df.columns:
-            products.update(existing_df['product'].dropna().unique())
-        if 'requester' in existing_df.columns:
-            requesters.update(existing_df['requester'].dropna().unique())
+    # Carried forward from the last pass rather than recomputed off the trends
+    # cache, which would mean loading every row of it.
+    filters = _read_json(filters_file, {})
+    products = set(filters.get("products", []))
+    requesters = set(filters.get("requesters", []))
+    datasets = set(filters.get("datasets", []))
 
-    successfully_processed = []
-    
+    cached_job_ids = _cached_job_ids(cache_file)
+
     from concurrent.futures import ThreadPoolExecutor
-    
-    logging.info(f"Processing {len(new_directories)} new directories with 50 threads...")
-    with ThreadPoolExecutor(max_workers=50) as executor:
-        futures = [executor.submit(process_directory, d, results_dir) for d in new_directories]
-        
-        for future in futures:
-            res = future.result()
-            if res:
-                data.append(res)
-                successfully_processed.append(res['job_id'])
+
+    logging.info(
+        f"Processing {total_new} new directories in batches of {BATCH_SIZE} "
+        f"with {MAX_WORKERS} threads..."
+    )
+
+    for start in range(0, total_new, BATCH_SIZE):
+        batch = new_directories[start:start + BATCH_SIZE]
+        rows = []
+        batch_processed = []
+
+        with ThreadPoolExecutor(max_workers=MAX_WORKERS) as executor:
+            futures = {
+                executor.submit(process_directory, d, results_dir): d for d in batch
+            }
+            for future, directory in futures.items():
+                try:
+                    res = future.result()
+                except Exception:
+                    # One unreadable run must not cost the rest of the batch.
+                    logging.exception(f"Error processing {directory}")
+                    continue
+                if not res:
+                    # No summary.csv yet — likely still running, so leave it
+                    # unprocessed and pick it up on a later pass.
+                    continue
+
+                batch_processed.append(res['job_id'])
+                if res['job_id'] in cached_job_ids:
+                    logging.info(f"{res['job_id']} already in trends cache; not re-appending")
+                    continue
+
+                rows.append(res)
+                cached_job_ids.add(res['job_id'])
                 if res['product'] != "unknown" and str(res['product']).strip() != "":
                     products.add(res['product'])
                 if res['requester'] != "unknown" and str(res['requester']).strip() != "":
                     requesters.add(res['requester'])
                 if res['dataset'] != "unknown":
                     datasets.add(res['dataset'])
-                
-    if not data and existing_df.empty:
-        logging.warning("No data found in any run directory and no existing cache.")
-        return
-        
-    new_df = pd.DataFrame(data)
-    
-    # Combine with existing data
-    if not existing_df.empty:
-        df = pd.concat([existing_df, new_df], ignore_index=True)
-    else:
-        df = new_df
-        
-    # Drop duplicates just in case (based on job_id)
-    df = df.drop_duplicates(subset=['job_id'], keep='last')
-    
-    # Save trends cache
-    df.to_csv(cache_file, index=False)
+
+        if rows:
+            _append_rows(cache_file, rows)
+
+        # Checkpoint after every batch: whatever this pass has managed so far
+        # survives a kill, and the next pass resumes instead of restarting.
+        processed_dirs.update(batch_processed)
+        _write_json(processed_dirs_file, sorted(processed_dirs))
+
+        # Filter values repeat heavily across runs, so most batches leave this
+        # unchanged and there is no reason to rewrite it.
+        new_filters = {
+            "products": sorted(products),
+            "requesters": sorted(requesters),
+            "eval_ids": sorted(all_directories),
+            "datasets": sorted(datasets),
+        }
+        if new_filters != filters:
+            _write_json(filters_file, new_filters)
+            filters = new_filters
+
+        logging.info(
+            f"Batch {start // BATCH_SIZE + 1}/{-(-total_new // BATCH_SIZE)}: "
+            f"appended {len(rows)} rows, {len(processed_dirs)} directories processed."
+        )
+
     logging.info(f"Precomputed trends data saved to {cache_file}")
-    
-    # Save filters cache
-    filters_file = os.path.join(results_dir, "filters_cache.json")
-    filters_data = {
-        "products": sorted(list(products)),
-        "requesters": sorted(list(requesters)),
-        "eval_ids": sorted(list(eval_ids)),
-        "datasets": sorted(list(datasets))
-    }
-    with open(filters_file, "w") as f:
-        json.dump(filters_data, f, indent=2)
     logging.info(f"Precomputed filter values saved to {filters_file}")
-    
-    # Save processed directories list
-    new_processed_dirs = processed_dirs.union(set(successfully_processed))
-    with open(processed_dirs_file, "w") as f:
-        json.dump(list(new_processed_dirs), f, indent=2)
-    logging.info(f"Saved {len(new_processed_dirs)} processed directories to state.")
+    logging.info(f"Saved {len(processed_dirs)} processed directories to state.")
 
 
 if __name__ == "__main__":

--- a/viewer/precompute_trends.py
+++ b/viewer/precompute_trends.py
@@ -6,17 +6,6 @@ import pandas as pd
 
 logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
 
-# A pass used to submit every unprocessed run at once, hold all of it in memory,
-# and write only after the last one finished. In production that pass never
-# finished: it was SIGKILLed roughly every two and a half minutes having got
-# through exactly 183 of 8168 directories, and because nothing had been written
-# it restarted from the same 8168 every time. The cache stood still for six
-# weeks. What exhausted the memory is fixed in summarizer.py; batching is what
-# stops a kill from costing the whole pass.
-#
-# The batch size is deliberately well under the 183 directories a cycle managed
-# before dying, so several checkpoints land inside a cycle even if the kills
-# continue for some other reason.
 BATCH_SIZE = int(os.environ.get("PRECOMPUTE_BATCH_SIZE", 50))
 
 # Each directory costs one Gemini call, so the pass is latency-bound rather than

--- a/viewer/summarizer.py
+++ b/viewer/summarizer.py
@@ -19,14 +19,6 @@ global_models = {"lock": threading.Lock(), "registered_models": {}}
 
 # Bounds on how much of scores.csv is rendered into the prompt.
 #
-# DataFrame.to_string() pads every column out to its widest value, so one large
-# cell is paid for by every row. An eight-row production scores.csv carrying a
-# single 1.27 MB comparison_logs blob rendered to 11.5 MB -- 8.9x the file on
-# disk, nearly all of it whitespace. Gemini rejects anything over 1,048,576
-# tokens and was doing so continuously: prompts between 1.5M and 4.36M tokens,
-# each one wasting the run's summary and returning an error string in its place.
-# Fifty of these were built concurrently during a precompute pass.
-#
 # Three bounds because each covers a different shape of run: cell width for a
 # run with one huge blob, row count for a run with many results, and total
 # characters as a backstop for anything that slips past both. The analyzer

--- a/viewer/summarizer.py
+++ b/viewer/summarizer.py
@@ -17,6 +17,38 @@ logger = logging.getLogger(__name__)
 # Global models dict for get_generator
 global_models = {"lock": threading.Lock(), "registered_models": {}}
 
+# Bounds on how much of scores.csv is rendered into the prompt.
+#
+# DataFrame.to_string() pads every column out to its widest value, so one large
+# cell is paid for by every row. An eight-row production scores.csv carrying a
+# single 1.27 MB comparison_logs blob rendered to 11.5 MB -- 8.9x the file on
+# disk, nearly all of it whitespace. Gemini rejects anything over 1,048,576
+# tokens and was doing so continuously: prompts between 1.5M and 4.36M tokens,
+# each one wasting the run's summary and returning an error string in its place.
+# Fifty of these were built concurrently during a precompute pass.
+#
+# Three bounds because each covers a different shape of run: cell width for a
+# run with one huge blob, row count for a run with many results, and total
+# characters as a backstop for anything that slips past both. The analyzer
+# prompt asks for per-comparator scores and representative failures, so
+# truncated cells cost it nothing.
+SCORES_MAX_COLWIDTH = 500
+SCORES_MAX_ROWS = 500
+SCORES_MAX_CHARS = 200_000
+
+
+def render_scores_for_prompt(scores_df):
+    """Render scores.csv for the analyzer prompt within a bounded size."""
+    body = scores_df.head(SCORES_MAX_ROWS).to_string(
+        max_colwidth=SCORES_MAX_COLWIDTH
+    )
+    omitted = len(scores_df) - SCORES_MAX_ROWS
+    if omitted > 0:
+        body += f"\n... {omitted} further rows omitted ..."
+    if len(body) > SCORES_MAX_CHARS:
+        body = body[:SCORES_MAX_CHARS] + "\n... truncated ..."
+    return body
+
 def get_summarizer(results_dir: str = None, dataset_name: str = None, model_config_path: str = None):
     """Loads the generator based on explicit parameter, run_config.yaml, dataset_models mapping, or viewer/config/summarizer_config.yaml fallback."""
     selected_config_path = model_config_path
@@ -92,7 +124,7 @@ def summarize_eval_scoring(results_dir, dataset_name=None, model_config_path=Non
 
         if scores_df is not None:
             prompt += "### Scores Data:\n"
-            prompt += scores_df.to_string() + "\n\n"
+            prompt += render_scores_for_prompt(scores_df) + "\n\n"
 
         # Get generator or use API key directly
         from google import genai


### PR DESCRIPTION
The Trends tab shows no data newer than **2026-06-25**. `trends_cache.csv` was last
written `2026-06-25T03:17:43Z`, holds 13,163 rows, and the newest `run_time` in it is
`2026-06-25 03:02:11`. 8,168 run directories have piled up behind it.

The precompute process is SIGKILLed roughly every 2.5 minutes. Every restart logs an
identical pair:

    WARN exited: precompute_trends (terminated by SIGKILL; not expected)
    Loaded 13163 processed directories from state.
    Found 21331 total directories. 8168 are new.

It then processes exactly 183 directories and dies. Because the old code wrote nothing
until the final lines of `precompute()`, all 183 were discarded every time — roughly
500 times a day for six weeks, with zero net progress.

### Root cause

`summarize_eval_scoring` pasted the entire `scores.csv` into the Gemini prompt via
`DataFrame.to_string()`. **That call pads every column to its widest value**, so a single
large `comparison_logs` cell is billed to every row in the frame.

Measured on `results/034b0627-59fa-4b4c-9193-612ed4a40304`:

| | |
|---|---|
| CSV on disk | 1.28 MB |
| Rows | **8** |
| Largest `comparison_logs` cell | 1,273,196 chars |
| `to_string()` output | **11,460,329 chars** = 1,536,138 tokens |
| Amplification | **8.9×**, almost entirely whitespace |

Gemini's limit is 1,048,576 tokens, so these were rejected outright — 61 rejections in a
45-minute window, ranging 1.5M to 4.36M tokens:

    400 INVALID_ARGUMENT: The input token count (1536138) exceeds the maximum
    number of tokens allowed (1048576).

Each rejection cost that run its summary and stored `"Error during summarization: ..."`
in the trends cache in its place. **50 of these strings were built concurrently** by
every precompute pass, which is what exhausted the container's memory.

Worth noting this is not a "too many rows" problem — the file above has 8 rows. Capping
row count would have changed nothing.