### PR TITLE
feat(agy_cli): pass --add-dir flag automatically on agy CLI invocations

### DIFF
--- a/evalbench/generators/models/agy_cli.py
+++ b/evalbench/generators/models/agy_cli.py
@@ -506,7 +506,7 @@ class AgyCliGenerator(AgentCliGenerator):
 
         env = self._merged_env()
         cmd = self._base_agy_command(
-            self.agy_bin, "ping", model=self.model
+            self.agy_bin, "ping", model=self.model, add_dirs=[self.fake_home]
         )
         try:
             subprocess.run(
@@ -833,7 +833,7 @@ class AgyCliGenerator(AgentCliGenerator):
     def _base_agy_command(
         cli: str, prompt: str, resume: bool = False, model: str = None,
         output_format: str = None, log_file: str = None,
-        timeout: str = None,
+        timeout: str = None, add_dirs: list[str] | str | None = None,
     ) -> list:
         """Builds the non-interactive ``agy -p`` argv shared by the eval
         turn path and the setup-time MCP probe.
@@ -854,6 +854,11 @@ class AgyCliGenerator(AgentCliGenerator):
         defaults to agy's internal default (5 minutes).
         """
         command = [cli, "-p", prompt, "--dangerously-skip-permissions"]
+        if add_dirs:
+            if isinstance(add_dirs, str):
+                add_dirs = [add_dirs]
+            for d in add_dirs:
+                command += ["--add-dir", d]
         if model:
             command += ["--model", model]
         if output_format:
@@ -895,15 +900,15 @@ class AgyCliGenerator(AgentCliGenerator):
 
     def _run_agy_cli(self, cli_cmd: CLICommand):
         env = self._merged_env(cli_cmd.env)
+        cwd = cli_cmd.cwd if cli_cmd.cwd else self.fake_home
         # The executable is always this session's sandbox binary, regardless of
         # the label carried on cli_cmd.cli (the evaluator passes agent_version,
         # "agy", which is not a path).
         command = self._base_agy_command(
             self.agy_bin, cli_cmd.prompt, cli_cmd.resume, self.model,
             output_format="stream-json", log_file=self.cli_log_path,
-            timeout=self.timeout,
+            timeout=self.timeout, add_dirs=[cwd],
         )
-        cwd = cli_cmd.cwd if cli_cmd.cwd else self.fake_home
         result = self._execute_cli_command(command, env=env, cwd=cwd)
 
         # Parse whenever agy emitted a stream, even on a non-zero exit: a

--- a/evalbench/test/agy_cli_test.py
+++ b/evalbench/test/agy_cli_test.py
@@ -265,7 +265,7 @@ def test_ensure_agy_installed_raises_when_binary_absent_after_install(
 
 def test_run_command_argv_shape(mock_run, sandbox):
     """``_run_agy_cli`` must build ``agy -p <prompt>
-    --dangerously-skip-permissions --output-format stream-json``."""
+    --dangerously-skip-permissions --add-dir <cwd> --output-format stream-json``."""
     generator = AgyCliGenerator({})
     cmd = CLICommand(cli="agy", prompt="hello world")
     generator._run_agy_cli(cmd)
@@ -273,7 +273,8 @@ def test_run_command_argv_shape(mock_run, sandbox):
     sent_argv = mock_run.call_args[0][0]
     assert sent_argv == [
         generator.agy_bin, "-p", "hello world",
-        "--dangerously-skip-permissions", "--output-format", "stream-json",
+        "--dangerously-skip-permissions", "--add-dir", generator.fake_home,
+        "--output-format", "stream-json",
         "--log-file", generator.cli_log_path,
     ]
 
@@ -286,7 +287,8 @@ def test_run_command_argv_shape_with_continue(mock_run, sandbox):
     sent_argv = mock_run.call_args[0][0]
     assert sent_argv == [
         generator.agy_bin, "-p", "next turn",
-        "--dangerously-skip-permissions", "--output-format", "stream-json",
+        "--dangerously-skip-permissions", "--add-dir", generator.fake_home,
+        "--output-format", "stream-json",
         "--log-file", generator.cli_log_path, "--continue",
     ]
 
@@ -321,7 +323,8 @@ def test_run_command_argv_shape_with_timeout(mock_run, sandbox):
     sent_argv = mock_run.call_args[0][0]
     assert sent_argv == [
         generator.agy_bin, "-p", "hello world",
-        "--dangerously-skip-permissions", "--output-format", "stream-json",
+        "--dangerously-skip-permissions", "--add-dir", generator.fake_home,
+        "--output-format", "stream-json",
         "--log-file", generator.cli_log_path, "--print-timeout", "20m",
     ]
 


### PR DESCRIPTION
When executing Antigravity (`agy`) CLI scenarios, `agy` expects active workspace directories to be registered. It seems that when it executes in an empty folder (fake_home), it just ignores the directory as a workspace directory. 

However, there's the `--add-dir` command-line flag. With this flag, `agy` initializes in non-interactive print mode with a registered workspce.

This PR updates `AgyCliGenerator` to automatically pass `--add-dir <cwd>` on all `agy` CLI executions, ensuring that the process working directory (`fake_home` or scenario `work_dir`) is registered as an active workspace.
