### PR TITLE
feat(query_data_api): capture pipeline_debug_info in eval reports via REST

### DIFF
--- a/datasets/query_data_api/model_configs/querydata_config.yaml
+++ b/datasets/query_data_api/model_configs/querydata_config.yaml
@@ -3,6 +3,10 @@ project_id: "<YOUR_GCP_PROJECT_ID>"
 location: "<YOUR_GDA_LOCATION>"
 generator: "query_data_api"
 
+# Use the REST path. Required to capture pipeline_debug_info in reports, as
+# generate_debug_info is an unreleased field the typed gRPC client rejects.
+use_rest_api: true
+
 # Optional. Override the default production endpoint (leave unset for prod).
 # Example — sandbox: "autopush-geminidataanalytics.sandbox.googleapis.com"
 # api_endpoint: "<HOSTNAME>"

--- a/evalbench/generators/models/query_data_api.py
+++ b/evalbench/generators/models/query_data_api.py
@@ -19,7 +19,10 @@ _REQUEST_TIMEOUT_SECONDS = 300.0
 # Default Production API Endpoint for Gemini Data Analytics
 _DEFAULT_API_ENDPOINT = "geminidataanalytics.googleapis.com"
 
-# Shared default generation options settings
+# Shared default generation options settings. generate_debug_info is added
+# only on the REST path: it is an unreleased field, absent from the SDK proto,
+# so the typed client would reject it. It returns pipeline_debug_info, which we
+# surface in the eval report.
 _DEFAULT_GENERATION_OPTIONS = {
     "generate_query_result": True,
     "generate_natural_language_answer": False,
@@ -54,6 +57,7 @@ def _format_result(
     generated_sql: Any,
     intent_explanation: Any,
     disambiguation_questions: Any,
+    pipeline_debug_info: Any = None,
 ) -> Dict[str, Any]:
     """Formats raw API response fields into standard result format."""
     return {
@@ -65,6 +69,7 @@ def _format_result(
             "disambiguation_question": list(
                 disambiguation_questions or []
             ),
+            "pipeline_debug_info": pipeline_debug_info or {},
         },
     }
 
@@ -175,7 +180,7 @@ class QueryDataAPIGenerator(QueryGenerator):
             "prompt": prompt,
             "context": _to_camel_case_dict(self.context),
             "generationOptions": _to_camel_case_dict(
-                _DEFAULT_GENERATION_OPTIONS
+                {**_DEFAULT_GENERATION_OPTIONS, "generate_debug_info": True}
             ),
         }
 
@@ -204,4 +209,5 @@ class QueryDataAPIGenerator(QueryGenerator):
             data.get("generatedQuery"),
             data.get("intentExplanation"),
             data.get("disambiguationQuestion"),
+            data.get("pipelineDebugInfo"),
         )

--- a/evalbench/test/query_data_api_test.py
+++ b/evalbench/test/query_data_api_test.py
@@ -220,6 +220,42 @@ class TestQueryDataAPIGenerator(unittest.TestCase):
         }
         self.assertEqual(call_kwargs["json"]["context"], expected_camel_context)
 
+    @patch('generators.models.query_data_api.requests')
+    @patch('generators.models.query_data_api.google.auth.default')
+    @patch('generators.models.query_data_api.gda')
+    def test_rest_sends_debug_flag_and_surfaces_pipeline_debug_info(
+        self, mock_gda, mock_auth_default, mock_requests
+    ):
+        mock_credentials = MagicMock()
+        mock_auth_default.return_value = (mock_credentials, "project-id")
+
+        debug_info = {"steps": [{"name": "plan", "duration_ms": 12}]}
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = {
+            "generatedQuery": "SELECT 1",
+            "intentExplanation": "trivial",
+            "disambiguationQuestion": [],
+            "pipelineDebugInfo": debug_info,
+        }
+        mock_requests.post.return_value = mock_resp
+
+        config = {
+            "project_id": "test-project",
+            "location": "us-east1",
+            "use_rest_api": True,
+        }
+        generator = QueryDataAPIGenerator(config)
+        result = generator.generate_internal("Anything")
+
+        # The request opts the API into debug output.
+        gen_opts = mock_requests.post.call_args[1]["json"]["generationOptions"]
+        self.assertTrue(gen_opts["generateDebugInfo"])
+
+        # The response's pipeline debug info flows into the report's `other`.
+        self.assertEqual(
+            result["other"]["pipeline_debug_info"], debug_info
+        )
+
     def test_to_camel_case_dict_coverage(self):
         from generators.models.query_data_api import _to_camel_case_dict
 


### PR DESCRIPTION
Requests generate_debug_info and surfaces the returned pipeline_debug_info in the eval report under other.pipeline_debug_info. REST-only, since both fields are unreleased and absent from the SDK proto; the sample querydata_config.yaml now sets use_rest_api: true.