### PR TITLE
fix(agy): register work_dir as an agy workspace via --add-dir

### DIFF
--- a/evalbench/generators/models/agy_cli.py
+++ b/evalbench/generators/models/agy_cli.py
@@ -833,7 +833,7 @@ class AgyCliGenerator(AgentCliGenerator):
     def _base_agy_command(
         cli: str, prompt: str, resume: bool = False, model: str = None,
         output_format: str = None, log_file: str = None,
-        timeout: str = None,
+        timeout: str = None, add_dir: str = None,
     ) -> list:
         """Builds the non-interactive ``agy -p`` argv shared by the eval
         turn path and the setup-time MCP probe.
@@ -852,6 +852,11 @@ class AgyCliGenerator(AgentCliGenerator):
 
         ``timeout`` maps to ``--print-timeout`` (e.g. "20m"). If omitted,
         defaults to agy's internal default (5 minutes).
+
+        ``add_dir`` maps to ``--add-dir``, registering the scenario's
+        ``work_dir`` as an agy workspace. Required on top of the subprocess
+        cwd: unregistered, agy runs its shell and write tools in
+        ``<appDataDir>/scratch`` and agent writes miss ``work_dir``.
         """
         command = [cli, "-p", prompt, "--dangerously-skip-permissions"]
         if model:
@@ -862,6 +867,8 @@ class AgyCliGenerator(AgentCliGenerator):
             command += ["--log-file", log_file]
         if timeout:
             command += ["--print-timeout", timeout]
+        if add_dir:
+            command += ["--add-dir", add_dir]
         if resume:
             command.append("--continue")
         return command
@@ -901,7 +908,7 @@ class AgyCliGenerator(AgentCliGenerator):
         command = self._base_agy_command(
             self.agy_bin, cli_cmd.prompt, cli_cmd.resume, self.model,
             output_format="stream-json", log_file=self.cli_log_path,
-            timeout=self.timeout,
+            timeout=self.timeout, add_dir=cli_cmd.cwd,
         )
         cwd = cli_cmd.cwd if cli_cmd.cwd else self.fake_home
         result = self._execute_cli_command(command, env=env, cwd=cwd)

--- a/evalbench/generators/models/agy_cli.py
+++ b/evalbench/generators/models/agy_cli.py
@@ -910,6 +910,9 @@ class AgyCliGenerator(AgentCliGenerator):
             output_format="stream-json", log_file=self.cli_log_path,
             timeout=self.timeout, add_dir=cli_cmd.cwd,
         )
+        # The fallback is deliberately not mirrored into --add-dir: fake_home
+        # holds harness internals (agy binary, settings, MCP config, session
+        # state), which the agent has no business editing as workspace files.
         cwd = cli_cmd.cwd if cli_cmd.cwd else self.fake_home
         result = self._execute_cli_command(command, env=env, cwd=cwd)
 

--- a/evalbench/test/agy_cli_test.py
+++ b/evalbench/test/agy_cli_test.py
@@ -296,7 +296,10 @@ def test_run_command_argv_passes_work_dir_as_add_dir(mock_run, sandbox):
     subprocess cwd: without a registered workspace agy runs its shell and write
     tools in ``<appDataDir>/scratch``, so agent writes miss ``work_dir``."""
     generator = AgyCliGenerator({})
-    cmd = CLICommand(cli="agy", prompt="hello world", cwd="/tmp/workspace")
+    cmd = generator.create_command(
+        cli="agy", prompt="hello world", cwd="/tmp/workspace"
+    )
+    assert cmd.cwd == "/tmp/workspace"
     generator._run_agy_cli(cmd)
 
     sent_argv = mock_run.call_args[0][0]

--- a/evalbench/test/agy_cli_test.py
+++ b/evalbench/test/agy_cli_test.py
@@ -291,6 +291,32 @@ def test_run_command_argv_shape_with_continue(mock_run, sandbox):
     ]
 
 
+def test_run_command_argv_passes_work_dir_as_add_dir(mock_run, sandbox):
+    """A scenario ``work_dir`` must reach agy as ``--add-dir``, not just as the
+    subprocess cwd: without a registered workspace agy runs its shell and write
+    tools in ``<appDataDir>/scratch``, so agent writes miss ``work_dir``."""
+    generator = AgyCliGenerator({})
+    cmd = CLICommand(cli="agy", prompt="hello world", cwd="/tmp/workspace")
+    generator._run_agy_cli(cmd)
+
+    sent_argv = mock_run.call_args[0][0]
+    assert sent_argv == [
+        generator.agy_bin, "-p", "hello world",
+        "--dangerously-skip-permissions", "--output-format", "stream-json",
+        "--log-file", generator.cli_log_path, "--add-dir", "/tmp/workspace",
+    ]
+    assert mock_run.call_args.kwargs["cwd"] == "/tmp/workspace"
+
+
+def test_run_command_argv_omits_add_dir_without_work_dir(mock_run, sandbox):
+    """No ``work_dir`` means no ``--add-dir``, leaving agy's default workspace
+    behaviour untouched for scenarios that never asked for one."""
+    generator = AgyCliGenerator({})
+    generator._run_agy_cli(CLICommand(cli="agy", prompt="hello world"))
+
+    assert "--add-dir" not in mock_run.call_args[0][0]
+
+
 def test_init_raises_on_non_string_timeout(sandbox):
     """The generator should raise TypeError if timeout is not a string."""
     with pytest.raises(TypeError, match="timeout must be a string"):

--- a/evalbench/test/agy_cli_test.py
+++ b/evalbench/test/agy_cli_test.py
@@ -308,15 +308,6 @@ def test_run_command_argv_passes_work_dir_as_add_dir(mock_run, sandbox):
     assert mock_run.call_args.kwargs["cwd"] == "/tmp/workspace"
 
 
-def test_run_command_argv_omits_add_dir_without_work_dir(mock_run, sandbox):
-    """No ``work_dir`` means no ``--add-dir``, leaving agy's default workspace
-    behaviour untouched for scenarios that never asked for one."""
-    generator = AgyCliGenerator({})
-    generator._run_agy_cli(CLICommand(cli="agy", prompt="hello world"))
-
-    assert "--add-dir" not in mock_run.call_args[0][0]
-
-
 def test_init_raises_on_non_string_timeout(sandbox):
     """The generator should raise TypeError if timeout is not a string."""
     with pytest.raises(TypeError, match="timeout must be a string"):


### PR DESCRIPTION
## Summary

  `work_dir` was only passed to agy as the subprocess cwd. agy uses the cwd
  for file reads, but runs its shell and write tools in `<appDataDir>/scratch`,
  so files the agent created never landed in `work_dir`. Only `--add-dir` sets
  the tool directory.

  This passes `--add-dir <work_dir>` in addition to the cwd, emitted only when
  a scenario declares `work_dir` — the MCP startup probe and existing scenarios
  are unaffected. The `fake_home` cwd fallback is not mirrored into the flag,
  since it holds harness internals rather than scenario data.

  Only agy needs this. `claude_code`, `codex_cli` and `gemini_cli` honour the
  process cwd directly.

  ## Test plan

  - [x] `pytest evalbench/test/agy_cli_test.py` — 68 passed
  - [x] New test pins the full path: `create_command(cwd=...)` → `--add-dir` → subprocess cwd
  - [x] The no-`work_dir` case is covered by existing exact-argv tests, which fail if the flag is
  always emitted
  - [x] Real eval run with `work_dir` set: the agent's file landed in `work_dir` and scratch was empty
  (before the fix, the reverse)
  - [x] Multi-turn: turn two still runs in `work_dir`

  The rubric scorer only reads the transcript, so the scenario scored 100%
  before and after. The fix was verified on disk.