### PR TITLE
docs(agy): correct the fake_home wording on the --add-dir fallback

### DIFF
--- a/evalbench/generators/models/agy_cli.py
+++ b/evalbench/generators/models/agy_cli.py
@@ -922,9 +922,9 @@ class AgyCliGenerator(AgentCliGenerator):
             output_format="stream-json", log_file=self.cli_log_path,
             timeout=self.timeout, add_dir=cli_cmd.cwd,
         )
-        # The fallback is deliberately not mirrored into --add-dir: fake_home
-        # holds harness internals (agy binary, settings, MCP config, session
-        # state), which the agent has no business editing as workspace files.
+        # The fallback is not mirrored into --add-dir: fake_home is agy's own
+        # HOME (binary, settings, MCP config, session state) plus the staged
+        # ADC copy, not a scenario workspace.
         cwd = cli_cmd.cwd if cli_cmd.cwd else self.fake_home
         result = self._execute_cli_command(command, env=env, cwd=cwd, timeout_seconds=timeout_seconds)
 


### PR DESCRIPTION
## Summary

Follow-up to #585. The comment above the `cwd` fallback in `_run_agy_cli`
called `fake_home` "harness internals". It isn't ours — the binary, settings,
MCP config and session state all belong to agy. Reworded to say that.

No behaviour change.

## Test plan

- [x] `pytest evalbench/test/agy_cli_test.py` — 68 passed