### PR TITLE
fix(agy): register the cwd as a workspace, not just a declared work_dir

### DIFF
--- a/evalbench/generators/models/agy_cli.py
+++ b/evalbench/generators/models/agy_cli.py
@@ -855,10 +855,10 @@ class AgyCliGenerator(AgentCliGenerator):
         ``timeout`` maps to ``--print-timeout`` (e.g. "20m"). If omitted,
         defaults to agy's internal default (5 minutes).
 
-        ``add_dir`` maps to ``--add-dir``, registering the scenario's
-        ``work_dir`` as an agy workspace. Required on top of the subprocess
-        cwd: unregistered, agy runs its shell and write tools in
-        ``<appDataDir>/scratch`` and agent writes miss ``work_dir``.
+        ``add_dir`` maps to ``--add-dir``, registering the working directory
+        as an agy workspace. Required on top of the subprocess cwd:
+        unregistered, agy runs its shell and write tools in
+        ``<appDataDir>/scratch`` rather than the cwd.
         """
         command = [cli, "-p", prompt, "--dangerously-skip-permissions"]
         if model:
@@ -914,18 +914,18 @@ class AgyCliGenerator(AgentCliGenerator):
 
     def _run_agy_cli(self, cli_cmd: CLICommand, timeout_seconds=None):
         env = self._merged_env(cli_cmd.env)
+        # Registered via --add-dir below, fake_home fallback included: without
+        # that, a scenario with no work_dir writes to <appDataDir>/scratch
+        # instead of the cwd, unlike the other CLI harnesses.
+        cwd = cli_cmd.cwd if cli_cmd.cwd else self.fake_home
         # The executable is always this session's sandbox binary, regardless of
         # the label carried on cli_cmd.cli (the evaluator passes agent_version,
         # "agy", which is not a path).
         command = self._base_agy_command(
             self.agy_bin, cli_cmd.prompt, cli_cmd.resume, self.model,
             output_format="stream-json", log_file=self.cli_log_path,
-            timeout=self.timeout, add_dir=cli_cmd.cwd,
+            timeout=self.timeout, add_dir=cwd,
         )
-        # The fallback is not mirrored into --add-dir: fake_home is agy's own
-        # HOME (binary, settings, MCP config, session state) plus the staged
-        # ADC copy, not a scenario workspace.
-        cwd = cli_cmd.cwd if cli_cmd.cwd else self.fake_home
         result = self._execute_cli_command(command, env=env, cwd=cwd, timeout_seconds=timeout_seconds)
 
         # Parse whenever agy emitted a stream, even on a non-zero exit: a

--- a/evalbench/test/agy_cli_test.py
+++ b/evalbench/test/agy_cli_test.py
@@ -265,7 +265,11 @@ def test_ensure_agy_installed_raises_when_binary_absent_after_install(
 
 def test_run_command_argv_shape(mock_run, sandbox):
     """``_run_agy_cli`` must build ``agy -p <prompt>
-    --dangerously-skip-permissions --output-format stream-json``."""
+    --dangerously-skip-permissions --output-format stream-json``.
+
+    With no scenario ``work_dir``, the cwd fallback ``fake_home`` is still
+    registered via ``--add-dir`` so agent writes land there instead of
+    ``<appDataDir>/scratch`` -- parity with the other CLI harnesses."""
     generator = AgyCliGenerator({})
     cmd = CLICommand(cli="agy", prompt="hello world")
     generator._run_agy_cli(cmd)
@@ -275,7 +279,9 @@ def test_run_command_argv_shape(mock_run, sandbox):
         generator.agy_bin, "-p", "hello world",
         "--dangerously-skip-permissions", "--output-format", "stream-json",
         "--log-file", generator.cli_log_path,
+        "--add-dir", generator.fake_home,
     ]
+    assert mock_run.call_args.kwargs["cwd"] == generator.fake_home
 
 
 def test_run_command_argv_shape_with_continue(mock_run, sandbox):
@@ -287,14 +293,16 @@ def test_run_command_argv_shape_with_continue(mock_run, sandbox):
     assert sent_argv == [
         generator.agy_bin, "-p", "next turn",
         "--dangerously-skip-permissions", "--output-format", "stream-json",
-        "--log-file", generator.cli_log_path, "--continue",
+        "--log-file", generator.cli_log_path,
+        "--add-dir", generator.fake_home, "--continue",
     ]
 
 
 def test_run_command_argv_passes_work_dir_as_add_dir(mock_run, sandbox):
     """A scenario ``work_dir`` must reach agy as ``--add-dir``, not just as the
     subprocess cwd: without a registered workspace agy runs its shell and write
-    tools in ``<appDataDir>/scratch``, so agent writes miss ``work_dir``."""
+    tools in ``<appDataDir>/scratch``, so agent writes miss ``work_dir``. It
+    also takes precedence over the ``fake_home`` fallback."""
     generator = AgyCliGenerator({})
     cmd = generator.create_command(
         cli="agy", prompt="hello world", cwd="/tmp/workspace"
@@ -343,6 +351,7 @@ def test_run_command_argv_shape_with_timeout(mock_run, sandbox):
         generator.agy_bin, "-p", "hello world",
         "--dangerously-skip-permissions", "--output-format", "stream-json",
         "--log-file", generator.cli_log_path, "--print-timeout", "20m",
+        "--add-dir", generator.fake_home,
     ]
 
 


### PR DESCRIPTION
## Summary

agy runs its write and shell tools in `<appDataDir>/scratch` unless the directory is registered via `--add-dir`. #585 passed the flag only when a scenario declared `work_dir`, so the default path still scattered agent writes into scratch instead of landing them in the cwd — unlike `gemini_cli`, `claude_code` and `codex_cli`.

This resolves the effective cwd first and registers that, `fake_home` fallback included. A declared `work_dir` still takes precedence.

## Test plan

- [x] `pytest evalbench/test/agy_cli_test.py` — 68 passed; the argv tests now pin `--add-dir <fake_home>` and the subprocess cwd
- [x] Verified on disk with a real agy run against a fresh sandbox, same prompt, only this change differing. The agent was asked to create a file and read it back:
  - without the fix, the file landed in `fake_home/`, `<appDataDir>/scratch/` **and** `<appDataDir>/brain/<uuid>/scratch/`
  - with it, only in `fake_home/`

A fresh sandbox is needed to reproduce: agy caches a conversation per cwd carrying its `WorkspaceURIs`, so a reused `fake_home` inherits an earlier run's registration and the unregistered case silently passes.

Note the rubric scorer only reads the transcript, so a write scenario scores the same either way — this had to be checked on disk.

## Not covered

With `work_dir` set, files land outside `fake_home`, and `GcsReporter` and the file-reading scorers still only look at `fake_home`. Separate change.