### PR TITLE
fix: remove hardcoded GCP project ID from default summarizer config

### DIFF
--- a/viewer/config/gemini_summarizer_model.yaml
+++ b/viewer/config/gemini_summarizer_model.yaml
@@ -1,5 +1,5 @@
 generator: gcp_vertex_gemini
 vertex_model: gemini-2.5-flash
-gcp_project_id: evalbench-dev
+gcp_project_id: ""
 gcp_region: us-central1
 execs_per_minute: 5


### PR DESCRIPTION
The default summarizer config hardcodes the `evalbench-dev` project. This prevents the code from falling back to the `EVAL_GCP_PROJECT_ID` environment variable, which breaks hosted deployments (e.g. on GKE/Cloud Run) for outside users. Setting it to an empty string fixes this by allowing the environment variable fallback to work as intended.