### PR TITLE
feat(mcp_readability): group style findings per tool

### DIFF
--- a/evalbench/scorers/mcp_readability_scoring.py
+++ b/evalbench/scorers/mcp_readability_scoring.py
@@ -51,3 +51,24 @@ class ScoreContribution:
     row_fields: dict[str, Any] = field(default_factory=dict)
     score: int = 100
     logs: str = ""
+
+
+# Severity display order, and the badge each finding bullet is prefixed with now
+# that the judge groups its findings by tool rather than by severity.
+SEVERITY_BADGES = {"P0": "🚫 P0", "P1": "⚠️ P1", "P2": "💡 P2"}
+
+
+def severity_tally(findings: list[dict]) -> str:
+    """Summarize a tool's findings as e.g. ``"1 P0, 2 P2"`` (zeros omitted)."""
+    counts = {sev: 0 for sev in SEVERITY_BADGES}
+    other = 0
+    for finding in findings:
+        sev = str(finding.get("severity", "")).upper()
+        if sev in counts:
+            counts[sev] += 1
+        else:
+            other += 1
+    parts = [f"{n} {sev}" for sev, n in counts.items() if n]
+    if other:
+        parts.append(f"{other} unclassified")
+    return ", ".join(parts) or "no findings"

--- a/evalbench/scorers/mcp_style_readability.py
+++ b/evalbench/scorers/mcp_style_readability.py
@@ -18,7 +18,12 @@ import logging
 import re
 
 from generators.models import get_generator
-from scorers.mcp_readability_scoring import EndpointContext, ScoreContribution
+from scorers.mcp_readability_scoring import (
+    EndpointContext,
+    SEVERITY_BADGES,
+    ScoreContribution,
+    severity_tally,
+)
 
 
 # Output-token ceiling for the JSON-mode judge call. Gemini 3.x is a *thinking*
@@ -43,21 +48,25 @@ _OUTPUT_SCHEMA = """### OUTPUT
 Return ONLY a JSON object (no markdown, no prose) with exactly this shape:
 {{
   "readability_score": <integer 0-100, higher is better>,
-  "p0_issues": <integer>,
-  "p1_issues": <integer>,
-  "p2_issues": <integer>,
-  "findings": [
-    {{"severity": "P0|P1|P2", "rule_id": "<string>", "tool": "<tool name or ''>",
-      "title": "<short one-line summary>", "message": "<what is wrong>",
-      "suggestion": "<how to fix>"}}
+  "findings_by_tool": [
+    {{"tool": "<tool name, or 'general'>",
+      "findings": [
+        {{"severity": "P0|P1|P2", "rule_id": "<string>",
+          "title": "<short one-line summary>", "message": "<what is wrong>",
+          "suggestion": "<how to fix>"}}
+      ]}}
   ],
   "waived": [
     {{"rule_id": "<string>", "reason": "<reason>", "would_have_violated": <true|false>}}
   ],
   "summary": "<one-paragraph overall assessment>"
 }}
-The counts p0_issues/p1_issues/p2_issues MUST equal the number of findings of
-each severity."""
+Emit one "findings_by_tool" entry per tool that has findings, in the order the
+tools appear in the man page, with the "general" entry (if any) first. Within an
+entry, order findings P0, then P1, then P2. Omit tools with no findings.
+
+Do not report issue counts: the P0/P1/P2 totals are counted from the findings
+you return, one per finding."""
 
 
 PROMPT_TEMPLATE = (
@@ -99,11 +108,20 @@ How to assign severity and rule_id:
   about platform/registration/dashboards that cannot be judged from the tool
   schema alone should not be flagged as violations.
 
-Avoid duplication (global vs per-tool):
-- If an issue is global or repeats across many tools (e.g. a convention violated
-  everywhere), report it ONCE with "tool" set to "" (empty string). Do NOT emit
-  the same global issue once per tool.
-- Report tool-specific issues with "tool" set to that tool's name.
+Group findings under the tool they affect:
+- Report a violation SEPARATELY for each tool it affects, under that tool's
+  entry, with a "message"/"suggestion" written for that tool specifically (name
+  its own parameters, description, or wording). Repeating the same rule_id under
+  several tools is expected -- a rule broken by ten tools appears under all ten,
+  and counts as ten findings.
+- Use the "general" entry only for an issue that belongs to no individual tool:
+  the server exposes too many tools, the tool set is missing a capability (e.g.
+  no polling tool for a long-running operation), or a parameter for the same
+  concept is named inconsistently across tools.
+- Do not paper over the difference between tools: if a rule is broken in a
+  different way by two tools, say what is wrong with each.
+- Keep each message and suggestion to one or two sentences -- one finding per
+  affected tool makes the response long.
 
 ### STYLE GUIDE
 {style_guide}
@@ -115,10 +133,9 @@ Avoid duplication (global vs per-tool):
 {tools_markup}
 
 ### EXCEPTIONS (waived rules — DO NOT count these as issues)
-The following rules have been explicitly waived for this endpoint. Do not include
-them in p0_issues/p1_issues/p2_issues or in "findings". Instead list them under
-"waived" with their reason. If a waived rule would otherwise have been violated,
-note that in the waived entry.
+The following rules have been explicitly waived for this endpoint. Do not report
+them as findings. Instead list them under "waived" with their reason. If a waived
+rule would otherwise have been violated, note that in the waived entry.
 {exceptions}
 
 """
@@ -281,33 +298,16 @@ class McpStyleReadabilityScorer:
     def _parse(self, raw: str) -> dict:
         """Normalize the model output into a stable feedback dict."""
         data = self._extract_json(raw)
-        findings = data.get("findings") or []
-        if not isinstance(findings, list):
-            findings = []
-
-        # Counts derived from findings are authoritative (a single pass). Only
-        # fall back to the model's self-reported integers when there are no
-        # findings at all -- otherwise a legitimately-zero severity would be
-        # overwritten by a mismatched self-reported count.
-        if findings:
-            counts = {"P0": 0, "P1": 0, "P2": 0}
-            for f in findings:
-                if isinstance(f, dict):
-                    sev = str(f.get("severity", "")).upper()
-                    if sev in counts:
-                        counts[sev] += 1
-            p0, p1, p2 = counts["P0"], counts["P1"], counts["P2"]
-        else:
-            p0 = _safe_int(data.get("p0_issues"))
-            p1 = _safe_int(data.get("p1_issues"))
-            p2 = _safe_int(data.get("p2_issues"))
-
+        by_tool = _clean_findings_by_tool(data.get("findings_by_tool"))
+        counts = _severity_counts(
+            [f for entry in by_tool for f in entry["findings"]]
+        )
         return {
             "readability_score": _safe_int(data.get("readability_score")),
-            "p0_issues": p0,
-            "p1_issues": p1,
-            "p2_issues": p2,
-            "findings": findings,
+            "p0_issues": counts["P0"],
+            "p1_issues": counts["P1"],
+            "p2_issues": counts["P2"],
+            "findings_by_tool": by_tool,
             "waived": data.get("waived") or [],
             "summary": data.get("summary", ""),
         }
@@ -316,10 +316,11 @@ class McpStyleReadabilityScorer:
     def to_html(feedback: dict, product_name: str = "") -> str:
         """Render feedback as a human-readable HTML fragment.
 
-        Leads with the overall summary, groups findings by severity, and ends
-        with the allowed exceptions (waived rules) and their reasons. It
-        deliberately omits any numeric readability score -- the intent is review
-        notes an engineer can act on, not a grade.
+        Leads with the overall summary, renders the judge's per-tool findings
+        lists in the order it returned them, and ends with the allowed exceptions
+        (waived rules) and their reasons. It deliberately omits any numeric
+        readability score -- the intent is review notes an engineer can act on,
+        not a grade.
 
         HTML (rather than Markdown) because this column is surfaced in a
         dashboard that renders it as HTML. All model-supplied text is escaped.
@@ -338,25 +339,20 @@ class McpStyleReadabilityScorer:
         if summary:
             parts.append(f"<p><b>Summary:</b> {esc(summary)}</p>")
 
-        # Group findings by severity so each section can be rendered in order.
-        by_sev = {"P0": [], "P1": [], "P2": []}
-        for f in feedback.get("findings") or []:
-            if isinstance(f, dict):
-                sev = str(f.get("severity", "")).upper()
-                if sev in by_sev:
-                    by_sev[sev].append(f)
-
-        for sev, heading in _SEVERITY_SECTIONS:
-            items = by_sev[sev]
-            parts.append(f"<h4>{heading} — {len(items)}</h4>")
-            if not items:
-                parts.append("<p><i>None</i></p>")
-                continue
+        by_tool = _clean_findings_by_tool(feedback.get("findings_by_tool"))
+        if not by_tool:
+            parts.append("<p><i>No findings</i></p>")
+        for entry in by_tool:
+            items = entry["findings"]
+            parts.append(
+                f"<h4>{esc(entry['tool'])} — {severity_tally(items)}</h4>"
+            )
             parts.append("<ul>")
             for f in items:
                 rule = esc(str(f.get("rule_id", "")).strip() or "(rule)")
-                tool = esc(str(f.get("tool", "")).strip() or "all tools")
-                li = [f"<b>[{rule}] {tool}</b>"]
+                sev = str(f.get("severity", "")).upper()
+                badge = esc(SEVERITY_BADGES.get(sev, sev or "?"))
+                li = [f"<b>{badge} · [{rule}]</b>"]
                 finding_title = str(f.get("title", "")).strip()
                 if finding_title:
                     li.append(f" — {esc(finding_title)}")
@@ -392,12 +388,44 @@ class McpStyleReadabilityScorer:
         return "".join(parts)
 
 
-# Severity display order + section heading for the HTML feedback report.
-_SEVERITY_SECTIONS = [
-    ("P0", "🚫 Blockers (P0)"),
-    ("P1", "⚠️ Recommended (P1)"),
-    ("P2", "💡 Suggestions (P2)"),
-]
+def _clean_findings_by_tool(by_tool) -> list[dict]:
+    """The judge's per-tool findings, with unusable entries dropped.
+
+    The judge groups findings itself, so this only guards the shape: an entry
+    needs a tool name and a list of dict findings to be renderable. Entry and
+    finding order are the judge's -- it is told to lead with "general" and to
+    order findings P0 -> P1 -> P2.
+    """
+    if not isinstance(by_tool, list):
+        return []
+    cleaned = []
+    for entry in by_tool:
+        if not isinstance(entry, dict):
+            continue
+        tool = str(entry.get("tool", "")).strip()
+        raw_findings = entry.get("findings")
+        if not isinstance(raw_findings, list):
+            continue
+        findings = [f for f in raw_findings if isinstance(f, dict)]
+        if tool and findings:
+            cleaned.append({"tool": tool, "findings": findings})
+    return cleaned
+
+
+def _severity_counts(findings: list) -> dict[str, int]:
+    """P0/P1/P2 as the number of findings at each severity.
+
+    The judge reports a violation once per affected tool, and each of those
+    occurrences counts: a rule broken by ten tools is ten findings.
+    """
+    counts = {"P0": 0, "P1": 0, "P2": 0}
+    for f in findings:
+        if not isinstance(f, dict):
+            continue
+        sev = str(f.get("severity", "")).upper()
+        if sev in counts:
+            counts[sev] += 1
+    return counts
 
 
 def _public_feedback(feedback: dict) -> dict:

--- a/evalbench/test/mcp_readability_test.py
+++ b/evalbench/test/mcp_readability_test.py
@@ -181,9 +181,11 @@ def test_generator_missing_file_raises():
 # --------------------------------------------------------------------------
 def test_scorer_parse_and_html():
     raw = """```json
-    {"readability_score": 75, "findings": [
-       {"severity": "P0", "rule_id": "P0-X", "tool": "t", "title": "Bad name", "message": "m", "suggestion": "s"},
-       {"severity": "P2", "rule_id": "P2-Y", "tool": "t", "message": "m", "suggestion": "s"}
+    {"readability_score": 75, "findings_by_tool": [
+       {"tool": "t", "findings": [
+         {"severity": "P0", "rule_id": "P0-X", "title": "Bad name", "message": "m", "suggestion": "s"},
+         {"severity": "P2", "rule_id": "P2-Y", "message": "m", "suggestion": "s"}
+       ]}
      ], "waived": [{"rule_id": "use-enums", "reason": "legacy", "would_have_violated": true}],
      "summary": "ok"}
     ```"""
@@ -193,15 +195,17 @@ def test_scorer_parse_and_html():
     assert fb["p0_issues"] == 1
     assert fb["p2_issues"] == 1
     assert fb["readability_score"] == 75
-    # title flows through the parser unchanged.
-    assert fb["findings"][0]["title"] == "Bad name"
+    # The judge's grouping flows through the parser unchanged.
+    assert fb["findings_by_tool"][0]["tool"] == "t"
+    assert fb["findings_by_tool"][0]["findings"][0]["title"] == "Bad name"
 
     html = McpStyleReadabilityScorer.to_html(fb, product_name="Cloud SQL")
     # Human-readable report: product heading + summary, no numeric score.
     assert "MCP Tool Readability Review — Cloud SQL" in html
     assert "readability score" not in html.lower()
-    # Findings are grouped by severity and carry their title/rule.
-    assert "Blockers (P0) — 1" in html
+    # Findings are grouped per tool, tallied by severity, and carry their
+    # title/rule with a severity badge.
+    assert "<h4>t — 1 P0, 1 P2</h4>" in html
     assert "P0-X" in html and "Bad name" in html
     # Allowed exceptions section surfaces the waiver, reason, and flag note.
     assert "Allowed exceptions (waived) — 1" in html
@@ -210,19 +214,20 @@ def test_scorer_parse_and_html():
 
 
 def test_scorer_counts_are_authoritative_from_findings():
-    """A severity with zero findings must stay 0 even if the model over-reports.
-
-    Regression: the old `_count(sev) or _safe_int(...)` fell back to the model's
-    self-reported integer whenever a severity's true count was 0.
-    """
+    """Counts come from the findings, never from model-reported integers."""
     raw = json.dumps(
         {
             "readability_score": 90,
             # No P0 findings, but the model wrongly claims 3.
             "p0_issues": 3,
-            "findings": [
-                {"severity": "P1", "rule_id": "P1-A", "tool": "t",
-                 "message": "m", "suggestion": "s"},
+            "findings_by_tool": [
+                {
+                    "tool": "t",
+                    "findings": [
+                        {"severity": "P1", "rule_id": "P1-A",
+                         "message": "m", "suggestion": "s"},
+                    ],
+                }
             ],
             "summary": "ok",
         }
@@ -232,10 +237,12 @@ def test_scorer_counts_are_authoritative_from_findings():
     assert fb["p0_issues"] == 0  # derived from findings, not the bogus 3
     assert fb["p1_issues"] == 1
 
-    # When there are NO findings at all, fall back to the reported integers.
-    raw2 = json.dumps({"readability_score": 50, "p0_issues": 2, "findings": []})
+    # No findings means zero, whatever the model reports.
+    raw2 = json.dumps(
+        {"readability_score": 50, "p0_issues": 2, "findings_by_tool": []}
+    )
     fb2 = scorer._parse(raw2)
-    assert fb2["p0_issues"] == 2
+    assert fb2["p0_issues"] == 0
 
 
 def test_scorer_single_pass():
@@ -287,9 +294,14 @@ class _FakeLLM:
         return json.dumps(
             {
                 "readability_score": 80,
-                "findings": [
-                    {"severity": "P1", "rule_id": "P1-A", "tool": "list_datasets",
-                     "message": "m", "suggestion": "s"},
+                "findings_by_tool": [
+                    {
+                        "tool": "list_datasets",
+                        "findings": [
+                            {"severity": "P1", "rule_id": "P1-A",
+                             "message": "m", "suggestion": "s"},
+                        ],
+                    }
                 ],
                 "waived": [{"rule_id": "use-enums", "reason": "r"}],
                 "summary": "fine",

--- a/evalbench/test/mcp_style_readability_test.py
+++ b/evalbench/test/mcp_style_readability_test.py
@@ -1,11 +1,13 @@
-"""Unit tests for McpStyleReadabilityScorer._generate token/truncation handling.
+"""Unit tests for McpStyleReadabilityScorer generation and response parsing.
 
-These cover the Gemini-3.x follow-ups: a high ``max_output_tokens`` is set on the
-JSON-mode call, and a truncated response (``finish_reason == MAX_TOKENS``) raises
-a clear ``TruncatedResponseError`` instead of falling through to a cryptic JSON
-parse failure.
+Generation covers the Gemini-3.x follow-ups: a high ``max_output_tokens`` is set
+on the JSON-mode call, and a truncated response (``finish_reason ==
+MAX_TOKENS``) raises a clear ``TruncatedResponseError`` instead of falling
+through to a cryptic JSON parse failure. Parsing covers the per-tool findings
+layout and the per-finding P0/P1/P2 counts derived from it.
 """
 
+import json
 import os
 import tempfile
 import types as pytypes
@@ -110,6 +112,78 @@ class GenerateTruncationTest(unittest.TestCase):
         out = scorer._generate("prompt")
         self.assertTrue(model.generate_called)
         self.assertIn("readability_score", out)
+
+
+class ParsePerToolFindingsTest(unittest.TestCase):
+    """`_parse` keeps the judge's per-tool grouping and counts every finding."""
+
+    def _parse(self, by_tool):
+        scorer = McpStyleReadabilityScorer.__new__(McpStyleReadabilityScorer)
+        return scorer._parse(json.dumps({"findings_by_tool": by_tool}))
+
+    def test_grouping_is_kept_as_returned(self):
+        out = self._parse(
+            [
+                {
+                    "tool": "general",
+                    "findings": [
+                        {"severity": "P0", "rule_id": "Tool Count Limits"}
+                    ],
+                },
+                {
+                    "tool": "create_instance",
+                    "findings": [
+                        {
+                            "severity": "P0",
+                            "rule_id": "Avoid complex parameters",
+                            "message": "pscInstanceConfig is deeply nested.",
+                        }
+                    ],
+                },
+            ]
+        )
+        # Entry order and per-tool findings come straight from the judge.
+        self.assertEqual(
+            [e["tool"] for e in out["findings_by_tool"]],
+            ["general", "create_instance"],
+        )
+        self.assertIn(
+            "pscInstanceConfig",
+            out["findings_by_tool"][1]["findings"][0]["message"],
+        )
+        self.assertEqual(out["p0_issues"], 2)
+
+    def test_same_rule_under_two_tools_counts_twice(self):
+        rule = {"severity": "P0", "rule_id": "Avoid complex parameters"}
+        out = self._parse(
+            [
+                {"tool": "create_instance", "findings": [dict(rule)]},
+                {"tool": "update_instance", "findings": [dict(rule)]},
+            ]
+        )
+        self.assertEqual(out["p0_issues"], 2)
+        self.assertEqual(len(out["findings_by_tool"]), 2)
+
+    def test_ruleless_findings_each_count(self):
+        out = self._parse(
+            [
+                {"tool": "a", "findings": [{"severity": "P2"}]},
+                {"tool": "b", "findings": [{"severity": "P2"}]},
+            ]
+        )
+        self.assertEqual(out["p2_issues"], 2)
+
+    def test_unusable_entries_are_dropped(self):
+        out = self._parse(
+            [
+                "not an entry",
+                {"tool": "", "findings": [{"severity": "P0"}]},
+                {"tool": "a", "findings": "not a list"},
+                {"tool": "b", "findings": [{"severity": "P1"}]},
+            ]
+        )
+        self.assertEqual([e["tool"] for e in out["findings_by_tool"]], ["b"])
+        self.assertEqual(out["p1_issues"], 1)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Style-judge feedback was organized by severity, with a single finding carrying a comma-joined tool list (`"tool": "get_cluster, list_clusters"`). A reviewer fixing one tool had to scan every severity bucket and work out which findings applied to it.

The judge now returns its findings already grouped by tool, so the scorer parses that grouping rather than reconstructing it:

```json
"findings_by_tool": [
  {"tool": "general", "findings": [{"severity": "P0", "rule_id": "Tool Count Limits", ...}]},
  {"tool": "get_cluster", "findings": [{"severity": "P0", ...}, {"severity": "P2", ...}]}
]
```

- **Prompt**: one entry per tool, findings ordered P0 -> P1 -> P2 within an entry, and a violation affecting several tools reported under each with wording specific to that tool (its own parameters, description). A `general` entry covers issues tied to no single tool — the server exceeding the 40-tool limit, a missing LRO polling tool, a parameter named inconsistently across tools.
- **Parsing**: `_clean_findings_by_tool` only drops entries that can't be rendered (no tool name, findings not a list). Entry and finding order are the judge's.
- **Feedback HTML**: one findings list per tool, headed by that tool's severity tally (`get_cluster — 1 P0, 1 P2`).
- **Counts**: `p0/p1/p2_issues` count every finding, so a rule broken by ten tools is ten findings and a larger tool surface carries the full weight of a repeated design mistake.
- **Deterministic counting**: the judge is no longer asked to report counts at all — they were dropped from the output schema, and the totals are derived from the findings it returns. The same findings always yield the same numbers, and there is no longer a path where a model-reported integer overrides them.

## Test plan

- [x] `cd evalbench && uv run pytest test -q -k mcp` — 109 passed
- [ ] One live judge run against a real endpoint to confirm the model returns the nested shape; unit tests cover parsing and rendering but not the model's behavior