### PR TITLE
ci: verify the built wheel is importable, and fix the import-time credential crash it found

### DIFF
--- a/.ci/verify_package.py
+++ b/.ci/verify_package.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+"""Imports every module in the installed evalbench wheel.
+
+Run from outside the repo, against a virtualenv holding only the wheel:
+
+    /tmp/pkgcheck/bin/python /path/to/repo/.ci/verify_package.py
+"""
+import importlib
+import pkgutil
+import sys
+
+from absl.flags import DuplicateFlagError
+
+SKIP_PREFIXES = ("evalbench.test",)
+
+
+def main():
+    try:
+        import evalbench
+    except Exception as e:
+        print(f"FAIL: the wheel cannot be imported at all -- "
+              f"{type(e).__name__}: {e}")
+        return 1
+
+    origin = evalbench.__file__ or ""
+    if "site-packages" not in origin:
+        print(f"FAIL: evalbench resolved to {origin}, which is not an "
+              f"installed wheel. Run this from outside the repo.")
+        return 1
+
+    failures = []
+    walk_errors = []
+    tolerated = 0
+    checked = 0
+
+    modules = pkgutil.walk_packages(
+        evalbench.__path__, "evalbench.", onerror=walk_errors.append
+    )
+    for module in modules:
+        if module.name.startswith(SKIP_PREFIXES):
+            continue
+        checked += 1
+        try:
+            importlib.import_module(module.name)
+        except DuplicateFlagError:
+            # absl rejects only the second registration, so the module ran.
+            tolerated += 1
+        except Exception as e:
+            detail = str(e).splitlines()[0] if str(e) else ""
+            failures.append((module.name, type(e).__name__, detail[:100]))
+
+    print(f"Checked {checked} modules in {origin}")
+    if tolerated:
+        print(f"Tolerated {tolerated} duplicate absl flag registration(s)")
+
+    for name in walk_errors:
+        failures.append((name, "ImportError", "failed while listing submodules"))
+
+    if failures:
+        print(f"\n{len(failures)} module(s) failed to import from the wheel:")
+        for name, exc, detail in sorted(failures):
+            print(f"  {name}: {exc}: {detail}")
+        return 1
+
+    print("Wheel is importable.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/workflows/verify-package.yml
+++ b/.github/workflows/verify-package.yml
@@ -15,11 +15,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
         persist-credentials: false
     - name: Install uv
-      uses: astral-sh/setup-uv@v5
+      uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
       with:
         enable-cache: true
         cache-dependency-glob: "uv.lock"

--- a/.github/workflows/verify-package.yml
+++ b/.github/workflows/verify-package.yml
@@ -1,0 +1,35 @@
+name: verify-package
+
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+
+permissions: read-all
+
+jobs:
+  wheel:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+      with:
+        persist-credentials: false
+    - name: Install uv
+      uses: astral-sh/setup-uv@v5
+      with:
+        enable-cache: true
+        cache-dependency-glob: "uv.lock"
+    - name: Build wheel
+      run: uv build --wheel --out-dir dist
+    - name: Install wheel into a clean environment
+      run: |
+        uv venv /tmp/pkgcheck
+        VIRTUAL_ENV=/tmp/pkgcheck uv pip install dist/*.whl
+    # /tmp so the source tree cannot satisfy an import the wheel is missing.
+    - name: Import every module
+      working-directory: /tmp
+      run: /tmp/pkgcheck/bin/python "$GITHUB_WORKSPACE/.ci/verify_package.py"

--- a/evalbench/databases/alloydb.py
+++ b/evalbench/databases/alloydb.py
@@ -6,7 +6,16 @@ from sqlalchemy.pool import NullPool
 from google.cloud.alloydb.connector import Connector as AlloyDBConnector
 from google.cloud.alloydb.connector import IPTypes as AlloyDBIPTypes
 
-CONNECTOR = AlloyDBConnector()
+_CONNECTOR = None
+
+
+def get_connector():
+    # Built on first use: the constructor resolves ADC, which would make
+    # importing evalbench fail on machines without credentials.
+    global _CONNECTOR
+    if _CONNECTOR is None:
+        _CONNECTOR = AlloyDBConnector()
+    return _CONNECTOR
 
 
 class AlloyDB(PGDB):
@@ -19,10 +28,10 @@ class AlloyDB(PGDB):
         self.nl_config = db_config['nl_config']
 
         if 'api_endpoint' in db_config:
-            CONNECTOR._alloydb_api_endpoint = db_config['api_endpoint']
+            get_connector()._alloydb_api_endpoint = db_config['api_endpoint']
 
         def get_conn_alloydb():
-            return CONNECTOR.connect(
+            return get_connector().connect(
                 self.db_path,
                 "pg8000",
                 user=self.username,

--- a/evalbench/databases/postgres.py
+++ b/evalbench/databases/postgres.py
@@ -36,7 +36,16 @@ GRANT USAGE ON SCHEMA public TO {DML_USERNAME};
 GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA public TO {DML_USERNAME};
 """
 
-CONNECTOR = Connector()
+_CONNECTOR = None
+
+
+def get_connector():
+    # Built on first use: the constructor resolves ADC, which would make
+    # importing evalbench fail on machines without credentials.
+    global _CONNECTOR
+    if _CONNECTOR is None:
+        _CONNECTOR = Connector()
+    return _CONNECTOR
 
 
 class PGDB(DB):
@@ -66,7 +75,7 @@ class PGDB(DB):
 
         def get_conn():
             # Only used for Cloud SQL Connector path
-            conn = CONNECTOR.connect(
+            conn = get_connector().connect(
                 self.db_path,
                 "pg8000",
                 user=self.username,

--- a/evalbench/test/evalproto_packaging_test.py
+++ b/evalbench/test/evalproto_packaging_test.py
@@ -34,6 +34,15 @@ def test_generators_models_import_without_eager_grpc_proxy():
     assert not hasattr(models, "AgentGrpcProxyGenerator")
 
 
+def test_databases_import_without_eager_connector():
+    """Verify that importing databases does not resolve credentials."""
+    import evalbench.databases.alloydb as alloydb
+    import evalbench.databases.postgres as postgres
+
+    assert postgres._CONNECTOR is None
+    assert alloydb._CONNECTOR is None
+
+
 def test_reporting_import_without_eager_remote_reporter():
     """Verify that reporting imports without eagerly loading RemoteReporter."""
     import evalbench.reporting as reporting


### PR DESCRIPTION
## What broke

Until #589, `.gitignore` listed `evalbench/evalproto/*.py`, so the generated proto files were not in git. Any wheel built from the source was missing them.

Two releases shipped that way and crash on import:

| Version | evalproto files in wheel |
|---|---|
| 1.12.0 | 0 |
| 1.15.0 | 0 |
| 1.17.0 | 25 |

Nothing in CI caught it. Tests run with the repo on `sys.path`, so a module missing from the wheel still imports fine.

## The check

A PR job that builds the wheel, installs it into a clean virtualenv, and imports all 163 non-test modules, running from `/tmp` so the source tree cannot cover for a file the wheel is missing. About 30 seconds.

## The bug it found

It failed on its first run, for a different reason than expected:

```
FAIL: the wheel cannot be imported at all -- DefaultCredentialsError:
Your default credentials were not found.
```

`databases/postgres.py` and `databases/alloydb.py` built their connectors at module level. Both constructors resolve Application Default Credentials, so `import evalbench` needed Google credentials just to load. On a laptop with no `gcloud auth`, this crashes:

```
$ google-evalbench --help
google.auth.exceptions.TransportError: ...metadata service...
```

That is the `uvx google-evalbench --help` failure from the original thread. It never showed up locally because developer machines all have credentials.

Both connectors are now built on first use. Added a regression test that fails without the fix.

## Why this runs at PR time

The wheel on PyPI is built and uploaded by an internal pipeline, on its own schedule, from this source. We cannot gate that step. We can keep `main` always publishable, so whatever the pipeline picks up is already known good.

## Not covered

Stale proto files. `remote_scorer.py:98` uses `eval_agent_pb2.ScoringContext`, which the committed stubs do not define. That fails when the function runs, not on import, so this check passes it. Separate fix.