### PR TITLE
feat: normalize namespaced skill names in SkillsTrajectoryMatcher

### DIFF
--- a/evalbench/scorers/skillstrajectorymatcher.py
+++ b/evalbench/scorers/skillstrajectorymatcher.py
@@ -24,6 +24,7 @@ class SkillsTrajectoryMatcher(comparator.Comparator):
         self.config = config
         self.enforce_order = config.get("enforce_order", False)
         self.allow_extra_skills = config.get("allow_extra_skills", False)
+        self.ignore_prefix = config.get("ignore_prefix", "")
 
         if self.enforce_order and self.allow_extra_skills:
             raise ValueError(
@@ -91,6 +92,12 @@ class SkillsTrajectoryMatcher(comparator.Comparator):
 
         if not isinstance(expected, list) or not isinstance(actual, list):
             return 0.0, "Skills data must be lists."
+
+        if self.ignore_prefix:
+            prefix = self.ignore_prefix
+            actual = [
+                s[len(prefix):] if s.startswith(prefix) else s for s in actual
+            ]
 
         if not expected and not actual:
             return 100.0, "Both expected and actual skill lists are empty."

--- a/evalbench/test/skillstrajectorymatcher_test.py
+++ b/evalbench/test/skillstrajectorymatcher_test.py
@@ -98,6 +98,33 @@ class SkillsTrajectoryMatcherTest(unittest.TestCase):
         with self.assertRaises(ValueError):
             SkillsTrajectoryMatcher({"enforce_order": True, "allow_extra_skills": True})
 
+    def test_namespace_normalization_default_jaccard(self):
+        matcher = SkillsTrajectoryMatcher({"ignore_prefix": "dak:"})
+        expected = ["dataform_bigquery"]
+        actual = ["dak:dataform_bigquery", "gcp_pipeline_orchestration"]
+
+        score, explanation = _compare(matcher, expected, actual)
+        self.assertEqual(score, 50.0)
+        self.assertIn("Jaccard Similarity", explanation)
+
+    def test_namespace_normalization_allow_extra_skills(self):
+        matcher = SkillsTrajectoryMatcher({"allow_extra_skills": True, "ignore_prefix": "dak:"})
+        expected = ["dataform_bigquery"]
+        actual = ["dak:dataform_bigquery", "gcp_pipeline_orchestration"]
+
+        score, explanation = _compare(matcher, expected, actual)
+        self.assertEqual(score, 100.0)
+        self.assertIn("allow_extra_skills=True", explanation)
+
+    def test_namespace_normalization_enforce_order(self):
+        matcher = SkillsTrajectoryMatcher({"enforce_order": True, "ignore_prefix": "dak:"})
+        expected = ["skill_a", "skill_b"]
+        actual = ["dak:skill_a", "dak:skill_b"]
+
+        score, explanation = _compare(matcher, expected, actual)
+        self.assertEqual(score, 100.0)
+        self.assertIn("Sequence Alignment", explanation)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Added ignore_prefix config option to normalize actual skills by stripping the prefix upfront. This is useful because some generators (like Claude) prefix skills with a namespace (e.g., 'dak:'). Added unit tests covering normalization under various configurations.