### PR TITLE
fix(examples): fix Jupyter Notebook JSON schema validation errors and update title

### DIFF
--- a/docs/examples/agent_runtime_deployment.ipynb
+++ b/docs/examples/agent_runtime_deployment.ipynb
@@ -4,7 +4,7 @@
    "id": "5b5c8393",
    "cell_type": "markdown",
    "source": [
-    "# Evaluating an ADK Agent to Agent Runtime (Gemini Enterprise Agent Platform)\n",
+    "# Evaluating an ADK Agent in Agent Runtime with EvalBench\n",
     "\n",
     "This notebook guides you through the process of:\n",
     "1. Writing a minimal SQL-generating agent using **Agent Development Kit (ADK)**.\n",
@@ -14,8 +14,7 @@
    ],
    "metadata": {
     "id": "5b5c8393"
-   },
-   "execution_count": null
+   }
   },
   {
    "id": "96e96c58",
@@ -25,8 +24,7 @@
    ],
    "metadata": {
     "id": "96e96c58"
-   },
-   "execution_count": null
+   }
   },
   {
    "id": "3a2541a2",
@@ -38,7 +36,8 @@
    "metadata": {
     "id": "3a2541a2"
    },
-   "execution_count": null
+   "execution_count": null,
+   "outputs": []
   },
   {
    "id": "4a1023be",
@@ -46,8 +45,7 @@
    "source": [
     "If running in a hosted environment like Colab Enterprise, we clone the `evalbench` repository to load evaluation datasets, model configurations, and pipeline execution shell scripts."
    ],
-   "metadata": {},
-   "execution_count": null
+   "metadata": {}
   },
   {
    "id": "ff6a777c",
@@ -56,7 +54,8 @@
     "!git clone https://github.com/GoogleCloudPlatform/evalbench.git"
    ],
    "metadata": {},
-   "execution_count": null
+   "execution_count": null,
+   "outputs": []
   },
   {
    "id": "8fa1abd1",
@@ -64,8 +63,7 @@
    "source": [
     "We install uv to manage python packages, sync the virtual environment, install the mcp library package, and compile the protobuf message files."
    ],
-   "metadata": {},
-   "execution_count": null
+   "metadata": {}
   },
   {
    "id": "94d69b26",
@@ -73,8 +71,8 @@
    "source": [
     "# Re-install dependencies and compile protobufs\n",
     "!pip install --quiet uv\n",
-    "!cd /content/evalbench \u0026\u0026 uv sync\n",
-    "!cd /content/evalbench \u0026\u0026 .venv/bin/python3 -m grpc_tools.protoc \\\n",
+    "!cd /content/evalbench && uv sync\n",
+    "!cd /content/evalbench && .venv/bin/python3 -m grpc_tools.protoc \\\n",
     "    --proto_path=evalbench/evalproto \\\n",
     "    --python_out=evalbench/evalproto \\\n",
     "    --pyi_out=evalbench/evalproto \\\n",
@@ -83,12 +81,13 @@
     "\n",
     "import os\n",
     "os.chdir(\"/content/evalbench/docs/examples\")\n",
-    "print(f\"✅ Working directory set to: {os.getcwd()}\")"
+    "print(f\"\u2705 Working directory set to: {os.getcwd()}\")"
    ],
    "metadata": {
     "id": "94d69b26"
    },
-   "execution_count": null
+   "execution_count": null,
+   "outputs": []
   },
   {
    "id": "476091be",
@@ -99,20 +98,20 @@
    ],
    "metadata": {
     "id": "476091be"
-   },
-   "execution_count": null
+   }
   },
   {
    "id": "7994b603",
    "cell_type": "code",
    "source": [
     "# Download the BIRD dataset and database connections\n",
-    "!cd ../.. \u0026\u0026 bash datasets/bird/download_dataset.sh"
+    "!cd ../.. && bash datasets/bird/download_dataset.sh"
    ],
    "metadata": {
     "id": "7994b603"
    },
-   "execution_count": null
+   "execution_count": null,
+   "outputs": []
   },
   {
    "id": "25850460",
@@ -124,8 +123,7 @@
    ],
    "metadata": {
     "id": "25850460"
-   },
-   "execution_count": null
+   }
   },
   {
    "id": "8481f972",
@@ -134,7 +132,7 @@
     "%%writefile minimal_agent.py\n",
     "import google.adk as adk\n",
     "\n",
-    "def create_agent() -\u003e adk.Agent:\n",
+    "def create_agent() -> adk.Agent:\n",
     "    \"\"\"Creates a minimal SQL-generating ADK agent.\"\"\"\n",
     "    return adk.Agent(\n",
     "        name=\"minimal_adk_sql_agent\",\n",
@@ -149,7 +147,8 @@
    "metadata": {
     "id": "8481f972"
    },
-   "execution_count": null
+   "execution_count": null,
+   "outputs": []
   },
   {
    "id": "d153df7b",
@@ -161,8 +160,7 @@
    ],
    "metadata": {
     "id": "d153df7b"
-   },
-   "execution_count": null
+   }
   },
   {
    "id": "57e7af39",
@@ -174,7 +172,8 @@
    "metadata": {
     "id": "57e7af39"
    },
-   "execution_count": null
+   "execution_count": null,
+   "outputs": []
   },
   {
    "id": "fd22b631",
@@ -184,8 +183,7 @@
    ],
    "metadata": {
     "id": "fd22b631"
-   },
-   "execution_count": null
+   }
   },
   {
    "id": "8adb6260",
@@ -221,7 +219,8 @@
    "metadata": {
     "id": "8adb6260"
    },
-   "execution_count": null
+   "execution_count": null,
+   "outputs": []
   },
   {
    "id": "80748249",
@@ -235,8 +234,7 @@
    ],
    "metadata": {
     "id": "80748249"
-   },
-   "execution_count": null
+   }
   },
   {
    "id": "fe59c109",
@@ -266,13 +264,14 @@
     "    )\n",
     ")\n",
     "\n",
-    "print(f\"\\n✅ Agent deployed successfully!\")\n",
+    "print(f\"\\n\u2705 Agent deployed successfully!\")\n",
     "print(f\"Resource Name: {remote_agent.api_resource.name}\")"
    ],
    "metadata": {
     "id": "fe59c109"
    },
-   "execution_count": null
+   "execution_count": null,
+   "outputs": []
   },
   {
    "id": "e277933c",
@@ -286,8 +285,7 @@
    ],
    "metadata": {
     "id": "e277933c"
-   },
-   "execution_count": null
+   }
   },
   {
    "id": "0164110c",
@@ -307,7 +305,8 @@
    "metadata": {
     "id": "0164110c"
    },
-   "execution_count": null
+   "execution_count": null,
+   "outputs": []
   },
   {
    "id": "66a03a42",
@@ -323,8 +322,7 @@
    ],
    "metadata": {
     "id": "66a03a42"
-   },
-   "execution_count": null
+   }
   },
   {
    "id": "99f82cfd",
@@ -410,7 +408,8 @@
    "metadata": {
     "id": "99f82cfd"
    },
-   "execution_count": null
+   "execution_count": null,
+   "outputs": []
   },
   {
    "id": "f71131b9",
@@ -422,8 +421,7 @@
    ],
    "metadata": {
     "id": "f71131b9"
-   },
-   "execution_count": null
+   }
   },
   {
    "id": "d88ccc37",
@@ -440,7 +438,8 @@
    "metadata": {
     "id": "d88ccc37"
    },
-   "execution_count": null
+   "execution_count": null,
+   "outputs": []
   }
  ],
  "metadata": {


### PR DESCRIPTION
This PR fixes Jupyter Notebook JSON schema validation errors in `docs/examples/agent_runtime_deployment.ipynb` that prevent the notebook from being rendered correctly on GitHub.

#### Issues resolved:
1. **Invalid `execution_count` on Markdown cells**: Removed the `"execution_count": null` field from all markdown cells.
2. **Missing `outputs` property on Code cells**: Added the required `"outputs": []` array to all code cells that were missing it.