### PR TITLE
feat(scorers): score skills_trajectory based on expected skills activated ratio

### DIFF
--- a/evalbench/scorers/skillstrajectorymatcher.py
+++ b/evalbench/scorers/skillstrajectorymatcher.py
@@ -2,8 +2,10 @@
 SkillsTrajectoryMatcher
 
 Compares expected activated skills vs actual activated skill names.
-Supports flexible coverage matching (when allow_extra_skills is True),
-Jaccard set similarity (default), and strict Levenshtein sequence alignment.
+Scores based on:
+  denominator = number of skills expected to activate (across all turns)
+  numerator = number of expected skills activated (across all turns)
+Also supports strict Levenshtein sequence alignment when enforce_order is True.
 """
 from typing import Tuple, Any, List
 from scorers import comparator
@@ -116,20 +118,15 @@ class SkillsTrajectoryMatcher(comparator.Comparator):
                 f"(Distance: {distance}, Max: {max_len}). "
                 f"Expected: {expected}, Actual: {actual}"
             )
-        elif self.allow_extra_skills:
-            expected_set = set(expected)
-            actual_set = set(actual)
-            matched = expected_set & actual_set
-            similarity = len(matched) / len(expected_set)
-            score = similarity * 100.0
-            return score, (
-                f"Skills Coverage (allow_extra_skills=True): {score:.2f}%. "
-                f"Expected: {expected_set}, Actual: {actual_set}, Matched: {matched}"
-            )
-        else:
-            similarity = self._jaccard_similarity(set(expected), set(actual))
-            score = similarity * 100.0
-            return score, (
-                f"Skills Jaccard Similarity: {score:.2f}. "
-                f"Expected: {set(expected)}, Actual: {set(actual)}"
-            )
+
+        expected_set = set(expected)
+        actual_set = set(actual)
+        matched = expected_set & actual_set
+        similarity = len(matched) / len(expected_set) if expected_set else (1.0 if not actual_set or self.allow_extra_skills else 0.0)
+        score = similarity * 100.0
+        return score, (
+            f"Skills Trajectory Match: {score:.2f}% "
+            f"({len(matched)}/{len(expected_set)} expected skills activated). "
+            f"Expected: {expected_set}, Actual: {actual_set}, Matched: {matched}"
+        )
+

--- a/evalbench/test/skillstrajectorymatcher_test.py
+++ b/evalbench/test/skillstrajectorymatcher_test.py
@@ -45,7 +45,7 @@ class SkillsTrajectoryMatcherTest(unittest.TestCase):
         matcher = SkillsTrajectoryMatcher({"allow_extra_skills": False})
         score, explanation = _compare(matcher, [], ["dataform_bigquery"])
         self.assertEqual(score, 0.0)
-        self.assertIn("Jaccard Similarity: 0.00", explanation)
+        self.assertIn("0/0 expected skills activated", explanation)
 
     def test_empty_expected_skills_with_extra_skills_when_allow_extra_true(self):
         matcher = SkillsTrajectoryMatcher({"allow_extra_skills": True})
@@ -53,14 +53,14 @@ class SkillsTrajectoryMatcherTest(unittest.TestCase):
         self.assertEqual(score, 100.0)
         self.assertIn("extra skills are allowed", explanation)
 
-    def test_default_uses_jaccard_similarity(self):
+    def test_default_ratio_scoring(self):
         matcher = SkillsTrajectoryMatcher({})
         expected = ["dataform_bigquery"]
         actual = ["dataform_bigquery", "gcp_pipeline_orchestration"]
 
         score, explanation = _compare(matcher, expected, actual)
-        self.assertEqual(score, 50.0)
-        self.assertIn("Jaccard Similarity", explanation)
+        self.assertEqual(score, 100.0)
+        self.assertIn("1/1 expected skills activated", explanation)
 
     def test_allow_extra_skills_enabled(self):
         matcher = SkillsTrajectoryMatcher({"allow_extra_skills": True})
@@ -69,15 +69,16 @@ class SkillsTrajectoryMatcherTest(unittest.TestCase):
 
         score, explanation = _compare(matcher, expected, actual)
         self.assertEqual(score, 100.0)
-        self.assertIn("allow_extra_skills=True", explanation)
+        self.assertIn("1/1 expected skills activated", explanation)
 
     def test_partial_coverage(self):
-        matcher = SkillsTrajectoryMatcher({"allow_extra_skills": True})
+        matcher = SkillsTrajectoryMatcher({})
         expected = ["dataform_bigquery", "dbt_bigquery"]
         actual = ["dataform_bigquery"]
 
         score, explanation = _compare(matcher, expected, actual)
         self.assertEqual(score, 50.0)
+        self.assertIn("1/2 expected skills activated", explanation)
 
     def test_enforce_order(self):
         matcher = SkillsTrajectoryMatcher({"enforce_order": True})
@@ -98,23 +99,23 @@ class SkillsTrajectoryMatcherTest(unittest.TestCase):
         with self.assertRaises(ValueError):
             SkillsTrajectoryMatcher({"enforce_order": True, "allow_extra_skills": True})
 
-    def test_namespace_normalization_default_jaccard(self):
+    def test_namespace_normalization_default_ratio(self):
         matcher = SkillsTrajectoryMatcher({"ignore_prefix": "dak:"})
         expected = ["dataform_bigquery"]
         actual = ["dak:dataform_bigquery", "gcp_pipeline_orchestration"]
 
         score, explanation = _compare(matcher, expected, actual)
-        self.assertEqual(score, 50.0)
-        self.assertIn("Jaccard Similarity", explanation)
+        self.assertEqual(score, 100.0)
+        self.assertIn("1/1 expected skills activated", explanation)
 
-    def test_namespace_normalization_allow_extra_skills(self):
-        matcher = SkillsTrajectoryMatcher({"allow_extra_skills": True, "ignore_prefix": "dak:"})
-        expected = ["dataform_bigquery"]
+    def test_namespace_normalization_partial_match(self):
+        matcher = SkillsTrajectoryMatcher({"ignore_prefix": "dak:"})
+        expected = ["dataform_bigquery", "dbt_bigquery"]
         actual = ["dak:dataform_bigquery", "gcp_pipeline_orchestration"]
 
         score, explanation = _compare(matcher, expected, actual)
-        self.assertEqual(score, 100.0)
-        self.assertIn("allow_extra_skills=True", explanation)
+        self.assertEqual(score, 50.0)
+        self.assertIn("1/2 expected skills activated", explanation)
 
     def test_namespace_normalization_enforce_order(self):
         matcher = SkillsTrajectoryMatcher({"enforce_order": True, "ignore_prefix": "dak:"})


### PR DESCRIPTION
## Summary
Modifies the `skills_trajectory` scorer to score based on:
- **Denominator**: Number of skills expected to activate across all turns
- **Numerator**: Number of expected skills activated across all turns

## Changes
- Updated `SkillsTrajectoryMatcher.compare` to calculate score as `(len(expected & actual) / len(expected)) * 100.0`.
- Updated test cases in `skillstrajectorymatcher_test.py` to verify the expected skills activated ratio scoring.